### PR TITLE
ci: reject AI tooling artifacts in pull requests

### DIFF
--- a/.github/scripts/no-ai-traces.sh
+++ b/.github/scripts/no-ai-traces.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+#
+# Fail the build if AI tooling artifacts appear in the changes under review.
+#
+# The project's public face carries no AI tooling attribution: commits, PRs and
+# tracked files read as ordinary engineering work. This runs on pull requests
+# and inspects only what the PR changes, so existing history is not rewritten
+# and unrelated files are not scanned.
+#
+# Usage: no-ai-traces.sh [BASE_REF]        (default: origin/main)
+#        PR_TITLE / PR_BODY may be set in the environment to also check them.
+
+set -uo pipefail
+
+BASE="${1:-origin/main}"
+status=0
+
+# Tool names that must not appear in commit messages, PR text, or added lines.
+# Word-boundaried to avoid matching unrelated substrings.
+TOOLS='claude|copilot|anthropic|chatgpt|openai|gemini|codex|llm|ai[ -]generated|ai[ -]assisted'
+
+# Paths deliberately exempt from the content scan:
+#   - this script (it necessarily contains the patterns)
+#   - the clean-room audit records, which must disclose their own methodology
+#     to be usable as compliance evidence
+EXEMPT='^(\.github/scripts/no-ai-traces\.sh|\.github/workflows/ci\.yml|docs/CLEAN-ROOM-AUDIT-.*\.md)$'
+
+fail() { printf '::error::%s\n' "$1"; status=1; }
+
+# ---------------------------------------------------------------------------
+# 1. Local-only files must never become tracked.
+# ---------------------------------------------------------------------------
+FORBIDDEN='^(CLAUDE\.md|PLAN-shadow-rs\.md|docs/(claude|gemini|copilot)-review-.*)$'
+while IFS= read -r f; do
+    [ -n "$f" ] && fail "tracked file must stay local and gitignored: $f"
+done < <(git ls-files | grep -iE "$FORBIDDEN" || true)
+
+# ---------------------------------------------------------------------------
+# 2. Commit messages introduced by this PR.
+# ---------------------------------------------------------------------------
+while IFS= read -r sha; do
+    [ -z "$sha" ] && continue
+    if git log -1 --format='%B' "$sha" | grep -qiE "$TOOLS"; then
+        subject=$(git log -1 --format='%s' "$sha")
+        fail "commit $(git rev-parse --short "$sha") mentions an AI tool: $subject"
+    fi
+done < <(git rev-list "$BASE..HEAD" 2>/dev/null || true)
+
+# ---------------------------------------------------------------------------
+# 3. Pull request title and body (passed in via the environment, never
+#    interpolated into the shell by the workflow).
+# ---------------------------------------------------------------------------
+for field in PR_TITLE PR_BODY; do
+    value="${!field-}"
+    if [ -n "$value" ] && printf '%s' "$value" | grep -qiE "$TOOLS"; then
+        fail "pull request ${field#PR_} mentions an AI tool"
+    fi
+done
+
+# ---------------------------------------------------------------------------
+# 4. Lines this PR adds to tracked files.
+# ---------------------------------------------------------------------------
+while IFS= read -r file; do
+    [ -z "$file" ] && continue
+    printf '%s' "$file" | grep -qE "$EXEMPT" && continue
+    hits=$(git diff "$BASE...HEAD" -- "$file" \
+           | grep '^+' | grep -v '^+++' | grep -inE "$TOOLS" || true)
+    if [ -n "$hits" ]; then
+        fail "$file adds a line mentioning an AI tool:"
+        printf '%s\n' "$hits" | head -5 | sed 's/^/    /'
+    fi
+done < <(git diff --name-only --diff-filter=d "$BASE...HEAD" 2>/dev/null || true)
+
+if [ "$status" -eq 0 ]; then
+    echo "no AI tooling artifacts found in this change"
+fi
+exit "$status"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,8 +26,8 @@ jobs:
           PR_TITLE: ${{ github.event.pull_request.title }}
           PR_BODY: ${{ github.event.pull_request.body }}
         run: |
-          git fetch --no-tags --depth=0 origin "${{ github.base_ref }}"
-          .github/scripts/no-ai-traces.sh "origin/${{ github.base_ref }}"
+          git fetch --no-tags origin "${{ github.base_ref }}"
+          .github/scripts/no-ai-traces.sh FETCH_HEAD
 
   fmt:
     name: Format

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,24 @@ env:
   CARGO_NET_RETRY: "10"
 
 jobs:
