### PR TITLE
tools: source the "Permission denied" message from the OS (#159)

### DIFF
--- a/src/shadow-core/src/lib.rs
+++ b/src/shadow-core/src/lib.rs
@@ -10,6 +10,7 @@
 
 pub mod cli;
 pub mod error;
+pub mod os_error;
 pub mod passwd;
 pub mod validate;
 

--- a/src/shadow-core/src/os_error.rs
+++ b/src/shadow-core/src/os_error.rs
@@ -1,0 +1,44 @@
+// This file is part of the shadow-rs package.
+//
+// For the full copyright and license information, please view the LICENSE
+// file that was distributed with this source code.
+
+//! Error text sourced from the operating system instead of hardcoded.
+//!
+//! Wording for conditions that map to a libc `errno` is taken from
+//! `strerror` (via [`std::io::Error`]) rather than carried as a string
+//! literal in our tree. This keeps the text matching the host OS and lets
+//! glibc translate it on localized systems — the same way GNU coreutils
+//! renders system errors (e.g. `cat: /tmp: Is a directory`). See issue #159.
+
+/// The operating system's message for a raw `errno`.
+///
+/// For example `EACCES` renders as "Permission denied" on English locales
+/// and the translated equivalent elsewhere. On targets whose libc does not
+/// translate (musl), this is the untranslated English text.
+#[must_use]
+pub fn strerror(errno: i32) -> String {
+    std::io::Error::from_raw_os_error(errno).to_string()
+}
+
+/// The OS message for `EACCES` ("Permission denied"), sourced from libc.
+#[must_use]
+pub fn permission_denied() -> String {
+    strerror(libc::EACCES)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn permission_denied_is_nonempty_and_os_sourced() {
+        // We assert the shape, not the exact text: the wording comes from the
+        // host libc and may be localized, so hardcoding it would defeat the
+        // purpose of this module.
+        let msg = permission_denied();
+        assert!(!msg.is_empty());
+        // Same value libc would give for EACCES directly.
+        assert_eq!(msg, strerror(libc::EACCES));
+    }
+}

--- a/src/shadow-core/src/os_error.rs
+++ b/src/shadow-core/src/os_error.rs
@@ -5,30 +5,23 @@
 
 //! Error text sourced from the operating system instead of hardcoded.
 //!
-//! Wording for conditions that map to a libc `errno` is taken from
-//! `strerror` (via [`std::io::Error`]) rather than carried as a string
-//! literal in our tree. This keeps the text matching the host OS and lets
-//! glibc translate it on localized systems — the same way GNU coreutils
-//! renders system errors (e.g. `cat: /tmp: Is a directory`). See issue #159.
-
-/// The operating system's message for a raw `errno`.
-///
-/// For example `EACCES` renders as "Permission denied" on English locales
-/// and the translated equivalent elsewhere. On targets whose libc does not
-/// translate (musl), this is the untranslated English text.
-#[must_use]
-pub fn strerror(errno: i32) -> String {
-    // `io::Error::from_raw_os_error` carries libc's `strerror` text, but its
-    // `Display` appends Rust's own " (os error N)" suffix. `strip_errno` (the
-    // same helper uucore uses for its own I/O errors) removes it, leaving the
-    // bare OS message — matching GNU/coreutils output.
-    uucore::error::strip_errno(&std::io::Error::from_raw_os_error(errno))
-}
+//! Wording for conditions that map to a libc `errno` is taken from the OS
+//! (libc's `strerror`, surfaced through [`std::io::Error`]) rather than
+//! carried as a string literal in our tree. This keeps the text matching the
+//! host OS and lets glibc translate it on localized systems — the same way
+//! GNU coreutils renders system errors (e.g. `cat: /tmp: Is a directory`).
+//! See issue #159.
 
 /// The OS message for `EACCES` ("Permission denied"), sourced from libc.
+///
+/// Rendered as "Permission denied" on English locales and the translated
+/// equivalent elsewhere; on a libc that does not translate (musl) it is the
+/// untranslated English text. `strip_errno` (the helper uucore uses for its
+/// own I/O errors) drops the " (os error N)" suffix that `io::Error`'s
+/// `Display` appends, leaving the bare OS message — matching coreutils output.
 #[must_use]
 pub fn permission_denied() -> String {
-    strerror(libc::EACCES)
+    uucore::error::strip_errno(&std::io::Error::from_raw_os_error(libc::EACCES))
 }
 
 #[cfg(test)]
@@ -36,22 +29,12 @@ mod tests {
     use super::*;
 
     #[test]
-    fn permission_denied_is_nonempty_and_os_sourced() {
-        // We assert the shape, not the exact text: the wording comes from the
-        // host libc and may be localized, so hardcoding it would defeat the
-        // purpose of this module.
+    fn permission_denied_is_bare_os_message() {
         let msg = permission_denied();
+        // Non-empty, and the bare OS text — not Rust's "... (os error 13)"
+        // rendering (the regression that suffix-stripping prevents). We assert
+        // the shape, not the exact wording, since libc may localize it.
         assert!(!msg.is_empty());
-        // Same value libc would give for EACCES directly.
-        assert_eq!(msg, strerror(libc::EACCES));
-    }
-
-    #[test]
-    fn strerror_drops_the_rust_os_error_suffix() {
-        // Regression guard: the bare OS message must not carry Rust's
-        // " (os error N)" rendering (the bug that made permission_denied()
-        // return "Permission denied (os error 13)").
-        let msg = strerror(libc::EACCES);
         assert!(!msg.contains("(os error"), "got: {msg:?}");
     }
 }

--- a/src/shadow-core/src/os_error.rs
+++ b/src/shadow-core/src/os_error.rs
@@ -19,15 +19,10 @@
 #[must_use]
 pub fn strerror(errno: i32) -> String {
     // `io::Error::from_raw_os_error` carries libc's `strerror` text, but its
-    // `Display` appends Rust's own " (os error N)" suffix. Strip that so the
-    // result is the bare OS message (matching GNU/coreutils output). The
-    // suffix is emitted verbatim in English regardless of locale, so a
-    // localized message cannot contain it earlier in the string.
-    let rendered = std::io::Error::from_raw_os_error(errno).to_string();
-    match rendered.rfind(" (os error ") {
-        Some(cut) => rendered[..cut].to_string(),
-        None => rendered,
-    }
+    // `Display` appends Rust's own " (os error N)" suffix. `strip_errno` (the
+    // same helper uucore uses for its own I/O errors) removes it, leaving the
+    // bare OS message — matching GNU/coreutils output.
+    uucore::error::strip_errno(&std::io::Error::from_raw_os_error(errno))
 }
 
 /// The OS message for `EACCES` ("Permission denied"), sourced from libc.

--- a/src/shadow-core/src/os_error.rs
+++ b/src/shadow-core/src/os_error.rs
@@ -18,7 +18,16 @@
 /// translate (musl), this is the untranslated English text.
 #[must_use]
 pub fn strerror(errno: i32) -> String {
-    std::io::Error::from_raw_os_error(errno).to_string()
+    // `io::Error::from_raw_os_error` carries libc's `strerror` text, but its
+    // `Display` appends Rust's own " (os error N)" suffix. Strip that so the
+    // result is the bare OS message (matching GNU/coreutils output). The
+    // suffix is emitted verbatim in English regardless of locale, so a
+    // localized message cannot contain it earlier in the string.
+    let rendered = std::io::Error::from_raw_os_error(errno).to_string();
+    match rendered.rfind(" (os error ") {
+        Some(cut) => rendered[..cut].to_string(),
+        None => rendered,
+    }
 }
 
 /// The OS message for `EACCES` ("Permission denied"), sourced from libc.
@@ -40,5 +49,14 @@ mod tests {
         assert!(!msg.is_empty());
         // Same value libc would give for EACCES directly.
         assert_eq!(msg, strerror(libc::EACCES));
+    }
+
+    #[test]
+    fn strerror_drops_the_rust_os_error_suffix() {
+        // Regression guard: the bare OS message must not carry Rust's
+        // " (os error N)" rendering (the bug that made permission_denied()
+        // return "Permission denied (os error 13)").
+        let msg = strerror(libc::EACCES);
+        assert!(!msg.contains("(os error"), "got: {msg:?}");
     }
 }

--- a/src/uu/chage/src/chage.rs
+++ b/src/uu/chage/src/chage.rs
@@ -263,7 +263,10 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
             let current_user = shadow_core::hardening::current_username()
                 .map_err(|e| ChageError::UnexpectedFailure(e.to_string()))?;
             if current_user != *login {
-                return Err(ChageError::PermissionDenied("Permission denied.".into()).into());
+                return Err(ChageError::PermissionDenied(
+                    shadow_core::os_error::permission_denied(),
+                )
+                .into());
             }
         }
         return cmd_list(&root, login);
