### PR TITLE
useradd: implemented useradd -K/--key KEY=VALUE (override /etc/login.defs defaults)

### DIFF
--- a/src/shadow-core/src/login_defs.rs
+++ b/src/shadow-core/src/login_defs.rs
@@ -72,6 +72,24 @@ impl LoginDefs {
     pub fn get_i64(&self, key: &str) -> Option<i64> {
         self.entries.get(key).and_then(|v| v.parse().ok())
     }
+
+    /// Insert or replace a configuration value for later `get` / `get_i64` calls.
+    ///
+    /// Used when a tool accepts runtime overrides of login.defs defaults
+    /// (for example `useradd -K KEY=VALUE`).
+    pub fn set(&mut self, key: impl Into<String>, value: impl Into<String>) {
+        self.entries.insert(key.into(), value.into());
+    }
+
+    /// Apply several `KEY=VALUE` overrides; later entries win on duplicate keys.
+    pub fn apply_overrides<'a, I>(&mut self, overrides: I)
+    where
+        I: IntoIterator<Item = (&'a str, &'a str)>,
+    {
+        for (key, value) in overrides {
+            self.set(key, value);
+        }
+    }
 }
 
 #[cfg(test)]
@@ -136,6 +154,32 @@ mod tests {
         let path = write_login_defs(dir.path(), "ENCRYPT_METHOD SHA512\n");
         let defs = LoginDefs::load(&path).unwrap();
         assert_eq!(defs.get_i64("ENCRYPT_METHOD"), None);
+    }
+
+    #[test]
+    fn test_set_overrides_existing_and_inserts_new() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_login_defs(dir.path(), "UID_MIN 1000\n");
+        let mut defs = LoginDefs::load(&path).unwrap();
+        assert_eq!(defs.get_i64("UID_MIN"), Some(1000));
+
+        defs.set("UID_MIN", "9100");
+        defs.set("PASS_MAX_DAYS", "-1");
+        assert_eq!(defs.get_i64("UID_MIN"), Some(9100));
+        assert_eq!(defs.get("PASS_MAX_DAYS"), Some("-1"));
+    }
+
+    #[test]
+    fn test_apply_overrides() {
+        let mut defs = LoginDefs::load(Path::new("/nonexistent")).unwrap();
+        defs.apply_overrides([
+            ("UID_MIN", "2000"),
+            ("UID_MAX", "2000"),
+            ("UID_MIN", "3000"),
+        ]);
+        // Later duplicate wins.
+        assert_eq!(defs.get("UID_MIN"), Some("3000"));
+        assert_eq!(defs.get("UID_MAX"), Some("2000"));
     }
 
     // -------------------------------------------------------------------

--- a/src/uu/useradd/src/useradd.rs
+++ b/src/uu/useradd/src/useradd.rs
@@ -14,7 +14,6 @@
 //! directory and populate it from `/etc/skel`.
 
 use std::fmt;
-use std::io::Write as _;
 use std::os::unix::fs::DirBuilderExt;
 use std::path::Path;
 
@@ -293,11 +292,17 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 // ---------------------------------------------------------------------------
 
 /// Handle `useradd -D` -- print default values.
