### PR TITLE
docs: document platform support and what a musl build loses

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,6 +60,10 @@ docker compose run --rm alpine cargo test --workspace  # test on Alpine (musl)
 docker compose run --rm fedora cargo test --workspace  # test on Fedora (SELinux)
 ```
 
+All three must pass. Note that musl is tested but not a release target — a
+static musl build loses PAM, NSS and yescrypt; see
+[docs/PLATFORM-SUPPORT.md](docs/PLATFORM-SUPPORT.md).
+
 ### Linting
 
 ```shell

--- a/README.md
+++ b/README.md
@@ -108,9 +108,9 @@ sudo make install-multicall PREFIX=/usr/local
 
 Each release publishes `uu_shadow-x86_64-unknown-linux-gnu.tar.gz` (with a
 `.sha256` alongside), containing the `shadow-rs` multicall binary. Archives are
-built against glibc. A static musl archive is not published yet: PAM loads its
-modules with `dlopen`, which a fully static binary cannot do, so a musl build
-would have to drop `passwd`'s interactive password change. Tracked in #224.
+built against glibc. A static musl archive is not published: such a build works
+but loses PAM, NSS and yescrypt support, so it is not equivalent to this one.
+See [docs/PLATFORM-SUPPORT.md](docs/PLATFORM-SUPPORT.md).
 
 The archive ships a plain binary — nothing is installed, symlinked, or made
 setuid by extracting it. To deploy it the same way `make install-multicall`
@@ -183,6 +183,11 @@ merge is frictionless.
 | `debian` | `rust:latest` (Trixie) | glibc | Linux-PAM | headers |
 | `alpine` | `rust:alpine` | musl | Linux-PAM | none |
 | `fedora` | `fedora:latest` | glibc | Linux-PAM | enforcing |
+
+musl is covered by the test matrix but is not a release target: a static musl
+build loses PAM, NSS and yescrypt. See
+[docs/PLATFORM-SUPPORT.md](docs/PLATFORM-SUPPORT.md) for what that means and
+why.
 
 ## Credits
 

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -28,8 +28,8 @@ features = ["pam"]
 
 # `shadow-core::crypt` links crypt(3) via `#[link(name = "crypt")]`, which on
 # Debian/Ubuntu lives in libxcrypt rather than glibc; the `pam` feature above
-# links libpam. Both are why targets stay glibc-only for now: a static musl
-# binary cannot dlopen PAM modules at all (see issue #224).
+# links libpam. Both are why targets stay glibc-only: a static musl build loses
+# PAM, NSS and yescrypt — see docs/PLATFORM-SUPPORT.md and issue #224.
 [dist.dependencies.apt]
 libcrypt-dev = "*"
 libpam0g-dev = "*"

