### PR TITLE
docs: correct the stated reason musl is not published

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,8 +108,9 @@ sudo make install-multicall PREFIX=/usr/local
 
 Each release publishes `uu_shadow-x86_64-unknown-linux-gnu.tar.gz` (with a
 `.sha256` alongside), containing the `shadow-rs` multicall binary. Archives are
-built against glibc; musl is not yet published because `crypt(3)` is not part
-of the static musl target.
+built against glibc. A static musl archive is not published yet: PAM loads its
+modules with `dlopen`, which a fully static binary cannot do, so a musl build
+would have to drop `passwd`'s interactive password change. Tracked in #224.
 
 The archive ships a plain binary — nothing is installed, symlinked, or made
 setuid by extracting it. To deploy it the same way `make install-multicall`

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -28,7 +28,8 @@ features = ["pam"]
 
 # `shadow-core::crypt` links crypt(3) via `#[link(name = "crypt")]`, which on
 # Debian/Ubuntu lives in libxcrypt rather than glibc; the `pam` feature above
-# links libpam.
+# links libpam. Both are why targets stay glibc-only for now: a static musl
+# binary cannot dlopen PAM modules at all (see issue #224).
 [dist.dependencies.apt]
 libcrypt-dev = "*"
 libpam0g-dev = "*"


### PR DESCRIPTION
The README and `dist-workspace.toml` both justified the glibc-only release by saying `crypt(3)` is not part of the static musl target. **That is wrong**, and it was my reasoning in #216.

musl implements `crypt()` inside libc:

```console
$ nm .../x86_64-unknown-linux-musl/lib/self-contained/libc.a | grep ' T crypt'
0000000000000000 T crypt
$ ar t libc.a | grep crypt
crypt.lo crypt_blowfish.lo crypt_des.lo crypt_md5.lo crypt_r.lo crypt_sha256.lo crypt_sha512.lo
```

The link failure came from `#[link(name = "crypt")]` emitting `-lcrypt`: Rust's musl sysroot has no `libcrypt.a`, so the linker fell through to the host's **glibc-built** libxcrypt and failed on glibc-only symbols. Gating that attribute on `not(target_env = "musl")` produces a working 1.4 MB static binary that runs.

The real blocker is **PAM**: it `dlopen`s its modules, which a fully static binary cannot do (musl's static `dlopen` is a stub, and Alpine ships no `libpam.a`). Since #220 the release build enables the `pam` feature, so a musl artifact would have to drop `passwd`'s interactive password change.

This PR only corrects the explanation and points at #224, where the full evaluation and the path to actually shipping musl are recorded. No behaviour change — `dist plan` still produces the same single glibc archive.