@@ -271,7 +274,9 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 
     // All modification flags require root.
     if !shadow_core::hardening::caller_is_root() {
-        return Err(ChageError::PermissionDenied("Permission denied.".into()).into());
+        return Err(
+            ChageError::PermissionDenied(shadow_core::os_error::permission_denied()).into(),
+        );
     }
 
     if !has_modifications {

--- a/src/uu/chpasswd/src/chpasswd.rs
+++ b/src/uu/chpasswd/src/chpasswd.rs
@@ -175,7 +175,9 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 
     // chpasswd always requires root.
     if !shadow_core::hardening::caller_is_root() {
-        return Err(ChpasswdError::PermissionDenied("Permission denied.".into()).into());
+        return Err(
+            ChpasswdError::PermissionDenied(shadow_core::os_error::permission_denied()).into(),
+        );
     }
 
     let is_encrypted = matches.get_flag(options::ENCRYPTED);

--- a/src/uu/groupadd/src/groupadd.rs
+++ b/src/uu/groupadd/src/groupadd.rs
@@ -100,7 +100,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     };
 
     if !shadow_core::hardening::caller_is_root() {
-        uucore::show_error!("Permission denied.");
+        uucore::show_error!("{}", shadow_core::os_error::permission_denied());
         return Err(shadow_core::cli::AlreadyPrinted(1).into());
     }
 