--- a/docs/PLATFORM-SUPPORT.md
+++ b/docs/PLATFORM-SUPPORT.md
@@ -1,0 +1,102 @@
+# Platform support
+
+What shadow-rs builds and runs on, and where a build differs in behaviour.
+
+The distinction that matters most is the C library. shadow-rs is tested on both
+glibc and musl, but *tested on* and *released for* are not the same thing:
+released archives are glibc, and a musl build is functionally reduced in three
+specific ways described below.
+
+## Release artifacts
+
+| Target | Published | Linking |
+|---|---|---|
+| `x86_64-unknown-linux-gnu` | yes | dynamic (libpam, libcrypt, libc) |
+| `x86_64-unknown-linux-musl` | no — see below | static |
+| `aarch64-unknown-linux-gnu` | no — tracked in #222 | dynamic |
+
+## Test matrix
+
+CI builds and runs the full suite on three images, so musl regressions are
+caught even though musl is not released:
+
+| Image | Base | libc | PAM | SELinux |
+|---|---|---|---|---|
+| `debian` | `rust:latest` (Trixie) | glibc | Linux-PAM | headers |
+| `alpine` | `rust:alpine` | musl | Linux-PAM | none |
+| `fedora` | `fedora:latest` | glibc | Linux-PAM | enforcing |
+
+## musl
+
+A static musl binary **builds and runs**. What stops it being published is that
+it is not equivalent to the glibc build — it loses three things, and for
+account-management tools none of them is cosmetic.
+
+### 1. No PAM
+
+Linux-PAM loads its modules with `dlopen`. A fully static binary cannot do
+that: musl's static `dlopen` is a stub that returns *"Dynamic loading not
+supported"*, and Alpine ships no `libpam.a` to link against in the first place.
+
+Effect: `passwd`'s interactive password change is unavailable. Everything else
+is unaffected — `passwd -S/-l/-u/-d/-e/-n/-x/-w/-i` and the other 13 tools
+reach `/etc/shadow` and crypt(3) directly.
+
+### 2. No NSS
+
+`shadow_core::process` resolves the calling user through `getpwuid_r`, used by
+`passwd`, `chfn`, `chsh`, `chage` and `newgrp`.
+
+glibc answers such lookups through its NSS module system, so it sees users from
+LDAP, SSSD, Active Directory or systemd-userdb. musl has no NSS module system
+and reads `/etc/passwd` directly. On a directory-joined host, those five tools
+would not see network users at all.
+
+### 3. No yescrypt (`$y$`)
+
+musl's crypt(3) implements DES, MD5, SHA-256, SHA-512 (including
+`rounds=`) and bcrypt, and produces byte-identical output to libxcrypt for all
+of them. It does not implement yescrypt.
+
+This is not a marginal format: **Debian 12+ and Ubuntu 24.04 use yescrypt as
+the default password hash.** A musl build can neither verify nor produce `$y$`
+hashes, so `newgrp` fails against a `$y$` group password and `chpasswd`
+produces SHA-512 where the system default is yescrypt. The prefix guard in
+`shadow_core::crypt` rejects the format explicitly rather than silently
+falling back.
+
+### Where musl is nonetheless the right choice
+
+Minimal containers and embedded images: a local `/etc/passwd`, no directory
+service, no PAM stack. There, none of the three gaps costs anything, and a
+single static binary with no runtime dependencies is worth having.
+
+If a musl archive is published it must be labelled as static, PAM-less,
+NSS-less and without `$y$` — never presented as an alternative to the glibc
+archive. Tracked in #224.
+
+### Building for musl
+
+The `#[link(name = "crypt")]` attribute in `shadow_core::crypt` emits
+`-lcrypt`. Rust's self-contained musl sysroot has no `libcrypt.a`, so the
+linker falls through to the host's glibc-built libxcrypt and fails on
+glibc-only symbols. musl implements `crypt()` inside libc itself, so the
+attribute simply should not be emitted for that target:
+
+```rust
+#[cfg_attr(not(target_env = "musl"), link(name = "crypt"))]
+```
+
+Alpine builds work today without this because `musl-dev` ships an empty
+`libcrypt.a` that absorbs the flag.
+
+Note that libxcrypt is **LGPL-2.1+**, so it cannot be vendored to fill the gap:
+shadow-rs takes no GPL or LGPL dependencies. Pure-Rust alternatives exist
+(`sha-crypt`, `yescrypt`, both MIT/Apache-2.0), but the yescrypt crate is
+self-declared unaudited, which rules it out of a setuid-root path for now.
+
+## Architectures
+
+Only `x86_64` is published. aarch64 needs the target's system libraries for
+crypt(3) and PAM, so it requires a cross-compilation setup or a native runner —
+tracked in #222.


### PR DESCRIPTION
Follow-up to the musl evaluation in #224.

The README explained the glibc-only release with one sentence about PAM. Evaluating musl properly turned up two more gaps, both of which matter specifically for account-management tools:

**No NSS.** `getpwuid_r` backs `current_username()`, used by `passwd`, `chfn`, `chsh`, `chage` and `newgrp`. glibc resolves those through its NSS modules and therefore sees LDAP, SSSD, AD and systemd-userdb users. musl has no module system and reads `/etc/passwd` directly, so on a directory-joined host those five tools would not see network users at all.

**No yescrypt.** musl's crypt(3) covers DES, MD5, SHA-256, SHA-512 (with `rounds=`) and bcrypt, byte-identical to libxcrypt — but not `$y$`, which is **the default hash on Debian 12+ and Ubuntu 24.04**. A musl build could neither verify nor produce them.

Together with the PAM limitation, a musl artifact is a reduced build, not an alternative to the glibc one. That is worth stating somewhere durable rather than in a PR description.

Adds `docs/PLATFORM-SUPPORT.md`: release targets, the test matrix and the distinction between *tested on* and *released for*, the three gaps with their consequences, how to build for musl anyway (the one-line `cfg_attr` on `#[link(name = "crypt")]`), and why libxcrypt cannot fill the gap (LGPL-2.1+, excluded by the project's licence rule).

README, CONTRIBUTING and the `dist-workspace.toml` comment now point at it instead of repeating a partial explanation. Documentation only — no behaviour change.