### PR TITLE
chfn, chsh: authenticate the caller before applying a change

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,10 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - run: sudo apt-get update && sudo apt-get install -y libpam0g-dev libselinux1-dev libaudit-dev libcrypt-dev
       - run: cargo test --workspace
+      # Release binaries enable `pam`, and the feature changes behaviour rather
+      # than only adding code: without it the setuid tools refuse to
+      # authenticate. Both configurations have to be tested.
+      - run: cargo test --workspace --features pam
 
   msrv:
     name: MSRV (1.94.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- `chfn` and `chsh` now authenticate the caller before applying a change.
+  Both are installed setuid-root and restricted non-root callers to their own
+  account, but never verified who was asking — anyone with access to an
+  unlocked session could change that user's login shell or GECOS field.
+  Distributions already ship `/etc/pam.d/chfn` and `/etc/pam.d/chsh` for this
+  (#226)
+
+### Changed
+
+- Without the `pam` feature, `chfn` and `chsh` refuse non-root invocations
+  rather than applying an unauthenticated change. Every install path enables
+  the feature; a static musl build would not — see
+  [docs/PLATFORM-SUPPORT.md](docs/PLATFORM-SUPPORT.md)
+- `PrivDrop`, the guard that lowers privileges for a PAM conversation, moved
+  from `passwd` into `shadow-core` so every setuid tool uses one implementation
+- CI lints and tests the `pam` code path, which the release binaries use but
+  no job previously exercised
+
 ## [0.2.2] - 2026-09-03
 
 First release to ship prebuilt binaries.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,7 +119,7 @@ feat_common = ["feat_phase1", "feat_phase2"]
 feat_common_core = ["feat_phase1", "feat_phase2", "feat_phase3"]
 
 # PAM authentication (requires libpam-dev)
-pam = ["passwd/pam"]
+pam = ["passwd/pam", "chfn/pam", "chsh/pam"]
 
 # Shell completions generator
 completions = ["dep:clap_complete"]

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,8 @@ all: build
 # Installed binaries must have it; the PAM headers are already listed as a
 # build requirement in the README.
 build:
-	cargo build --release --workspace --bins --exclude uu_shadow --features uu_passwd/pam
+	cargo build --release --workspace --bins --exclude uu_shadow \
+		--features uu_passwd/pam,uu_chfn/pam,uu_chsh/pam
 
 build-multicall:
 	cargo build --release --bin shadow-rs --features pam

--- a/docs/PLATFORM-SUPPORT.md
+++ b/docs/PLATFORM-SUPPORT.md
@@ -38,9 +38,17 @@ Linux-PAM loads its modules with `dlopen`. A fully static binary cannot do
 that: musl's static `dlopen` is a stub that returns *"Dynamic loading not
 supported"*, and Alpine ships no `libpam.a` to link against in the first place.
 
-Effect: `passwd`'s interactive password change is unavailable. Everything else
-is unaffected — `passwd -S/-l/-u/-d/-e/-n/-x/-w/-i` and the other 13 tools
-reach `/etc/shadow` and crypt(3) directly.
+Effect, and this is the heaviest of the three gaps:
+
+- `passwd`'s interactive password change is unavailable.
+- `chfn` and `chsh` become **root-only**. They authenticate the caller through
+  PAM before applying a change, and a setuid-root tool must fail closed rather
+  than apply an unverified one — so without PAM they refuse every non-root
+  invocation outright.
+
+Unaffected: `passwd -S/-l/-u/-d/-e/-n/-x/-w/-i`, `newgrp` (which authenticates
+against the group password via crypt(3), not PAM), and the other 11 tools,
+which are root-only anyway and reach `/etc/shadow` directly.
 
 ### 2. No NSS
 

--- a/src/shadow-core/src/process.rs
+++ b/src/shadow-core/src/process.rs
@@ -293,3 +293,45 @@ pub fn verify_argv0_matches_execfn(argv0: &str) -> bool {
 
     argv0_base == execfn_base
 }
+
+// ---------------------------------------------------------------------------
+// Privilege dropping
+// ---------------------------------------------------------------------------
+
+/// RAII guard that drops the effective UID and restores it when dropped.
+///
+/// A setuid-root tool should run its PAM conversation as the real caller, so
+/// that PAM modules see the actual user rather than root. Restoration happens
+/// in `Drop`, so it also covers the early-return and error paths.
+pub struct PrivDrop {
+    original_euid: u32,
+}
+
+impl PrivDrop {
+    /// Drop the effective UID to `uid`, restoring the previous value on drop.
+    ///
+    /// # Errors
+    ///
+    /// Returns the `seteuid` failure if privileges cannot be dropped. Callers
+    /// must treat that as fatal rather than continuing as root.
+    pub fn drop_to(uid: u32) -> io::Result<Self> {
+        let original_euid = rustix::process::geteuid().as_raw();
+        if original_euid != uid {
+            seteuid(uid)?;
+        }
+        Ok(Self { original_euid })
+    }
+}
+
+impl Drop for PrivDrop {
+    fn drop(&mut self) {
+        if let Err(e) = seteuid(self.original_euid) {
+            // Drop cannot report an error, and carrying on with the wrong
+            // effective UID is worse than being noisy about it.
+            uucore::show_error!(
+                "CRITICAL: failed to restore euid to {}: {e}",
+                self.original_euid
+            );
+        }
+    }
+}

--- a/src/uu/chfn/Cargo.toml
+++ b/src/uu/chfn/Cargo.toml
@@ -23,6 +23,10 @@ rustix = { workspace = true }
 shadow-core = { workspace = true }
 uucore = { workspace = true }
 
+[features]
+default = []
+pam = ["shadow-core/pam"]
+
 [dev-dependencies]
 tempfile = { workspace = true }
 

--- a/src/uu/chfn/src/chfn.rs
+++ b/src/uu/chfn/src/chfn.rs
@@ -235,7 +235,8 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 
     let target_user = resolve_target_user(&matches)?;
 
-    // Non-root users can only change their own info.
+    // Non-root users can only change their own info, and must prove they are
+    // who they claim before anything is written.
     if !shadow_core::hardening::caller_is_root() {
         let current_user = shadow_core::hardening::current_username()
             .map_err(|e| ChfnError::Error(e.to_string()))?;
@@ -244,6 +245,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
                 ChfnError::Error("you may only change your own finger information".into()).into(),
             );
         }
+        authenticate_caller(&current_user)?;
     }
 
     // At least one field flag must be present (we require flags, no interactive mode).