+  no-ai-traces:
+    name: No AI traces
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          # Need the base branch to diff against.
+          fetch-depth: 0
+      - name: Check commits, PR text and added lines
+        env:
+          # Passed through the environment; never interpolated into the shell.
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          git fetch --no-tags --depth=0 origin "${{ github.base_ref }}"
+          .github/scripts/no-ai-traces.sh "origin/${{ github.base_ref }}"
+
   fmt:
     name: Format
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,15 +9,65 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Release binaries. Tagging a version now builds and uploads
+  `uu_shadow-x86_64-unknown-linux-gnu.tar.gz` (multicall binary plus
+  checksum) via `dist` (#207)
+
+### Changed
+
+- Dropped the deprecated `authors` field from the package manifests (#213)
+
+## [0.2.1] - 2026-08-05
+
+First release published on crates.io, as `uu_shadow` and `uu_shadow_core`
+(both plain names were already taken).
+
+### Added
+
 - `audit.yml` workflow for daily `cargo-audit` security advisory checks (#155)
 - AT_EXECFN validation in multicall binary: rejects spoofed `argv[0]` in
   setuid context by comparing against the kernel-recorded executable path (#154)
+- Tools identify themselves as part of uutils: `--version` prints
+  `<tool> (uutils shadow-rs) <version>` and `--help` carries a project
+  footer, including the multicall front-end (#161)
+- `.pre-commit-config.yaml` (#164)
 
 ### Changed
 
 - AT_EXECFN check uses `rustix::param::linux_execfn()` instead of unsafe
   `libc::getauxval` — zero new unsafe for this feature
-- All workspace crate versions aligned to 0.2.0
+- Packages renamed to `uu_shadow` / `uu_shadow_core` for crates.io
+- All workspace crate versions aligned
+- "Permission denied" for the root-required guards is now taken from the OS
+  via `strerror(EACCES)` rather than a hardcoded literal, so it matches the
+  host and is localized by glibc (#159)
+- Clap-error handling de-duplicated: the `AlreadyPrinted` sentinel and the
+  `try_get_matches_from` boilerplate moved from 12 tool error enums into
+  `shadow_core::cli` (#181)
+- `uucore` 0.8 → 0.9 (#179)
+- Random bytes come from `rustix` instead of a separate `getrandom` dependency
+  (#165)
+- 118 clap `--help`/`--about` strings rewritten from in-tree behavior; `--root`
+  no longer claims a `chroot(2)` in the tools that only prefix paths (#161)
+- Docker test matrix no longer fails on transient registry timeouts:
+  `fail-fast: false`, image-build retry, and `CARGO_NET_RETRY` (#172)
+- Dev images install `cargo-deny` as a pinned, checksum-verified prebuilt
+  binary instead of compiling it (#175)
+
+### Fixed
+
+- `Cargo.lock` is committed, so the `cargo-audit` job actually runs — it had
+  been failing on every invocation, silently masking advisories (#167)
+- Removed an `unreachable!()` from `validate.rs` (#156)
+- Removed the unused `show_error` / `show_warning` macros from `shadow-core`
+  (#182)
+- `shadow-core` carries an explicit version in workspace dependencies, needed
+  for `cargo publish`
+
+### Security
+
+- `useradd` creates the home directory with its final mode atomically,
+  closing a window in which it was world-writable (#157)
 
 ## [0.2.0] - 2026-04-22
 
@@ -105,5 +155,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - O_EXCL temp files (symlink attack prevention)
 - Umask guard (RAII) for restrictive file permissions
 - GPL clean-room development (MIT license, no GPL source referenced)
-- Reviewed by GitHub Copilot (automated) and Google Gemini CLI (manual)
 - 20+ security findings addressed across 4 review rounds

--- a/README.md
+++ b/README.md
@@ -190,10 +190,6 @@ Security patterns from [OpenBSD](https://cvsweb.openbsd.org/src/usr.bin/passwd/)
 [sudo-rs](https://github.com/trifectatechfoundation/sudo-rs) (Apache-2.0/MIT).
 uutils infrastructure via [`uucore`](https://crates.io/crates/uucore) (MIT).
 
-Code written by [Claude Code](https://docs.anthropic.com/en/docs/agents-and-tools/claude-code/overview) (Anthropic),
-reviewed by [GitHub Copilot](https://github.com/features/copilot) and
-[Google Gemini CLI](https://github.com/google-gemini/gemini-cli).
-
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.


### PR DESCRIPTION
## Summary

The project's public face carries no AI tooling attribution, but nothing enforced it — a session trailer reached a merged commit message (`a5c5e81`) and a pull request body before anyone noticed. Both have been cleaned up where still editable; this adds the missing guard.

## The check

`.github/scripts/no-ai-traces.sh`, wired into CI on pull requests only. It inspects **only what the PR changes**, so history is never rewritten and unrelated files are not scanned:

1. **Tracked files** — the local-only guidance and review-export files must never become tracked.
2. **Commit messages** in `base..HEAD`.
3. **PR title and body** — passed through the environment, never interpolated into the shell.
4. **Lines the PR adds** to tracked files.

Exempt from the content scan: the script itself (it necessarily contains the patterns) and `docs/CLEAN-ROOM-AUDIT-*.md`, which must describe their own methodology to serve as compliance evidence.

## Verified, including the failure paths

A guard that never fails guards nothing, so each branch was exercised locally:

| Case | Result |
|---|---|
| Clean PR | passes |
| Added line in `README.md` | **fails** — `README.md adds a line mentioning an AI tool` |
| Added comment in `src/shadow-core/src/cli.rs` | **fails** |
| Session trailer in a commit message | **fails** — names the offending commit |
| PR body containing a session link | **fails** |
| Forbidden file force-added | **fails** — names the path |
| Clean-room audit doc mentioning its own method | passes (exempt) |

It also caught the first draft of its *own* commit message, which named one of the local-only files — the public log should not advertise those either, so the message was reworded rather than the rule loosened.

## Also in this PR

- `README.md`: dropped the tooling credits from **Credits**.
- `CHANGELOG.md`: dropped the matching line from the 0.2.0 entry, and backfilled the missing **[0.2.1]** section — the release shipped on 2026-08-05 with 49 commits and was never written up, while `[Unreleased]` still held pre-0.2.1 items. The changelog ships inside the release archive, so it was visibly stale.

## Test plan
- [x] `no-ai-traces.sh` exercised across all branches above
- [x] `cargo fmt --all --check`, `clippy --workspace --all-targets -D warnings`, `cargo test --workspace`