-fn cmd_defaults(_matches: &clap::ArgMatches) -> UResult<()> {
-    // Read login.defs for defaults.
-    let root = SysRoot::default();
-    let defs = LoginDefs::load(&root.login_defs_path())
+fn cmd_defaults(matches: &clap::ArgMatches) -> UResult<()> {
+    write_defaults(matches, &mut std::io::stdout().lock())
+}
+
+/// Load login.defs under `-R`, apply `-K` overrides, and write the `useradd -D` report.
+fn write_defaults(matches: &clap::ArgMatches, out: &mut dyn std::io::Write) -> UResult<()> {
+    let root_dir = matches.get_one::<String>(options::ROOT);
+    let root = SysRoot::new(root_dir.map(Path::new));
+    let mut defs = LoginDefs::load(&root.login_defs_path())
         .map_err(|e| UseraddError::CannotUpdatePasswd(format!("{e}")))?;
+    apply_login_defs_overrides(&mut defs, &parse_login_defs_overrides(matches)?);
 
     let default_home = defs.get("HOME").unwrap_or("/home");
     let default_inactive = defs.get("INACTIVE").unwrap_or("-1");
@@ -306,7 +311,6 @@ fn cmd_defaults(_matches: &clap::ArgMatches) -> UResult<()> {
     let default_skel = defs.get("SKEL").unwrap_or("/etc/skel");
     let default_create_mail = defs.get("CREATE_MAIL_SPOOL").unwrap_or("no");
 
-    let mut out = std::io::stdout().lock();
     let _ = writeln!(out, "GROUP=100");
     let _ = writeln!(out, "HOME={default_home}");
     let _ = writeln!(out, "INACTIVE={default_inactive}");
@@ -1189,6 +1193,27 @@ mod tests {
             .try_get_matches_from(["useradd", "-D"])
             .expect("should parse -D without LOGIN");
         assert!(m.get_flag(options::DEFAULTS));
+    }
+
+    #[test]
+    fn test_clap_defaults_with_key() {
+        let m = uu_app()
+            .try_get_matches_from([
+                "useradd",
+                "-D",
+                "-K",
+                "HOME=/OVERRIDDEN",
+                "-K",
+                "SHELL=/bin/zsh",
+            ])
+            .expect("should parse -D -K");
+        assert!(m.get_flag(options::DEFAULTS));
+        let keys: Vec<&str> = m
+            .get_many::<String>(options::KEY)
+            .expect("KEY present")
+            .map(String::as_str)
+            .collect();
+        assert_eq!(keys, ["HOME=/OVERRIDDEN", "SHELL=/bin/zsh"]);
     }
 
     #[test]
@@ -2229,6 +2254,40 @@ mod tests {
             .expect("clap accepts raw value");
         let err = parse_login_defs_overrides(&m).expect_err("empty key");
         assert!(matches!(err, UseraddError::BadArgument(_)));
+    }
+
+    #[test]
+    fn test_defaults_honors_key_overrides() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let etc = dir.path().join("etc");
+        fs::create_dir_all(&etc).expect("etc dir");
+        fs::write(etc.join("login.defs"), "HOME /home\nSHELL /bin/sh\n").expect("login.defs");
+
+        let root = dir.path().to_str().expect("utf-8 temp path");
+        let m = uu_app()
+            .try_get_matches_from([
+                "useradd",
+                "-R",
+                root,
+                "-D",
+                "-K",
+                "HOME=/OVERRIDDEN",
+                "-K",
+                "SHELL=/bin/zsh",
+            ])
+            .expect("parse -D -K");
+
+        let mut buf = Vec::new();
+        write_defaults(&m, &mut buf).expect("write defaults");
+        let output = String::from_utf8(buf).expect("utf-8 defaults output");
+        assert!(
+            output.lines().any(|l| l == "HOME=/OVERRIDDEN"),
+            "expected HOME override in -D output, got: {output}"
+        );
+        assert!(
+            output.lines().any(|l| l == "SHELL=/bin/zsh"),
+            "expected SHELL override in -D output, got: {output}"
+        );
     }
 
     #[test]

--- a/src/uu/useradd/src/useradd.rs
+++ b/src/uu/useradd/src/useradd.rs
@@ -48,6 +48,7 @@ mod options {
     pub const INACTIVE: &str = "inactive";
     pub const GID: &str = "gid";
     pub const GROUPS: &str = "groups";
+    pub const KEY: &str = "key";
     pub const CREATE_HOME: &str = "create-home";
     pub const NO_CREATE_HOME: &str = "no-create-home";
     pub const SKEL: &str = "skel";
@@ -162,6 +163,7 @@ struct UseraddOptions {
     inactive: Option<i64>,
     expire_date: Option<i64>,
     create_user_group: bool,
+    login_defs_overrides: Vec<(String, String)>,
     root: SysRoot,
 }
 
@@ -338,8 +340,12 @@ fn parse_options(matches: &clap::ArgMatches) -> Result<UseraddOptions, UseraddEr
 
     let home_dir = matches.get_one::<String>(options::HOME_DIR).cloned();
 
-    let defs = LoginDefs::load(&root.login_defs_path())
+    // Apply -K overrides before reading defaults so CREATE_HOME, SKEL, etc.
+    // match the overridden values when flags are not given.
+    let login_defs_overrides = parse_login_defs_overrides(matches)?;
+    let mut defs = LoginDefs::load(&root.login_defs_path())
         .map_err(|e| UseraddError::CannotUpdatePasswd(format!("{e}")))?;
+    apply_login_defs_overrides(&mut defs, &login_defs_overrides);
 
     let shell = matches
         .get_one::<String>(options::SHELL)
@@ -445,6 +451,7 @@ fn parse_options(matches: &clap::ArgMatches) -> Result<UseraddOptions, UseraddEr
         inactive,
         expire_date,
         create_user_group,
+        login_defs_overrides,
         root,
     })
 }