@@ -314,6 +316,46 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 
     uucore::show_error!("changed user '{target_user}' information");
     Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Caller authentication
+// ---------------------------------------------------------------------------
+
+/// Require the caller to authenticate before a non-root change is applied.
+///
+/// The tool is installed setuid-root, so the real UID check above establishes
+/// *who may be changed*; this establishes *who is asking*. Without it, anyone
+/// with access to an unlocked session could alter that user's account.
+/// Distributions ship a PAM service for this (`/etc/pam.d/chfn`), where
+/// `pam_rootok` lets root through and `common-auth` prompts everyone else.
+///
+/// Privileges are dropped to the real UID for the conversation so PAM modules
+/// see the actual caller, and restored when the guard falls out of scope.
+#[cfg(feature = "pam")]
+fn authenticate_caller(user: &str) -> Result<(), ChfnError> {
+    use shadow_core::pam::{ConvMode, PamContext};
+
+    let mut pam = PamContext::new("chfn", user, ConvMode::Tty)
+        .map_err(|e| ChfnError::Error(e.to_string()))?;
+
+    let _priv_drop = shadow_core::process::PrivDrop::drop_to(rustix::process::getuid().as_raw())
+        .map_err(|e| ChfnError::Error(format!("cannot drop privileges: {e}")))?;
+
+    pam.authenticate(0)
+        .map_err(|e| ChfnError::Error(e.to_string()))?;
+    pam.acct_mgmt(0)
+        .map_err(|e| ChfnError::Error(e.to_string()))?;
+    Ok(())
+}
+
+/// Without PAM there is no way to verify the caller, so refuse rather than
+/// silently applying an unauthenticated change to a setuid-root tool.
+#[cfg(not(feature = "pam"))]
+fn authenticate_caller(_user: &str) -> Result<(), ChfnError> {
+    Err(ChfnError::Error(
+        "PAM support is not compiled in — cannot authenticate; run as root".into(),
+    ))
 }
 
 /// Build the clap `Command` for `chfn`.
