### PR TITLE
ci: lint the PAM code path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,9 @@ jobs:
       # pre-installed tools: https://github.com/actions/runner-images/blob/main/images/ubuntu/
       - run: sudo apt-get update && sudo apt-get install -y libpam0g-dev libselinux1-dev libaudit-dev libcrypt-dev
       - run: cargo clippy --workspace --all-targets -- -D warnings
+      # Release binaries are built with `pam` (see dist-workspace.toml), so the
+      # PAM code path has to be linted too — it is invisible to the run above.
+      - run: cargo clippy --workspace --all-targets --features pam -- -D warnings
 
   test:
     name: Test

--- a/src/shadow-core/src/pam.rs
+++ b/src/shadow-core/src/pam.rs
@@ -822,14 +822,19 @@ mod tests {
 
     #[test]
     fn test_pam_message_layout() {
-        // Verify PamMessage has the expected C layout.
+        // Verify PamMessage has a plausible C layout: it holds an int and a
+        // pointer, so it must be at least their combined size and padded out
+        // to its own alignment. Computing the exact padding here only
+        // reimplements the compiler's layout rules, and the previous attempt
+        // clamped an unsigned subtraction with `.max(0)`, which never did
+        // anything.
+        assert!(
+            std::mem::size_of::<PamMessage>()
+                >= std::mem::size_of::<libc::c_int>() + std::mem::size_of::<*const libc::c_char>()
+        );
         assert_eq!(
-            std::mem::size_of::<PamMessage>(),
-            std::mem::size_of::<libc::c_int>() + std::mem::size_of::<*const libc::c_char>()
-                // Account for padding.
-                + (std::mem::align_of::<*const libc::c_char>()
-                    - std::mem::size_of::<libc::c_int>())
-                    .max(0)
+            std::mem::size_of::<PamMessage>() % std::mem::align_of::<PamMessage>(),
+            0
         );
     }
 

--- a/src/uu/passwd/src/passwd.rs
+++ b/src/uu/passwd/src/passwd.rs
@@ -515,22 +515,26 @@ impl Drop for PrivDrop {
 /// Default operation: change password via PAM.
 ///
 /// Feature-gated on `pam`. When PAM is not compiled in, prints an error.
-fn cmd_pam_change(matches: &clap::ArgMatches, _target_user: &str) -> UResult<()> {
-    let _keep_tokens = matches.get_flag(options::KEEP_TOKENS);
-    let _use_stdin = matches.get_flag(options::STDIN);
+// Every binding below is consumed only by the `pam` block; without the
+// feature the whole conversation is compiled out.
+#[cfg_attr(not(feature = "pam"), allow(unused_variables))]
+fn cmd_pam_change(matches: &clap::ArgMatches, target_user: &str) -> UResult<()> {
+    let keep_tokens = matches.get_flag(options::KEEP_TOKENS);
+    let use_stdin = matches.get_flag(options::STDIN);
+    // Parsed for compatibility only; shadow-rs always uses the files backend.
     let _repository = matches.get_one::<String>(options::REPOSITORY);
 
     #[cfg(feature = "pam")]
     {
         use shadow_core::pam::{ConvMode, PamContext, flags};
 
-        let conv_mode = if _use_stdin {
+        let conv_mode = if use_stdin {
             ConvMode::Stdin
         } else {
             ConvMode::Tty
         };
 
-        let mut pam = match PamContext::new("passwd", _target_user, conv_mode) {
+        let mut pam = match PamContext::new("passwd", target_user, conv_mode) {
             Ok(ctx) => ctx,
             Err(e) => {
                 return Err(PasswdError::PamError(e.to_string()).into());
@@ -542,10 +546,10 @@ fn cmd_pam_change(matches: &clap::ArgMatches, _target_user: &str) -> UResult<()>
         let _priv_drop = PrivDrop::drop_to(rustix::process::getuid().as_raw())?;
 
         // Non-root users changing their own password must authenticate first.
-        if !shadow_core::hardening::caller_is_root() {
-            if let Err(e) = pam.authenticate(0) {
-                return Err(PasswdError::PamError(e.to_string()).into());
-            }
+        if !shadow_core::hardening::caller_is_root()
+            && let Err(e) = pam.authenticate(0)
+        {
+            return Err(PasswdError::PamError(e.to_string()).into());
         }
 
         // Validate that the account is in good standing.
@@ -554,7 +558,7 @@ fn cmd_pam_change(matches: &clap::ArgMatches, _target_user: &str) -> UResult<()>
         }
 
         // Change the password token.
-        let chauthtok_flags = if _keep_tokens {
+        let chauthtok_flags = if keep_tokens {
             flags::PAM_CHANGE_EXPIRED_AUTHTOK
         } else {
             0
@@ -566,7 +570,7 @@ fn cmd_pam_change(matches: &clap::ArgMatches, _target_user: &str) -> UResult<()>
 
         audit::log_user_event(
             "CHNG_PASSWD",
-            _target_user,
+            target_user,
             rustix::process::getuid().as_raw(),
             true,
         );


### PR DESCRIPTION
CI runs `cargo clippy --workspace --all-targets -- -D warnings` — without `--features pam`. Everything behind that gate has therefore never been linted, and since #220 the release binaries **are** built with it. The code we ship is exactly the code nobody checks.

Running it against `main` today fails:

```
error: this `if` statement can be collapsed
error: used underscore-prefixed binding                                    (x4)
error: `(std::mem::align_of::<*const libc::c_char>()
         - std::mem::size_of::<libc::c_int>())` is never smaller than `0`
       and has therefore no effect
```

I found this while working on the PAM code, and confirmed on a clean `main` checkout that it predates my changes.

## Fixes

- **passwd** — `keep_tokens`, `use_stdin` and `target_user` are read by the `pam` block, so underscore-prefixing them was wrong. Named properly, with `allow(unused_variables)` for the build where the feature is off. `_repository` stays underscored: it really is parsed-and-ignored.
- **passwd** — the root check and the `authenticate` call collapse into a let chain, matching how the rest of the tree is written.
- **shadow-core::pam** — the layout test computed padding as `(align_of - size_of).max(0)` on `usize`. That subtraction is unsigned, so `.max(0)` never did anything. Replaced with what the test actually means and which holds on any target: the struct is at least int + pointer, and its size is a multiple of its alignment.

## Prevention

Adds the missing invocation to the clippy job:

```yaml
- run: cargo clippy --workspace --all-targets --features pam -- -D warnings
```

## Verified

| | without `pam` | with `pam` |
|---|---|---|
| clippy `-D warnings` | pass | **pass** (failed on main) |
| `cargo test --workspace` | 59 suites ok | pass |

`cargo fmt --all --check` clean.