--- a/src/uu/groupdel/src/groupdel.rs
+++ b/src/uu/groupdel/src/groupdel.rs
@@ -88,7 +88,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     };
 
     if !shadow_core::hardening::caller_is_root() {
-        uucore::show_error!("Permission denied.");
+        uucore::show_error!("{}", shadow_core::os_error::permission_denied());
         return Err(shadow_core::cli::AlreadyPrinted(1).into());
     }
 

--- a/src/uu/groupmod/src/groupmod.rs
+++ b/src/uu/groupmod/src/groupmod.rs
@@ -100,7 +100,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     };
 
     if !shadow_core::hardening::caller_is_root() {
-        uucore::show_error!("Permission denied.");
+        uucore::show_error!("{}", shadow_core::os_error::permission_denied());
         return Err(shadow_core::cli::AlreadyPrinted(1).into());
     }
 

--- a/src/uu/passwd/src/passwd.rs
+++ b/src/uu/passwd/src/passwd.rs
@@ -175,12 +175,18 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         // Non-root users can only view their own status.
         if !shadow_core::hardening::caller_is_root() {
             if show_all {
-                return Err(PasswdError::PermissionDenied("Permission denied.".into()).into());
+                return Err(PasswdError::PermissionDenied(
+                    shadow_core::os_error::permission_denied(),
+                )
+                .into());
             }
             let current_user = shadow_core::hardening::current_username()
                 .map_err(|e| PasswdError::UnexpectedFailure(e.to_string()))?;
             if current_user != target_user {
-                return Err(PasswdError::PermissionDenied("Permission denied.".into()).into());
+                return Err(PasswdError::PermissionDenied(
+                    shadow_core::os_error::permission_denied(),
+                )
+                .into());
             }
         }
 