@@ -498,6 +540,22 @@ mod tests {
                 .get_one::<String>(options::FULL_NAME)
                 .map(String::as_str),
             Some("New Name")
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Caller authentication
+    // -----------------------------------------------------------------------
+
+    /// A setuid-root tool must fail closed: with no way to authenticate the
+    /// caller, it refuses rather than applying an unverified change.
+    #[test]
+    #[cfg(not(feature = "pam"))]
+    fn test_authenticate_caller_fails_closed_without_pam() {
+        let err = authenticate_caller("someone").expect_err("must refuse without PAM");
+        assert!(
+            format!("{err}").contains("cannot authenticate"),
+            "unexpected message: {err}"
         );
     }
 }

--- a/src/uu/chsh/Cargo.toml
+++ b/src/uu/chsh/Cargo.toml
@@ -23,6 +23,10 @@ rustix = { workspace = true }
 shadow-core = { workspace = true }
 uucore = { workspace = true }
 
+[features]
+default = []
+pam = ["shadow-core/pam"]
+
 [dev-dependencies]
 tempfile = { workspace = true }
 

--- a/src/uu/chsh/src/chsh.rs
+++ b/src/uu/chsh/src/chsh.rs
@@ -263,13 +263,15 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 
     let target_user = resolve_target_user(&matches)?;
 
-    // Non-root users can only change their own shell.
+    // Non-root users can only change their own shell, and must prove they are
+    // who they claim before anything is written.
     if !shadow_core::hardening::caller_is_root() {
         let current_user = shadow_core::hardening::current_username()
             .map_err(|e| ChshError::Error(e.to_string()))?;
         if current_user != target_user {
             return Err(ChshError::Error("you may only change your own login shell".into()).into());
         }
+        authenticate_caller(&current_user)?;
     }
 
     let Some(new_shell) = matches.get_one::<String>(options::SHELL) else {
@@ -287,6 +289,46 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 
     uucore::show_error!("shell changed for '{target_user}'");
     Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Caller authentication
+// ---------------------------------------------------------------------------
+
+/// Require the caller to authenticate before a non-root change is applied.
+///
+/// The tool is installed setuid-root, so the real UID check above establishes
+/// *who may be changed*; this establishes *who is asking*. Without it, anyone
+/// with access to an unlocked session could alter that user's account.
+/// Distributions ship a PAM service for this (`/etc/pam.d/chsh`), where
+/// `pam_rootok` lets root through and `common-auth` prompts everyone else.
+///
+/// Privileges are dropped to the real UID for the conversation so PAM modules
+/// see the actual caller, and restored when the guard falls out of scope.
+#[cfg(feature = "pam")]
+fn authenticate_caller(user: &str) -> Result<(), ChshError> {
+    use shadow_core::pam::{ConvMode, PamContext};
+
+    let mut pam = PamContext::new("chsh", user, ConvMode::Tty)
+        .map_err(|e| ChshError::Error(e.to_string()))?;
+
+    let _priv_drop = shadow_core::process::PrivDrop::drop_to(rustix::process::getuid().as_raw())
+        .map_err(|e| ChshError::Error(format!("cannot drop privileges: {e}")))?;
+
+    pam.authenticate(0)
+        .map_err(|e| ChshError::Error(e.to_string()))?;
+    pam.acct_mgmt(0)
+        .map_err(|e| ChshError::Error(e.to_string()))?;
+    Ok(())
+}
+
+/// Without PAM there is no way to verify the caller, so refuse rather than
+/// silently applying an unauthenticated change to a setuid-root tool.
+#[cfg(not(feature = "pam"))]
+fn authenticate_caller(_user: &str) -> Result<(), ChshError> {
+    Err(ChshError::Error(
+        "PAM support is not compiled in — cannot authenticate; run as root".into(),
+    ))
 }
 
 /// Build the clap `Command` for `chsh`.
@@ -412,5 +454,21 @@ mod tests {
         std::fs::write(&shells_path, "/bin/sh\n").expect("write");
         let result = validate_shell("bin/sh", &shells_path);
         assert!(result.is_err());
+    }
+
+    // -----------------------------------------------------------------------
+    // Caller authentication
+    // -----------------------------------------------------------------------
+
+    /// A setuid-root tool must fail closed: with no way to authenticate the
+    /// caller, it refuses rather than applying an unverified change.
+    #[test]
+    #[cfg(not(feature = "pam"))]
+    fn test_authenticate_caller_fails_closed_without_pam() {
+        let err = authenticate_caller("someone").expect_err("must refuse without PAM");
+        assert!(
+            format!("{err}").contains("cannot authenticate"),
+            "unexpected message: {err}"
+        );
     }
 }

