### PR TITLE
build: ship binaries with PAM so passwd can change passwords (#220)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,11 +15,15 @@ ALL_TOOLS = $(SETUID_TOOLS) $(ROOT_TOOLS)
 
 all: build
 
+# `pam` is not a default cargo feature, so a plain build produces a `passwd`
+# that refuses the interactive change path ("PAM support is not compiled in").
+# Installed binaries must have it; the PAM headers are already listed as a
+# build requirement in the README.
 build:
-	cargo build --release --workspace --bins --exclude uu_shadow
+	cargo build --release --workspace --bins --exclude uu_shadow --features uu_passwd/pam
 
 build-multicall:
-	cargo build --release --bin shadow-rs
+	cargo build --release --bin shadow-rs --features pam
 
 test:
 	cargo test --workspace

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -16,6 +16,9 @@ targets = ["x86_64-unknown-linux-gnu"]
 # setuid bit to do anything useful (see the install notes in the README).
 installers = []
 unix-archive = ".tar.gz"
+# Build with PAM. Without it `passwd` refuses the interactive change path
+# ("PAM support is not compiled in"), which is the tool's primary function.
+features = ["pam"]
 
 # Ship only the multicall binary. `shadow-rs-completions` is a build-time
 # helper behind `required-features = ["completions"]`, so it is not part of a
@@ -24,6 +27,8 @@ unix-archive = ".tar.gz"
 "*" = ["shadow-rs"]
 
 # `shadow-core::crypt` links crypt(3) via `#[link(name = "crypt")]`, which on
-# Debian/Ubuntu lives in libxcrypt rather than glibc.
+# Debian/Ubuntu lives in libxcrypt rather than glibc; the `pam` feature above
+# links libpam.
 [dist.dependencies.apt]
 libcrypt-dev = "*"
+libpam0g-dev = "*"

--- a/tests/e2e/deploy-test.sh
+++ b/tests/e2e/deploy-test.sh
@@ -168,6 +168,12 @@ test_setuid() {
         fi
     done
 
+    # passwd must be built with the `pam` cargo feature, otherwise the
+    # interactive change path is compiled out and the tool can only report and
+    # lock accounts — it cannot actually change a password.
+    assert_ok "passwd is linked against PAM" \
+        sh -c "ldd $BINDIR/passwd | grep -q libpam"
+
     # Non-root user should be able to run passwd -S on themselves
     assert_ok "testrunner can run passwd -S" \
         su -s /bin/bash testrunner -c "$BINDIR/passwd -S testrunner"


### PR DESCRIPTION
## The defect

`pam` is not a default cargo feature, so almost every build path compiled the interactive change path out of `passwd`. Verified against the archive the new release pipeline produces:

```console
$ passwd -S alice      # works
alice P 2022-01-08 0 99999 7 -1
$ passwd -l alice      # works
shadow-rs: Locking password for user alice
$ passwd alice         # the tool's primary function
shadow-rs: PAM support is not compiled in — cannot change password interactively
```

| Build path | PAM before | after |
|---|---|---|
| `dist` release archive (#207 / #216) | no | **yes** |
| `make install` — the default install | no | **yes** |
| `make install-multicall` | no | **yes** |
| `docker/Dockerfile.e2e` | yes | yes |

The e2e image was the only correct path, and its assertions stop at `passwd -S`, which works fine without PAM — which is exactly why this went unnoticed.

## Changes

- `dist-workspace.toml`: `features = ["pam"]`, plus `libpam0g-dev` alongside `libcrypt-dev` in the apt dependencies.
- `Makefile`: `--features uu_passwd/pam` for `build`, `--features pam` for `build-multicall`. The README already lists PAM headers under build Requirements, so this matches the documented intent.
- `tests/e2e/deploy-test.sh`: assert the installed `passwd` is linked against libpam.

## Verified

```
make build            → passwd: libpam ✓
make build-multicall  → shadow-rs: libpam ✓
dist build            → ldd: libpam.so.0, libcrypt.so.1 ✓
apt matrix            → sudo apt-get install libcrypt-dev libpam0g-dev ✓
```

`passwd alice` now reaches the real PAM stack instead of the compiled-out branch (it fails on `pam_start` in a bare container with no `/etc/pam.d/passwd`, which is the expected environment error rather than a missing code path).

`cargo fmt --all --check`, `clippy --workspace --all-targets -D warnings`, `cargo test --workspace` all green.

## Note on scope

`chfn`, `chsh` and `newgrp` are installed setuid-root but do not link PAM. Whether they should authenticate the caller is a separate question and is not addressed here.

Closes #220.