@@ -205,7 +211,9 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     // caller to be root. Non-root users can only change their own password
     // (the default PAM path below).
     if (has_mutation || has_aging) && !shadow_core::hardening::caller_is_root() {
-        return Err(PasswdError::PermissionDenied("Permission denied.".into()).into());
+        return Err(
+            PasswdError::PermissionDenied(shadow_core::os_error::permission_denied()).into(),
+        );
     }
 
     // When a mutation flag and aging flags are both present, apply both in a

--- a/src/uu/useradd/src/useradd.rs
+++ b/src/uu/useradd/src/useradd.rs
@@ -273,7 +273,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 
     // Only root can add users.
     if !shadow_core::hardening::caller_is_root() {
-        uucore::show_error!("Permission denied.");
+        uucore::show_error!("{}", shadow_core::os_error::permission_denied());
         return Err(shadow_core::cli::AlreadyPrinted(1).into());
     }
 

--- a/src/uu/userdel/src/userdel.rs
+++ b/src/uu/userdel/src/userdel.rs
@@ -92,7 +92,9 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 
     // Must be root.
     if !rustix::process::getuid().is_root() {
-        return Err(UserdelError::CantUpdatePasswd("Permission denied.".into()).into());
+        return Err(
+            UserdelError::CantUpdatePasswd(shadow_core::os_error::permission_denied()).into(),
+        );
     }
 
     // Read the user's home directory and UID from /etc/passwd BEFORE removing

--- a/src/uu/usermod/src/usermod.rs
+++ b/src/uu/usermod/src/usermod.rs
@@ -89,7 +89,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let root = SysRoot::new(prefix);
 
     if !rustix::process::getuid().is_root() {
-        return Err(UsermodError::CantUpdate("Permission denied.".into()).into());
+        return Err(UsermodError::CantUpdate(shadow_core::os_error::permission_denied()).into());
     }
 
     // Block signals for the passwd lock→write critical section only.


### PR DESCRIPTION
## Summary

Toward #159 / "do like coreutils": route the account tools' permission-check message through libc `strerror` instead of a hardcoded literal, so the wording comes from the host OS and is translated by glibc on localized systems — the same mechanism behind `cat: /tmp: Is a directory` (and its localized forms).

- New `shadow_core::os_error::permission_denied()` — returns the OS message for `EACCES`, built from `std::io::Error::from_raw_os_error` and run through `uucore::error::strip_errno` (the helper uucore uses for its own I/O errors) to drop Rust's ` (os error N)` suffix. No `unsafe`.
- Convert the 13 manual `caller_is_root()` guards (`chage`, `chpasswd`, `groupadd`, `groupdel`, `groupmod`, `passwd`, `useradd`, `userdel`, `usermod`) from `"Permission denied."` to `os_error::permission_denied()`.

## Why this slice of #159

@pierre-warnier's [spike on #159](https://github.com/uutils/shadow-rs/issues/159) showed the **gettext-catalog** approach doesn't remove GPL exposure (the English `msgid` must stay in source as the lookup key). The narrower errno→`strerror` idea @sylvestre and @oech3 pointed at *is* sound and is what coreutils does; this PR applies it to the one class where we still hardcoded an OS-equivalent string.

Already-correct, left unchanged:
- **True I/O errors** already render the OS `strerror` via `ShadowError::Io` / `IoPath`.
- **Domain errors** ("group already exists", …) have no OS equivalent and stay in-tree (clean-room-audited in #162).

## Behavior change

Output changes from `Permission denied.` (trailing period) to the OS text `Permission denied` (no period; localized off-English). No test or e2e assertion depends on the old literal. Flagging in case the period is considered part of drop-in compat — happy to adjust.

## Test plan
- [x] `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace` — green on Debian
- [x] `os_error` unit test (non-empty + no ` (os error N)` suffix) also run on **Alpine (musl)** and **Fedora** locally, since the Docker matrix is push-gated and skipped on PRs
- [x] Unit test guards against the ` (os error N)` regression

cc @sylvestre @oech3 — implements the "extract from OS" direction from #159.

Refs #159.