--- a/src/uu/passwd/src/passwd.rs
+++ b/src/uu/passwd/src/passwd.rs
@@ -468,44 +468,6 @@ fn cmd_status(root: &SysRoot, target_user: Option<&str>) -> UResult<()> {
 // Security hardening — privilege dropping during PAM conversation
 // ---------------------------------------------------------------------------
 
-/// RAII guard that drops effective UID and restores on drop.
-///
-/// When passwd is installed setuid-root, we want to drop to the caller's
-/// real UID during the PAM conversation so that the PAM modules see the
-/// actual caller, not root. The destructor re-elevates.
-#[cfg_attr(not(feature = "pam"), allow(dead_code))]
-struct PrivDrop {
-    original_euid: u32,
-}
-
-impl PrivDrop {
-    /// Drop effective UID to the given UID.
-    #[cfg_attr(not(feature = "pam"), allow(dead_code))]
-    fn drop_to(uid: u32) -> Result<Self, PasswdError> {
-        let original_euid = rustix::process::geteuid().as_raw();
-        if original_euid != uid {
-            shadow_core::process::seteuid(uid).map_err(|e| {
-                PasswdError::UnexpectedFailure(format!("cannot drop privileges: {e}"))
-            })?;
-        }
-        Ok(Self { original_euid })
-    }
-}
-
-impl Drop for PrivDrop {
-    fn drop(&mut self) {
-        if let Err(e) = shadow_core::process::seteuid(self.original_euid) {
-            // Failing to restore privileges is a critical error — log it loudly.
-            // We can't return an error from Drop, so at least make it visible.
-            let _ = writeln!(
-                std::io::stderr().lock(),
-                "passwd: CRITICAL: failed to restore euid to {}: {e}",
-                self.original_euid
-            );
-        }
-    }
-}
-
 // Note: custom SIGINT handler removed — it required unsafe (sigaction +
 // libc::write + libc::_exit). SIGINT terminates without unwinding, so
 // EchoGuard::drop won't run. Terminal echo restoration after Ctrl+C relies
@@ -543,7 +505,10 @@ fn cmd_pam_change(matches: &clap::ArgMatches, target_user: &str) -> UResult<()> 
 
         // Drop privileges to caller's real UID during PAM conversation.
         // Re-elevate automatically when _priv_drop goes out of scope.
-        let _priv_drop = PrivDrop::drop_to(rustix::process::getuid().as_raw())?;
+        let _priv_drop = shadow_core::process::PrivDrop::drop_to(
+            rustix::process::getuid().as_raw(),
+        )
+        .map_err(|e| PasswdError::UnexpectedFailure(format!("cannot drop privileges: {e}")))?;
 
         // Non-root users changing their own password must authenticate first.
         if !shadow_core::hardening::caller_is_root()

--- a/tests/e2e/deploy-test.sh
+++ b/tests/e2e/deploy-test.sh
@@ -171,8 +171,12 @@ test_setuid() {
     # passwd must be built with the `pam` cargo feature, otherwise the
     # interactive change path is compiled out and the tool can only report and
     # lock accounts — it cannot actually change a password.
-    assert_ok "passwd is linked against PAM" \
-        sh -c "ldd $BINDIR/passwd | grep -q libpam"
+    # chfn and chsh authenticate the caller through PAM before applying a
+    # change, so a build without the feature refuses every non-root use.
+    for tool in passwd chfn chsh; do
+        assert_ok "$tool is linked against PAM" \
+            sh -c "ldd $BINDIR/$tool | grep -q libpam"
+    done
 
     # Non-root user should be able to run passwd -S on themselves
     assert_ok "testrunner can run passwd -S" \


### PR DESCRIPTION
Closes #226.

## The gap

`chfn` and `chsh` are installed setuid-root. They correctly restrict a non-root caller to their own account:

```rust
if !shadow_core::hardening::caller_is_root() {
    let current_user = shadow_core::hardening::current_username()?;
    if current_user != target_user { return Err(...); }
}
```

That is *authorisation* — who may be changed. It is sound, and there was no privilege escalation. What was missing is *authentication* — who is asking. Anyone with access to an unlocked session could change that user's login shell or GECOS field, and a login shell is a foothold.

Distributions already ship the service definitions we were ignoring:

```
/etc/pam.d/chfn:  auth sufficient pam_rootok.so   ← root passes
                  @include common-auth            ← everyone else authenticates
/etc/pam.d/chsh:  auth required   pam_shells.so
                  auth sufficient pam_rootok.so
                  @include common-auth
```

CONTRIBUTING states that differences from GNU are treated as bugs, so this is one rather than a design choice. (`pam_shells` has no gap — `chsh` already validates against `/etc/shells` itself.)

## Changes

**`shadow-core`** — `PrivDrop`, the RAII guard that lowers the effective UID for a PAM conversation, moves out of `uu_passwd` into `shadow_core::process`, next to the `seteuid` wrapper it calls. Its error becomes `io::Result` so any tool can use it, and the failure-to-restore message goes through `uucore::show_error!` instead of a hardcoded `passwd:` prefix.

**`chfn` / `chsh`** — gain a `pam` feature and authenticate non-root callers, reusing the pattern `passwd` already uses: drop to the real UID for the conversation, then `authenticate` and `acct_mgmt`.

**Fail closed.** Without the feature there is no way to verify anyone, so the tools refuse rather than apply an unauthenticated change. That is a behaviour change for that build only, and the safe direction for a setuid binary.

## A bug this created, and caught

Making authentication mandatory turns "feature missing" into "tool unusable", so every build path had to be checked — and one was wrong:

| path | before | after |
|---|---|---|
| `make build` — **the default install** | passwd only | all three |
| `make install-multicall` | ok | ok |
| `dist` release archive | ok | ok |
| e2e image | ok | ok |

`make build` passed `--features uu_passwd/pam`, so it would have shipped two setuid tools rejecting every non-root use — #220 recreated on two more tools, by its own fix. The end-to-end assertion that missed #220 (it only checked `passwd`) now loops over all three.

## Tests, invariants, CI

- **New invariant test**: the fail-closed behaviour is asserted, not just commented. It is `#[cfg(not(feature = "pam"))]`, so it runs in the build where it is meaningful and is absent from the other — verified both ways.
- **CI now runs `cargo test --workspace --features pam`.** #234 added the clippy pass; the tests were still missing. This feature changes behaviour rather than only adding code, so both configurations must be tested.
- **`docs/PLATFORM-SUPPORT.md` updated**: a musl build now also loses `chfn`/`chsh` for non-root users, not just `passwd`'s interactive change. That materially worsens the musl trade-off in #224 and had to be written down.
- `newgrp` is deliberately untouched: it authenticates against the *group* password through crypt(3), not PAM.

## Verified

| | without `pam` | with `pam` |
|---|---|---|
| clippy `-D warnings` | pass | pass |
| `cargo test --workspace` | pass | pass |
| fail-closed test | runs, passes | correctly absent |
| `make build` links libpam | — | passwd, chfn, chsh |
