### PR TITLE
groupadd: honour every -K override through LoginDefs (#223)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `groupadd -K` now honours any login.defs key, not only the four GID-range
+  ones, and rejects malformed pairs the same way `useradd -K` does; both tools
+  share one parser in `shadow-core` (#223)
 - Without the `pam` feature, `chfn` and `chsh` refuse non-root invocations
   rather than applying an unauthenticated change. Every install path enables
   the feature; a static musl build would not — see

--- a/src/shadow-core/src/login_defs.rs
+++ b/src/shadow-core/src/login_defs.rs
@@ -92,6 +92,24 @@ impl LoginDefs {
     }
 }
 
+/// Split a `-K KEY=VALUE` argument into its key and value.
+///
+/// Shared by every tool that accepts login.defs overrides so they agree on
+/// what is malformed: a missing `=` or an empty key is rejected, an empty
+/// value is allowed (it unsets the key for this run).
+///
+/// # Errors
+///
+/// Returns [`ShadowError::Validation`] for a malformed pair.
+pub fn parse_override(kv: &str) -> Result<(&str, &str), ShadowError> {
+    match kv.split_once('=') {
+        Some((key, value)) if !key.is_empty() => Ok((key, value)),
+        _ => Err(ShadowError::Validation(
+            format!("invalid key=value pair: '{kv}'").into(),
+        )),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -103,6 +121,22 @@ mod tests {
         let mut f = std::fs::File::create(&path).unwrap();
         f.write_all(content.as_bytes()).unwrap();
         path
+    }
+
+    #[test]
+    fn test_parse_override_accepts_key_value() {
+        assert_eq!(parse_override("GID_MIN=9100").unwrap(), ("GID_MIN", "9100"));
+        // An empty value is a legitimate way to unset a key for the run.
+        assert_eq!(parse_override("SKEL=").unwrap(), ("SKEL", ""));
+        // Only the first '=' separates; the value may contain more.
+        assert_eq!(parse_override("A=b=c").unwrap(), ("A", "b=c"));
+    }
+
+    #[test]
+    fn test_parse_override_rejects_malformed() {
+        assert!(parse_override("GID_MIN").is_err(), "missing '='");
+        assert!(parse_override("=9100").is_err(), "empty key");
+        assert!(parse_override("").is_err(), "empty argument");
     }
 
     #[test]

--- a/src/uu/groupadd/src/groupadd.rs
+++ b/src/uu/groupadd/src/groupadd.rs
@@ -19,7 +19,7 @@ use shadow_core::audit;
 use shadow_core::group::{self, GroupEntry};
 use shadow_core::gshadow::{self, GshadowEntry};
 use shadow_core::lock::FileLock;
-use shadow_core::login_defs::LoginDefs;
+use shadow_core::login_defs::{self, LoginDefs};
 use shadow_core::nscd;
 use shadow_core::sysroot::SysRoot;
 use shadow_core::uid_alloc;
@@ -127,16 +127,18 @@ fn do_groupadd(matches: &clap::ArgMatches) -> UResult<()> {
     let root_dir = matches.get_one::<String>(options::ROOT).map(Path::new);
     let root = SysRoot::new(prefix.or(root_dir));
 
-    // Parse -K KEY=VALUE overrides.
-    let key_values: Vec<&String> = matches
+    // Load login.defs once and fold the -K overrides into it, so every later
+    // lookup — not just the GID range — sees the overridden values.
+    let mut defs = LoginDefs::load(&root.login_defs_path())
+        .map_err(|e| GroupaddError::CantUpdate(format!("{e}")))?;
+    for kv in matches
         .get_many::<String>(options::KEY)
-        .map_or_else(Vec::new, Iterator::collect);
-    let mut login_defs_overrides: Vec<(&str, &str)> = Vec::new();
-    for kv in &key_values {
-        let (k, v) = kv
-            .split_once('=')
-            .ok_or_else(|| GroupaddError::BadArgument(format!("invalid key=value pair: '{kv}'")))?;
-        login_defs_overrides.push((k, v));
+        .into_iter()
+        .flatten()
+    {
+        let (key, value) = login_defs::parse_override(kv)
+            .map_err(|e| GroupaddError::BadArgument(e.to_string()))?;
+        defs.set(key, value);
     }
 
     // Validate the group name.
@@ -164,15 +166,7 @@ fn do_groupadd(matches: &clap::ArgMatches) -> UResult<()> {
     }
 
     // Determine GID.
-    let gid = determine_gid(
-        matches,
-        &existing_groups,
-        force,
-        non_unique,
-        system,
-        &root,
-        &login_defs_overrides,
-    )?;
+    let gid = determine_gid(matches, &existing_groups, force, non_unique, system, &defs)?;
 
     // Block signals for the duration of the critical section so a SIGINT
     // between lock acquisition and atomic_write cannot leave stale lock files.
@@ -199,8 +193,7 @@ fn determine_gid(
     force: bool,
     non_unique: bool,
     system: bool,
-    root: &SysRoot,
-    overrides: &[(&str, &str)],
+    defs: &LoginDefs,
 ) -> Result<u32, GroupaddError> {
     let explicit_gid = matches.get_one::<String>(options::GID);
 
@@ -211,7 +204,7 @@ fn determine_gid(
 
         if !non_unique && existing_groups.iter().any(|g| g.gid == gid) {
             if force {
-                allocate_gid(root, existing_groups, system, overrides)
+                allocate_gid(defs, existing_groups, system)
             } else {
                 Err(GroupaddError::GidInUse(format!(
                     "GID '{gid}' already exists"
@@ -221,7 +214,7 @@ fn determine_gid(
             Ok(gid)
         }
     } else {
-        allocate_gid(root, existing_groups, system, overrides)
+        allocate_gid(defs, existing_groups, system)
     }
 }
 
@@ -291,34 +284,12 @@ fn write_gshadow_entry(
 
 /// Allocate the next available GID from login.defs ranges.
 fn allocate_gid(
-    root: &SysRoot,
+    defs: &LoginDefs,
     existing: &[GroupEntry],
     system: bool,
-    overrides: &[(&str, &str)],
 ) -> Result<u32, GroupaddError> {
-    let defs = LoginDefs::load(&root.login_defs_path())
-        .map_err(|e| GroupaddError::CantUpdate(format!("{e}")))?;
-
-    // Apply -K overrides by creating a synthetic LoginDefs with the override values.
-    // We re-read and patch the range if overrides are present.
-    let (mut min, mut max) = uid_alloc::gid_range(&defs, system);
-
-    for &(key, val) in overrides {
-        match key {
-            "GID_MIN" | "SYS_GID_MIN" => {
-                if let Ok(v) = val.parse::<u32>() {
-                    min = v;
-                }
-            }
-            "GID_MAX" | "SYS_GID_MAX" => {
-                if let Ok(v) = val.parse::<u32>() {
-                    max = v;
-                }
-            }
-            _ => {}
-        }
-    }
-
+    // -K overrides were already merged into `defs` by the caller.
+    let (min, max) = uid_alloc::gid_range(defs, system);
     uid_alloc::next_gid(existing, min, max)
         .map_err(|e| GroupaddError::BadArgument(format!("cannot allocate GID: {e}")))
 }
@@ -350,10 +321,7 @@ pub fn uu_app() -> Command {
                 .long("key")
                 .value_name("KEY=VALUE")
                 .action(ArgAction::Append)
-                .help(
-                    "Override a GID-range key from login.defs (KEY=VALUE; \
-                     only GID_MIN, GID_MAX, SYS_GID_MIN, SYS_GID_MAX are honored)",
-                ),
+                .help("Override a login.defs key for this run (KEY=VALUE; may be repeated)"),
         )
         .arg(
             Arg::new(options::NON_UNIQUE)

--- a/src/uu/useradd/src/useradd.rs
+++ b/src/uu/useradd/src/useradd.rs
@@ -24,7 +24,7 @@ use shadow_core::audit;
 use shadow_core::group::{self, GroupEntry};
 use shadow_core::gshadow::{self, GshadowEntry};
 use shadow_core::lock::FileLock;
-use shadow_core::login_defs::LoginDefs;
+use shadow_core::login_defs::{self, LoginDefs};
 use shadow_core::nscd;
 use shadow_core::passwd::{self, PasswdEntry};
 use shadow_core::shadow::{self, ShadowEntry};
@@ -637,22 +637,16 @@ fn do_useradd(opts: &UseraddOptions) -> UResult<()> {
 fn parse_login_defs_overrides(
     matches: &clap::ArgMatches,
 ) -> Result<Vec<(String, String)>, UseraddError> {
-    let key_values: Vec<&String> = matches
+    matches
         .get_many::<String>(options::KEY)
-        .map_or_else(Vec::new, Iterator::collect);
-    let mut overrides = Vec::with_capacity(key_values.len());
-    for kv in &key_values {
-        let (k, v) = kv
-            .split_once('=')
-            .ok_or_else(|| UseraddError::BadArgument(format!("invalid key=value pair: '{kv}'")))?;
-        if k.is_empty() {
-            return Err(UseraddError::BadArgument(format!(
-                "invalid key=value pair: '{kv}'"
-            )));
-        }
-        overrides.push((k.to_string(), v.to_string()));
-    }
-    Ok(overrides)
+        .into_iter()
+        .flatten()
+        .map(|kv| {
+            login_defs::parse_override(kv)
+                .map(|(k, v)| (k.to_string(), v.to_string()))
+                .map_err(|e| UseraddError::BadArgument(e.to_string()))
+        })
+        .collect()
 }
 
 /// Merge `-K` overrides into `defs` so later lookups use the new values.

--- a/tests/by-util/test_groupadd.rs
+++ b/tests/by-util/test_groupadd.rs
@@ -235,3 +235,61 @@ fn test_other_entries_preserved() {
         "freshgrp should be added, got: {content}"
     );
 }
+
+#[test]
+fn test_key_override_wins_over_login_defs() {
+    if common::skip_unless_root() {
+        return;
+    }
+    // login.defs says 5000-5999; -K must take precedence for this run.
+    let dir = setup_prefix("root:x:0:\n", "GID_MIN 5000\nGID_MAX 5999\n");
+    let code = run_with_prefix(
+        &dir,
+        &["-K", "GID_MIN=9100", "-K", "GID_MAX=9100", "keygrp"],
+    );
+    assert_eq!(code, 0, "groupadd -K should exit 0");
+    assert!(
+        read_group(&dir).contains("keygrp:x:9100:"),
+        "GID should come from -K, got: {}",
+        read_group(&dir)
+    );
+}
+
+#[test]
+fn test_key_sys_range_override_for_system_group() {
+    if common::skip_unless_root() {
+        return;
+    }
+    let dir = setup_prefix("root:x:0:\n", "SYS_GID_MIN 100\nSYS_GID_MAX 999\n");
+    let code = run_with_prefix(
+        &dir,
+        &[
+            "-r",
+            "-K",
+            "SYS_GID_MIN=250",
+            "-K",
+            "SYS_GID_MAX=250",
+            "syskeygrp",
+        ],
+    );
+    assert_eq!(code, 0, "groupadd -r -K should exit 0");
+    assert!(
+        read_group(&dir).contains("syskeygrp:x:250:"),
+        "got: {}",
+        read_group(&dir)
+    );
+}
+
+#[test]
+fn test_key_missing_equals_exits_bad_argument() {
+    if common::skip_unless_root() {
+        return;
+    }
+    let dir = setup_prefix("root:x:0:\n", "");
+    let code = run_with_prefix(&dir, &["-K", "GID_MIN", "badkeygrp"]);
+    assert_eq!(code, 3, "malformed KEY=VALUE should exit 3 (bad argument)");
+    assert!(
+        !read_group(&dir).contains("badkeygrp"),
+        "nothing must be written"
+    );
+}


### PR DESCRIPTION
Closes #223. Follow-up promised in the review of #211.

## The inconsistency

`groupadd -K` was handled by hand-patching two variables inside `allocate_gid`:

```rust
for &(key, val) in overrides {
    match key {
        "GID_MIN" | "SYS_GID_MIN" => if let Ok(v) = val.parse::<u32>() { min = v; }
        "GID_MAX" | "SYS_GID_MAX" => if let Ok(v) = val.parse::<u32>() { max = v; }
        _ => {}
    }
}
```

So only four keys were understood, every other key was silently dropped, and the pair parser differed from `useradd`'s — `groupadd` accepted an empty key, `useradd` rejected it. The same flag behaved differently depending on which tool you ran.

## Changes

- **`shadow-core`** gains `login_defs::parse_override`, the one place that decides what a malformed `KEY=VALUE` is: missing `=` or empty key rejected, empty value allowed (it unsets the key for the run). Unit-tested.
- **`groupadd`** loads `login.defs` once, folds the overrides in with `LoginDefs::set` (from #211), and passes that to `determine_gid`. `allocate_gid` no longer reloads the file or carries a patch table — `gid_range` simply reads the overridden values. The `-K` help text, which I had narrowed in #162 to the four keys the old code honoured, is widened back to match.
- **`useradd`**'s parser becomes a thin wrapper over the shared one, so the duplication introduced in #211 is gone.

Behaviour change for `groupadd` only: a malformed pair now exits 3 (bad argument) as `useradd` already did, instead of being partly accepted.

## Tests

- Unit: `parse_override` accepts `K=V`, `K=` and `A=b=c`; rejects `K`, `=V` and `""`.
- Integration, as root: a `-K` GID range wins over the one in `login.defs` (regular and system ranges); a malformed pair exits 3 and writes nothing.
- `test_useradd` unchanged and still green (25/25), confirming the wrapper is behaviour-preserving.

## Verified

Full gate on Debian, rebased onto `main` after #235: `fmt`, `clippy -D warnings` with and without `pam`, `cargo test --workspace` with and without `pam`, plus the root integration suites for `groupadd` (14/14) and `useradd` (25/25).
