### PR TITLE
chore: release 0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.2] - 2026-09-03
+
+First release to ship prebuilt binaries.
+
 ### Added
 
 - Release binaries. Tagging a version now builds and uploads
-  `uu_shadow-x86_64-unknown-linux-gnu.tar.gz` (multicall binary plus
-  checksum) via `dist` (#207)
+  `uu_shadow-x86_64-unknown-linux-gnu.tar.gz` (the `shadow-rs` multicall
+  binary) with a `.sha256` checksum, via `dist` (#207)
+- README section on deploying a release archive: symlinks and the setuid
+  bit, neither of which extracting the tarball sets up
+- CI rejects AI tooling artifacts in pull requests
+
+### Fixed
+
+- `passwd` could not change a password. `pam` is not a default cargo
+  feature, so the release archive, `make install` and
+  `make install-multicall` all compiled the interactive change path out;
+  only the end-to-end image enabled it. Account status and locking were
+  unaffected, which is why it went unnoticed (#220)
 
 ### Changed
 
 - Dropped the deprecated `authors` field from the package manifests (#213)
+- Renovate no longer edits `.github/workflows/release.yml`, which `dist`
+  generates and validates (#227)
 
 ## [0.2.1] - 2026-08-05
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -553,7 +553,7 @@ dependencies = [
 
 [[package]]
 name = "shadow-core"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "clap",
  "landlock",
@@ -714,7 +714,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uu_chage"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "clap",
  "rustix",
@@ -725,7 +725,7 @@ dependencies = [
 
 [[package]]
 name = "uu_chfn"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "clap",
  "rustix",
@@ -736,7 +736,7 @@ dependencies = [
 
 [[package]]
 name = "uu_chpasswd"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "clap",
  "rustix",
@@ -748,7 +748,7 @@ dependencies = [
 
 [[package]]
 name = "uu_chsh"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "clap",
  "rustix",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "uu_groupadd"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "clap",
  "rustix",
@@ -770,7 +770,7 @@ dependencies = [
 
 [[package]]
 name = "uu_groupdel"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "clap",
  "rustix",
@@ -781,7 +781,7 @@ dependencies = [
 
 [[package]]
 name = "uu_groupmod"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "clap",
  "rustix",
@@ -792,7 +792,7 @@ dependencies = [
 
 [[package]]
 name = "uu_grpck"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "clap",
  "shadow-core",
@@ -802,7 +802,7 @@ dependencies = [
 
 [[package]]
 name = "uu_newgrp"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "clap",
  "rustix",
@@ -814,7 +814,7 @@ dependencies = [
 
 [[package]]
 name = "uu_passwd"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "clap",
  "rustix",
@@ -825,7 +825,7 @@ dependencies = [
 
 [[package]]
 name = "uu_pwck"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "clap",
  "shadow-core",
@@ -835,7 +835,7 @@ dependencies = [
 
 [[package]]
 name = "uu_shadow"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "clap",
  "clap_complete",
@@ -860,7 +860,7 @@ dependencies = [
 
 [[package]]
 name = "uu_useradd"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "clap",
  "rustix",
@@ -871,7 +871,7 @@ dependencies = [
 
 [[package]]
 name = "uu_userdel"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "clap",
  "rustix",
@@ -882,7 +882,7 @@ dependencies = [
 
 [[package]]
 name = "uu_usermod"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "clap",
  "rustix",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.1"
+version = "0.2.2"
 edition = "2024"
 rust-version = "1.94.0"
 license = "MIT"
@@ -44,7 +44,7 @@ categories = ["command-line-utilities"]
 
 [workspace.dependencies]
 # Internal crates
-shadow-core = { path = "src/shadow-core", version = "0.2.1" }
+shadow-core = { path = "src/shadow-core", version = "0.2.2" }
 
 # CLI
 clap = { version = "4", features = ["derive", "wrap_help"] }
@@ -72,24 +72,24 @@ tempfile = "3"
 [dependencies]
 clap = { workspace = true }
 clap_complete = { workspace = true, optional = true }
-shadow-core = { path = "src/shadow-core", version = "0.2.1" }
+shadow-core = { path = "src/shadow-core", version = "0.2.2" }
 rustix = { workspace = true }
 
 # Tool crates (optional, enabled by features)
-passwd = { optional = true, version = "0.2.1", package = "uu_passwd", path = "src/uu/passwd" }
-pwck = { optional = true, version = "0.2.1", package = "uu_pwck", path = "src/uu/pwck" }
-useradd = { optional = true, version = "0.2.1", package = "uu_useradd", path = "src/uu/useradd" }
-userdel = { optional = true, version = "0.2.1", package = "uu_userdel", path = "src/uu/userdel" }
-usermod = { optional = true, version = "0.2.1", package = "uu_usermod", path = "src/uu/usermod" }
-chpasswd = { optional = true, version = "0.2.1", package = "uu_chpasswd", path = "src/uu/chpasswd" }
-chage = { optional = true, version = "0.2.1", package = "uu_chage", path = "src/uu/chage" }
-groupadd = { optional = true, version = "0.2.1", package = "uu_groupadd", path = "src/uu/groupadd" }
-groupdel = { optional = true, version = "0.2.1", package = "uu_groupdel", path = "src/uu/groupdel" }
-groupmod = { optional = true, version = "0.2.1", package = "uu_groupmod", path = "src/uu/groupmod" }
-grpck = { optional = true, version = "0.2.1", package = "uu_grpck", path = "src/uu/grpck" }
-chfn = { optional = true, version = "0.2.1", package = "uu_chfn", path = "src/uu/chfn" }
-chsh = { optional = true, version = "0.2.1", package = "uu_chsh", path = "src/uu/chsh" }
-newgrp = { optional = true, version = "0.2.1", package = "uu_newgrp", path = "src/uu/newgrp" }
+passwd = { optional = true, version = "0.2.2", package = "uu_passwd", path = "src/uu/passwd" }
+pwck = { optional = true, version = "0.2.2", package = "uu_pwck", path = "src/uu/pwck" }
+useradd = { optional = true, version = "0.2.2", package = "uu_useradd", path = "src/uu/useradd" }
+userdel = { optional = true, version = "0.2.2", package = "uu_userdel", path = "src/uu/userdel" }
+usermod = { optional = true, version = "0.2.2", package = "uu_usermod", path = "src/uu/usermod" }
+chpasswd = { optional = true, version = "0.2.2", package = "uu_chpasswd", path = "src/uu/chpasswd" }
+chage = { optional = true, version = "0.2.2", package = "uu_chage", path = "src/uu/chage" }
+groupadd = { optional = true, version = "0.2.2", package = "uu_groupadd", path = "src/uu/groupadd" }
+groupdel = { optional = true, version = "0.2.2", package = "uu_groupdel", path = "src/uu/groupdel" }
+groupmod = { optional = true, version = "0.2.2", package = "uu_groupmod", path = "src/uu/groupmod" }
+grpck = { optional = true, version = "0.2.2", package = "uu_grpck", path = "src/uu/grpck" }
+chfn = { optional = true, version = "0.2.2", package = "uu_chfn", path = "src/uu/chfn" }
+chsh = { optional = true, version = "0.2.2", package = "uu_chsh", path = "src/uu/chsh" }
+newgrp = { optional = true, version = "0.2.2", package = "uu_newgrp", path = "src/uu/newgrp" }
 
 [features]
 default = ["passwd", "pwck", "useradd", "userdel", "usermod", "chpasswd", "chage",
@@ -190,21 +190,21 @@ name = "test_groupadd"
 path = "tests/by-util/test_groupadd.rs"
 
 [dev-dependencies]
-chage = { version = "0.2.1", package = "uu_chage", path = "src/uu/chage" }
-chfn = { version = "0.2.1", package = "uu_chfn", path = "src/uu/chfn" }
-chpasswd = { version = "0.2.1", package = "uu_chpasswd", path = "src/uu/chpasswd" }
-chsh = { version = "0.2.1", package = "uu_chsh", path = "src/uu/chsh" }
-groupadd = { version = "0.2.1", package = "uu_groupadd", path = "src/uu/groupadd" }
-groupdel = { version = "0.2.1", package = "uu_groupdel", path = "src/uu/groupdel" }
-groupmod = { version = "0.2.1", package = "uu_groupmod", path = "src/uu/groupmod" }
-newgrp = { version = "0.2.1", package = "uu_newgrp", path = "src/uu/newgrp" }
-passwd = { version = "0.2.1", package = "uu_passwd", path = "src/uu/passwd" }
-useradd = { version = "0.2.1", package = "uu_useradd", path = "src/uu/useradd" }
-userdel = { version = "0.2.1", package = "uu_userdel", path = "src/uu/userdel" }
-usermod = { version = "0.2.1", package = "uu_usermod", path = "src/uu/usermod" }
-pwck = { version = "0.2.1", package = "uu_pwck", path = "src/uu/pwck" }
-grpck = { version = "0.2.1", package = "uu_grpck", path = "src/uu/grpck" }
-shadow-core = { path = "src/shadow-core", version = "0.2.1", features = ["shadow"] }
+chage = { version = "0.2.2", package = "uu_chage", path = "src/uu/chage" }
+chfn = { version = "0.2.2", package = "uu_chfn", path = "src/uu/chfn" }
+chpasswd = { version = "0.2.2", package = "uu_chpasswd", path = "src/uu/chpasswd" }
+chsh = { version = "0.2.2", package = "uu_chsh", path = "src/uu/chsh" }
+groupadd = { version = "0.2.2", package = "uu_groupadd", path = "src/uu/groupadd" }
+groupdel = { version = "0.2.2", package = "uu_groupdel", path = "src/uu/groupdel" }
+groupmod = { version = "0.2.2", package = "uu_groupmod", path = "src/uu/groupmod" }
+newgrp = { version = "0.2.2", package = "uu_newgrp", path = "src/uu/newgrp" }
+passwd = { version = "0.2.2", package = "uu_passwd", path = "src/uu/passwd" }
+useradd = { version = "0.2.2", package = "uu_useradd", path = "src/uu/useradd" }
+userdel = { version = "0.2.2", package = "uu_userdel", path = "src/uu/userdel" }
+usermod = { version = "0.2.2", package = "uu_usermod", path = "src/uu/usermod" }
+pwck = { version = "0.2.2", package = "uu_pwck", path = "src/uu/pwck" }
+grpck = { version = "0.2.2", package = "uu_grpck", path = "src/uu/grpck" }
+shadow-core = { path = "src/shadow-core", version = "0.2.2", features = ["shadow"] }
 rustix = { workspace = true }
 tempfile = { workspace = true }
 


### PR DESCRIPTION
Prepares 0.2.2 — the first release to actually ship binaries.

## Contents

- **Release binaries** (#207 / #216): a tag now builds and uploads `uu_shadow-x86_64-unknown-linux-gnu.tar.gz` with a `.sha256`. 0.2.1 and everything before it published no assets.
- **`passwd` can change passwords again** (#220): `pam` is not a default cargo feature, so the archive, `make install` and `make install-multicall` all compiled the interactive path out. Status and locking still worked, which is why it slipped through.
- Manifest cleanup (#213) and the Renovate/generated-workflow fix (#227).

## Verified

```console
$ dist build --artifacts=local
uu_shadow-x86_64-unknown-linux-gnu.tar.gz  [bin] shadow-rs  [misc] CHANGELOG.md LICENSE README.md
$ ./shadow-rs --version
shadow-rs (uutils shadow-rs) 0.2.2
$ ldd shadow-rs | grep -cE 'pam|crypt'
2
```

`cargo fmt --all --check`, `clippy --workspace --all-targets -D warnings` and `cargo test --workspace` all pass.

## Note

The release workflow has never run against a real tag — only `dist plan` and local `dist build`. Pushing `0.2.2` after this merges is what finally exercises the upload path, which is the point of #221.

Closes #221.