### PR TITLE
ci: track the dist release tooling version

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,5 +8,16 @@
       "matchFileNames": [".github/workflows/release.yml"],
       "enabled": false
     }
+  ],
+  "customManagers": [
+    {
+      "description": "Track the dist release tooling pinned in dist-workspace.toml, which no built-in manager understands.",
+      "customType": "regex",
+      "managerFilePatterns": ["/^dist-workspace\\.toml$/"],
+      "matchStrings": ["cargo-dist-version = \"(?<currentValue>[^\"]+)\""],
+      "depNameTemplate": "axodotdev/cargo-dist",
+      "datasourceTemplate": "github-releases",
+      "extractVersionTemplate": "^v(?<version>.*)$"
+    }
   ]
 }


### PR DESCRIPTION
`dist-workspace.toml` pins the release tooling:

```toml
[dist]
cargo-dist-version = "0.32.0"
```

No built-in manager reads that, and #227 stopped Renovate touching the generated `release.yml` — so nothing signals a new dist release and the tooling would quietly go stale.

Adds a regex custom manager sourcing `axodotdev/cargo-dist` from GitHub releases.

## Verified rather than guessed

A malformed Renovate config invalidates the whole file and stops **every** dependency update, so this was checked with the official validator (Renovate 42.99.0) before pushing:

| Variant | Result |
|---|---|
| `fileMatch` | validates, but **"Config needs migrating"** — deprecated |
| `managerFilePatterns` (regex in slashes) | **clean, no warnings** |

Final config: `Config validated successfully`, no migration warning.

The regex was also exercised against the real file using the same engine Renovate uses:

```
match             : true
currentValue      : 0.32.0
file pattern match: true
extractVersion    : v0.33.0 → 0.33.0
```

A syntactically valid manager that matches nothing would have been useless, so both halves are confirmed.

Closes #228.