@@ -487,9 +494,11 @@ fn do_useradd(opts: &UseraddOptions) -> UResult<()> {
         );
     }
 
-    // Step 4: Load login.defs for UID/GID ranges.
-    let defs = LoginDefs::load(&opts.root.login_defs_path())
+    // Step 4: Load login.defs and apply -K overrides before allocation and
+    // shadow aging fields that are taken from the table.
+    let mut defs = LoginDefs::load(&opts.root.login_defs_path())
         .map_err(|e| UseraddError::CannotUpdatePasswd(format!("{e}")))?;
+    apply_login_defs_overrides(&mut defs, &opts.login_defs_overrides);
 
     // Step 5: Determine UID.
     let uid = determine_uid(opts, &passwd_entries, &defs)?;
@@ -614,6 +623,37 @@ fn do_useradd(opts: &UseraddOptions) -> UResult<()> {
     audit::log_user_event("ADD_USER", &opts.login, uid, true);
 
     Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// login.defs -K overrides
+// ---------------------------------------------------------------------------
+
+/// Collect `-K`/`--key` pairs; each value must be non-empty `KEY=VALUE`.
+fn parse_login_defs_overrides(
+    matches: &clap::ArgMatches,
+) -> Result<Vec<(String, String)>, UseraddError> {
+    let key_values: Vec<&String> = matches
+        .get_many::<String>(options::KEY)
+        .map_or_else(Vec::new, Iterator::collect);
+    let mut overrides = Vec::with_capacity(key_values.len());
+    for kv in &key_values {
+        let (k, v) = kv
+            .split_once('=')
+            .ok_or_else(|| UseraddError::BadArgument(format!("invalid key=value pair: '{kv}'")))?;
+        if k.is_empty() {
+            return Err(UseraddError::BadArgument(format!(
+                "invalid key=value pair: '{kv}'"
+            )));
+        }
+        overrides.push((k.to_string(), v.to_string()));
+    }
+    Ok(overrides)
+}
+
+/// Merge `-K` overrides into `defs` so later lookups use the new values.
+fn apply_login_defs_overrides(defs: &mut LoginDefs, overrides: &[(String, String)]) {
+    defs.apply_overrides(overrides.iter().map(|(k, v)| (k.as_str(), v.as_str())));
 }
 
 // ---------------------------------------------------------------------------
@@ -1016,6 +1056,14 @@ pub fn uu_app() -> Command {
                 .help("Comma-separated supplementary groups"),
         )
         .arg(
+            Arg::new(options::KEY)
+                .short('K')
+                .long("key")
+                .value_name("KEY=VALUE")
+                .action(ArgAction::Append)
+                .help("Override /etc/login.defs defaults (KEY=VALUE; may be repeated)"),
+        )
+        .arg(
             Arg::new(options::CREATE_HOME)
                 .short('m')
                 .long("create-home")
@@ -1310,6 +1358,26 @@ mod tests {
             .try_get_matches_from(["useradd", "-N", "user"])
             .expect("should parse -N");
         assert!(m.get_flag(options::NO_USER_GROUP));
+    }
+
+    #[test]
+    fn test_clap_key_short_and_long() {
+        let m = uu_app()
+            .try_get_matches_from([
+                "useradd",
+                "-K",
+                "UID_MIN=9100",
+                "--key",
+                "UID_MAX=9100",
+                "user",
+            ])
+            .expect("should parse -K/--key");
+        let keys: Vec<&str> = m
+            .get_many::<String>(options::KEY)
+            .expect("KEY present")
+            .map(String::as_str)
+            .collect();
+        assert_eq!(keys, ["UID_MIN=9100", "UID_MAX=9100"]);
     }
 
     // -----------------------------------------------------------------------
@@ -1729,6 +1797,7 @@ mod tests {
             inactive: None,
             expire_date: None,
             create_user_group: false,
+            login_defs_overrides: Vec::new(),
             root: root.clone(),
         };
 
@@ -1872,6 +1941,7 @@ mod tests {
             inactive: None,
             expire_date: None,
             create_user_group: false,
+            login_defs_overrides: Vec::new(),
             root: SysRoot::default(),
         };
 
@@ -1906,6 +1976,7 @@ mod tests {
             inactive: None,
             expire_date: None,
             create_user_group: true,
+            login_defs_overrides: Vec::new(),
             root: SysRoot::default(),
         };
 
@@ -1944,6 +2015,7 @@ mod tests {
             inactive: None,
             expire_date: None,
             create_user_group: true,
+            login_defs_overrides: Vec::new(),
             root: SysRoot::default(),
         };
 
@@ -1972,6 +2044,7 @@ mod tests {
             inactive: None,
             expire_date: None,
             create_user_group: false,
+            login_defs_overrides: Vec::new(),
             root: SysRoot::default(),
         };
 
@@ -2006,6 +2079,7 @@ mod tests {
             inactive: None,
             expire_date: None,
             create_user_group: false,
+            login_defs_overrides: Vec::new(),
             root: SysRoot::default(),
         };
 
@@ -2042,6 +2116,7 @@ mod tests {
             inactive: None,
             expire_date: None,
             create_user_group: false,
+            login_defs_overrides: Vec::new(),
             root: SysRoot::default(),
         };
 
@@ -2078,10 +2153,185 @@ mod tests {
             inactive: None,
             expire_date: None,
             create_user_group: false,
+            login_defs_overrides: Vec::new(),
             root: SysRoot::default(),
         };
 
         let uid = determine_uid(&opts, &entries, &defs).expect("should allow duplicate");
         assert_eq!(uid, 5000);
+    }
+
+    // -----------------------------------------------------------------------
+    // -K / login.defs override tests
+    // -----------------------------------------------------------------------
+
+    fn empty_defs() -> LoginDefs {
+        LoginDefs::load(Path::new("/nonexistent")).expect("empty defs")
+    }
+
+    fn opts_for_uid_alloc(system: bool) -> UseraddOptions {
+        UseraddOptions {
+            login: "user".into(),
+            comment: String::new(),
+            home_dir: None,
+            shell: "/bin/bash".into(),
+            uid: None,
+            gid: None,
+            groups: vec![],
+            create_home: false,
+            skel_dir: "/etc/skel".into(),
+            system,
+            non_unique: false,
+            password: "!".into(),
+            inactive: None,
+            expire_date: None,
+            create_user_group: false,
+            login_defs_overrides: Vec::new(),
+            root: SysRoot::default(),
+        }
+    }
+
+    #[test]
+    fn test_parse_login_defs_overrides_valid() {
+        let m = uu_app()
+            .try_get_matches_from([
+                "useradd",
+                "-K",
+                "UID_MIN=9100",
+                "-K",
+                "PASS_MAX_DAYS=-1",
+                "user",
+            ])
+            .expect("parse args");
+        let overrides = parse_login_defs_overrides(&m).expect("valid KEY=VALUE");
+        assert_eq!(
+            overrides,
+            vec![
+                ("UID_MIN".into(), "9100".into()),
+                ("PASS_MAX_DAYS".into(), "-1".into()),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_parse_login_defs_overrides_rejects_missing_equals() {
+        let m = uu_app()
+            .try_get_matches_from(["useradd", "-K", "UID_MIN", "user"])
+            .expect("clap accepts raw value");
+        let err = parse_login_defs_overrides(&m).expect_err("missing '='");
+        assert!(matches!(err, UseraddError::BadArgument(_)));
+    }
+
+    #[test]
+    fn test_parse_login_defs_overrides_rejects_empty_key() {
+        let m = uu_app()
+            .try_get_matches_from(["useradd", "-K", "=9100", "user"])
+            .expect("clap accepts raw value");
+        let err = parse_login_defs_overrides(&m).expect_err("empty key");
+        assert!(matches!(err, UseraddError::BadArgument(_)));
+    }
+
+    #[test]
+    fn test_apply_login_defs_overrides_updates_table() {
+        let mut defs = empty_defs();
+        apply_login_defs_overrides(
+            &mut defs,
+            &[
+                ("UID_MIN".into(), "9100".into()),
+                ("PASS_MAX_DAYS".into(), "-1".into()),
+            ],
+        );
+        assert_eq!(defs.get("UID_MIN"), Some("9100"));
+        assert_eq!(defs.get_i64("PASS_MAX_DAYS"), Some(-1));
+    }
+
+    #[test]
+    fn test_determine_uid_honors_uid_range_overrides() {
+        let entries: Vec<PasswdEntry> = vec![];
+        let mut defs = empty_defs();
+        apply_login_defs_overrides(
+            &mut defs,
+            &[
+                ("UID_MIN".into(), "9100".into()),
+                ("UID_MAX".into(), "9100".into()),
+            ],
+        );
+        let opts = opts_for_uid_alloc(false);
+        let uid = determine_uid(&opts, &entries, &defs).expect("allocate");
+        assert_eq!(uid, 9100);
+    }
+
+    #[test]
+    fn test_determine_uid_honors_sys_uid_range_for_system() {
+        let entries: Vec<PasswdEntry> = vec![];
+        let mut defs = empty_defs();
+        apply_login_defs_overrides(
+            &mut defs,
+            &[
+                ("SYS_UID_MIN".into(), "250".into()),
+                ("SYS_UID_MAX".into(), "250".into()),
+            ],
+        );
+        let opts = opts_for_uid_alloc(true);
+        let uid = determine_uid(&opts, &entries, &defs).expect("allocate system");
+        assert_eq!(uid, 250);
+    }
+
+    #[test]
+    fn test_determine_uid_sys_override_does_not_affect_regular() {
+        let entries: Vec<PasswdEntry> = vec![];
+        let mut defs = empty_defs();
+        // Only system-range keys: regular allocation still uses UID_MIN default.
+        apply_login_defs_overrides(
+            &mut defs,
+            &[
+                ("SYS_UID_MIN".into(), "250".into()),
+                ("SYS_UID_MAX".into(), "250".into()),
+            ],
+        );
+        let opts = opts_for_uid_alloc(false);
+        let uid = determine_uid(&opts, &entries, &defs).expect("allocate regular");
+        assert_eq!(uid, 1000);
+    }
+
+    #[test]
+    fn test_determine_gid_honors_gid_range_overrides() {
+        let groups = vec![GroupEntry {
+            name: "taken".into(),
+            passwd: "x".into(),
+            gid: 9200,
+            members: vec![],
+        }];
+        let mut defs = empty_defs();
+        apply_login_defs_overrides(
+            &mut defs,
+            &[
+                ("GID_MIN".into(), "9201".into()),
+                ("GID_MAX".into(), "9201".into()),
+            ],
+        );
+        // Prefer same-as-UID is blocked (9200 taken), so allocate from range.
+        let opts = UseraddOptions {
+            login: "newgrp".into(),
+            comment: String::new(),
+            home_dir: None,
+            shell: "/bin/bash".into(),
+            uid: Some(9200),
+            gid: None,
+            groups: vec![],
+            create_home: false,
+            skel_dir: "/etc/skel".into(),
+            system: false,
+            non_unique: false,
+            password: "!".into(),
+            inactive: None,
+            expire_date: None,
+            create_user_group: true,
+            login_defs_overrides: Vec::new(),
+            root: SysRoot::default(),
+        };
+        let (gid, new_group) = determine_gid(&opts, 9200, &groups, &defs).expect("gid");
+        assert_eq!(gid, 9201);
+        assert!(new_group.is_some());
     }
 }

--- a/tests/by-util/test_useradd.rs
+++ b/tests/by-util/test_useradd.rs
@@ -366,3 +366,164 @@ fn test_create_user_with_home_dir_flag() {
         "passwd should contain custom home path, got: {passwd}"
     );
 }
+
+#[test]
+fn test_create_user_with_key_uid_range() {
+    if common::skip_unless_root() {
+        return;
+    }
+
+    let dir = setup_root_dir();
+    let code = run_with_root(
+        &dir,
+        &[
+            "-K",
+            "UID_MIN=9100",
+            "-K",
+            "UID_MAX=9100",
+            "-M",
+            "-N",
+            "keyuser",
+        ],
+    );
+    assert_eq!(code, 0, "useradd -K UID range should exit 0");
+
+    let passwd = read_passwd(&dir);
+    assert!(
+        passwd.contains("keyuser:x:9100:"),
+        "passwd should contain UID 9100 from -K, got: {passwd}"
+    );
+}
+
+#[test]
+fn test_create_user_with_key_long_option() {
+    if common::skip_unless_root() {
+        return;
+    }
+
+    let dir = setup_root_dir();
+    let code = run_with_root(
+        &dir,
+        &[
+            "--key",
+            "UID_MIN=9101",
+            "--key",
+            "UID_MAX=9101",
+            "-M",
+            "-N",
+            "keyuserlong",
+        ],
+    );
+    assert_eq!(code, 0, "useradd --key should exit 0");
+
+    let passwd = read_passwd(&dir);
+    assert!(
+        passwd.contains("keyuserlong:x:9101:"),
+        "passwd should contain UID 9101 from --key, got: {passwd}"
+    );
+}
+
+#[test]
+fn test_create_system_user_with_key_sys_uid_range() {
+    if common::skip_unless_root() {
+        return;
+    }
+
+    let dir = setup_root_dir();
+    let code = run_with_root(
+        &dir,
+        &[
+            "-r",
+            "-K",
+            "SYS_UID_MIN=250",
+            "-K",
+            "SYS_UID_MAX=250",
+            "-M",
+            "-N",
+            "syskeyuser",
+        ],
+    );
+    assert_eq!(code, 0, "useradd -r -K SYS_UID range should exit 0");
+
+    let passwd = read_passwd(&dir);
+    assert!(
+        passwd.contains("syskeyuser:x:250:"),
+        "passwd should contain UID 250 from -K, got: {passwd}"
+    );
+}
+
+#[test]
+fn test_create_user_with_key_gid_range_for_user_group() {
+    if common::skip_unless_root() {
+        return;
+    }
+
+    let dir = setup_root_dir();
+    // Without -N, create a matching user group; both UID and GID from -K.
+    let code = run_with_root(
+        &dir,
+        &[
+            "-K",
+            "UID_MIN=9200",
+            "-K",
+            "UID_MAX=9200",
+            "-K",
+            "GID_MIN=9200",
+            "-K",
+            "GID_MAX=9200",
+            "-M",
+            "keygrpuser",
+        ],
+    );
+    assert_eq!(code, 0, "useradd -K with user group should exit 0");
+
+    let passwd = read_passwd(&dir);
+    assert!(
+        passwd.contains("keygrpuser:x:9200:9200:"),
+        "passwd should contain UID/GID 9200 from -K, got: {passwd}"
+    );
+
+    let group = read_group(&dir);
+    assert!(
+        group.contains("keygrpuser:x:9200:"),
+        "group should contain GID 9200 from -K, got: {group}"
+    );
+}
+
+#[test]
+fn test_create_user_with_key_pass_max_days() {
+    if common::skip_unless_root() {
+        return;
+    }
+
+    let dir = setup_root_dir();
+    let code = run_with_root(&dir, &["-K", "PASS_MAX_DAYS=-1", "-M", "-N", "ageuser"]);
+    assert_eq!(code, 0, "useradd -K PASS_MAX_DAYS should exit 0");
+
+    let shadow = read_shadow(&dir);
+    let line = shadow
+        .lines()
+        .find(|l| l.starts_with("ageuser:"))
+        .expect("ageuser shadow entry");
+    // name:passwd:lstchg:min:max:warn:...
+    let fields: Vec<&str> = line.split(':').collect();
+    assert!(
+        fields.len() >= 5,
+        "shadow entry should have max field, got: {line}"
+    );
+    assert_eq!(
+        fields[4], "-1",
+        "PASS_MAX_DAYS override should set max age to -1, got: {line}"
+    );
+}
+
+#[test]
+fn test_key_missing_equals_exits_error() {
+    if common::skip_unless_root() {
+        return;
+    }
+
+    let dir = setup_root_dir();
+    let code = run_with_root(&dir, &["-K", "UID_MIN", "-M", "-N", "badkeyuser"]);
+    assert_eq!(code, 3, "invalid KEY=VALUE should exit 3 (bad argument)");
+}

--- a/tests/by-util/test_useradd.rs
+++ b/tests/by-util/test_useradd.rs
@@ -118,6 +118,31 @@ fn test_defaults_flag() {
 }
 
 #[test]
+fn test_defaults_flag_honors_key_overrides() {
+    if common::skip_unless_root() {
+        return;
+    }
+
+    let dir = setup_root_dir();
+    let code = run_with_root(
+        &dir,
+        &["-D", "-K", "HOME=/OVERRIDDEN", "-K", "SHELL=/bin/zsh"],
+    );
+    assert_eq!(code, 0, "useradd -D -K should exit 0");
+}
+
+#[test]
+fn test_defaults_flag_invalid_key_exits_error() {
+    if common::skip_unless_root() {
+        return;
+    }
+
+    let dir = setup_root_dir();
+    let code = run_with_root(&dir, &["-D", "-K", "UID_MIN"]);
+    assert_eq!(code, 3, "useradd -D with invalid KEY=VALUE should exit 3");
+}
+
+#[test]
 fn test_conflicting_create_no_create_home() {
     let code = run(&["useradd", "-m", "-M", "testuser"]);
     assert_eq!(code, 2, "-m -M conflict should exit 2");


### PR DESCRIPTION
This implements the useradd -K/--key KEY=VALUE (override /etc/login.defs defaults).