### PR TITLE
release: publish a labelled static musl archive (#224)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,40 @@ jobs:
       # authenticate. Both configurations have to be tested.
       - run: cargo test --workspace --features pam
 
+  musl-static:
+    name: Static musl archive
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: Swatinem/rust-cache@v2
+      # The exact command the release pipeline runs (extra-artifacts in
+      # dist-workspace.toml), so a tag is never the first place a musl
+      # regression shows up. No apt packages: the musl sysroot is self-contained.
+      - run: make dist-musl
+      - name: Smoke-test the archive
+        run: |
+          set -eu
+          name=uu_shadow-x86_64-unknown-linux-musl-static
+          (cd target/dist-musl && sha256sum -c "$name.tar.gz.sha256")
+          tar xzf "target/dist-musl/$name.tar.gz" -C "$RUNNER_TEMP"
+          bin="$RUNNER_TEMP/$name/shadow-rs"
+          "$bin" --version
+          "$bin" --list | grep -qE '^ *passwd$'
+          test -f "$RUNNER_TEMP/$name/PLATFORM-SUPPORT.md"
+      # shadow-core's crypt(3) wrapper has musl-specific expectations (no
+      # yescrypt, `rounds=` honoured). Run its unit tests against the static
+      # musl libc, not only Alpine's dynamic one in the Docker matrix.
+      - run: cargo test --target x86_64-unknown-linux-musl -p shadow-core --features crypt,shadow,group,gshadow,login-defs,subid
+      # `pam` must be refused on static musl, not silently produce a binary
+      # whose authentication path can never work.
+      - name: pam is rejected on static musl
+        run: |
+          if cargo check --target x86_64-unknown-linux-musl -p shadow-core --features pam 2>check.log; then
+            echo "::error::the pam feature built on static musl; the compile_error guard in shadow-core is gone"
+            exit 1
+          fi
+          grep -q "statically linked musl build" check.log
+
   msrv:
     name: MSRV (1.94.0)
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Static musl release archive,
+  `uu_shadow-x86_64-unknown-linux-musl-static.tar.gz`, published next to the
+  glibc one. It is a self-contained binary for minimal containers and embedded
+  images, built without `pam`, and it is not a substitute for the glibc
+  archive: no PAM (no interactive `passwd`; `chfn`/`chsh` root-only), no NSS,
+  no yescrypt. `make dist-musl` reproduces it and CI builds it on every pull
+  request. The trade-off is documented in
+  [docs/PLATFORM-SUPPORT.md](docs/PLATFORM-SUPPORT.md), shipped inside the
+  archive (#224)
+
+### Fixed
+
+- Cross-building for `x86_64-unknown-linux-musl` no longer fails at link time.
+  `shadow-core` asked for `-lcrypt` unconditionally; musl implements crypt(3)
+  inside libc and has no libcrypt, so the linker fell through to the host's
+  glibc libxcrypt (#224)
+
 ### Security
 
 - `chfn` and `chsh` now authenticate the caller before applying a change.
@@ -29,6 +48,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   from `passwd` into `shadow-core` so every setuid tool uses one implementation
 - CI lints and tests the `pam` code path, which the release binaries use but
   no job previously exercised
+- Requesting the `pam` feature in a statically linked musl build is now a
+  compile-time error instead of a binary whose authentication path can never
+  work: Linux-PAM loads its modules with `dlopen`, which static musl lacks
 
 ## [0.2.2] - 2026-09-03
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,8 +45,8 @@ then write an original implementation. Never search for or view the C source.
 ### Setup
 
 ```shell
-git clone https://github.com/uutils/shadow-rs
-cd shadow-rs
+git clone https://github.com/uutils/shadow
+cd shadow
 docker compose build
 ./hooks/install.sh  # install pre-commit and pre-push hooks
 ```
@@ -60,8 +60,10 @@ docker compose run --rm alpine cargo test --workspace  # test on Alpine (musl)
 docker compose run --rm fedora cargo test --workspace  # test on Fedora (SELinux)
 ```
 
-All three must pass. Note that musl is tested but not a release target — a
-static musl build loses PAM, NSS and yescrypt; see
+All three must pass. The `alpine` image tests musl with dynamic linking; the
+release also ships a *static* musl archive, built without PAM, which
+`make dist-musl` reproduces and CI builds on every pull request. What that
+build gives up is documented in
 [docs/PLATFORM-SUPPORT.md](docs/PLATFORM-SUPPORT.md).
 
 ### Linting
@@ -95,9 +97,10 @@ Utilities must be embeddable. Return `UResult<()>` from `uumain`. The
 
 ### `unsafe`
 
-Denied at the workspace level (`unsafe_code = "deny"`). Only two FFI boundary
-modules are exempted: `shadow_core::pam` (PAM C library) and `shadow_core::crypt`
-(POSIX crypt(3)). Every `unsafe` block must have a `// SAFETY:` comment.
+Denied at the workspace level (`unsafe_code = "deny"`). Only three FFI boundary
+modules are exempted: `shadow_core::pam` (PAM C library), `shadow_core::crypt`
+(POSIX crypt(3)) and `shadow_core::process` (setuid, signal masks,
+`getpwuid_r`). Every `unsafe` block must have a `// SAFETY:` comment.
 
 ### `str`, `OsStr` & `Path`
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,8 +37,8 @@ version = "0.2.2"
 edition = "2024"
 rust-version = "1.94.0"
 license = "MIT"
-repository = "https://github.com/uutils/shadow-rs"
-homepage = "https://github.com/uutils/shadow-rs"
+repository = "https://github.com/uutils/shadow"
+homepage = "https://github.com/uutils/shadow"
 keywords = ["shadow-utils", "uutils", "shadow", "passwd", "linux"]
 categories = ["command-line-utilities"]
 

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ ROOT_TOOLS = useradd userdel usermod chpasswd chage \
 
 ALL_TOOLS = $(SETUID_TOOLS) $(ROOT_TOOLS)
 
-.PHONY: all build build-multicall test install install-multicall uninstall clean
+.PHONY: all build build-multicall dist-musl test install install-multicall uninstall clean
 
 all: build
 
@@ -25,6 +25,33 @@ build:
 
 build-multicall:
 	cargo build --release --bin shadow-rs --features pam
+
+# Static musl archive, published as a release asset next to the glibc one
+# (dist-workspace.toml runs this target; see issue #224). Built without `pam`:
+# Linux-PAM dlopen()s its modules, which a static binary cannot do, and
+# shadow-core refuses the combination at compile time. The archive name carries
+# the "-static" label and docs/PLATFORM-SUPPORT.md, shipped inside, spells out
+# what the build does and does not do.
+MUSL_TARGET = x86_64-unknown-linux-musl
+MUSL_ARCHIVE = uu_shadow-$(MUSL_TARGET)-static
+MUSL_DIST_DIR = target/dist-musl
+
+dist-musl:
+	rustup target add $(MUSL_TARGET)
+	cargo build --release --locked --bin shadow-rs --target $(MUSL_TARGET)
+	@# A DT_NEEDED entry would mean a shared object slipped in and the archive
+	@# is not the self-contained binary its name promises.
+	@if readelf -d target/$(MUSL_TARGET)/release/shadow-rs | grep -q NEEDED; then \
+		echo "error: shadow-rs is not statically linked" >&2; exit 1; \
+	fi
+	rm -rf $(MUSL_DIST_DIR)
+	mkdir -p $(MUSL_DIST_DIR)/$(MUSL_ARCHIVE)
+	cp target/$(MUSL_TARGET)/release/shadow-rs LICENSE README.md CHANGELOG.md \
+		docs/PLATFORM-SUPPORT.md $(MUSL_DIST_DIR)/$(MUSL_ARCHIVE)/
+	tar -C $(MUSL_DIST_DIR) --owner=0 --group=0 --numeric-owner \
+		-czf $(MUSL_DIST_DIR)/$(MUSL_ARCHIVE).tar.gz $(MUSL_ARCHIVE)
+	cd $(MUSL_DIST_DIR) && sha256sum $(MUSL_ARCHIVE).tar.gz > $(MUSL_ARCHIVE).tar.gz.sha256
+	@echo "Built $(MUSL_DIST_DIR)/$(MUSL_ARCHIVE).tar.gz"
 
 test:
 	cargo test --workspace

--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ passwords, and groups on every Linux system.
 shadow-utils runs as **root or setuid-root on every Linux system**. It parses
 user-supplied input, writes to `/etc/passwd`, `/etc/shadow`, `/etc/group`, and
 has had recent CVEs (CVE-2023-4641: password leak in memory, CVE-2024-56433:
-subuid collision enabling account takeover). Until this project appear, there was **no
-Rust reimplementation** — not in uutils, not in Prossimo/Trifecta, not on
+subuid collision enabling account takeover). Before this project there was
+**no Rust reimplementation** — not in uutils, not in Prossimo/Trifecta, not on
 crates.io.
 
 [sudo-rs](https://github.com/trifectatechfoundation/sudo-rs) proved the model:
@@ -106,18 +106,37 @@ sudo make install-multicall PREFIX=/usr/local
 
 #### From a release archive
 
-Each release publishes `uu_shadow-x86_64-unknown-linux-gnu.tar.gz` (with a
-`.sha256` alongside), containing the `shadow-rs` multicall binary. Archives are
-built against glibc. A static musl archive is not published: such a build works
-but loses PAM, NSS and yescrypt support, so it is not equivalent to this one.
-See [docs/PLATFORM-SUPPORT.md](docs/PLATFORM-SUPPORT.md).
+Each [release](https://github.com/uutils/shadow/releases) publishes two
+archives, each with a `.sha256` alongside. They contain the same `shadow-rs`
+multicall binary but are **not interchangeable**:
 
-The archive ships a plain binary — nothing is installed, symlinked, or made
+| Archive | libc | Linking | Use it for |
+|---|---|---|---|
+| `uu_shadow-x86_64-unknown-linux-gnu.tar.gz` | glibc | dynamic | Any regular distribution. **This is the full build.** |
+| `uu_shadow-x86_64-unknown-linux-musl-static.tar.gz` | musl | static | Minimal containers and embedded images: local `/etc/passwd`, no directory service, no PAM stack. |
+
+The static archive has no runtime dependencies, and pays for that with three
+capabilities a static binary cannot have — none of them cosmetic for account
+tools:
+
+- **No PAM.** `passwd` cannot change a password interactively, and `chfn` /
+  `chsh` are root-only (they authenticate the caller through PAM and fail
+  closed without it).
+- **No NSS.** Users from LDAP, SSSD, Active Directory or systemd-userdb are
+  invisible to the five tools that look up the calling user.
+- **No yescrypt (`$y$`).** The default password hash on Debian 12+ and
+  Ubuntu 24.04 can be neither verified nor produced.
+
+If any of those matter on the host, use the glibc archive.
+[docs/PLATFORM-SUPPORT.md](docs/PLATFORM-SUPPORT.md) explains each gap, what
+still works, and how the archive is built.
+
+Either archive ships a plain binary — nothing is installed, symlinked, or made
 setuid by extracting it. To deploy it the same way `make install-multicall`
 would:
 
 ```shell
-tar xzf uu_shadow-x86_64-unknown-linux-gnu.tar.gz
+tar xzf uu_shadow-x86_64-unknown-linux-gnu.tar.gz   # or the -musl-static one
 sudo install -o root -g root -m 4755 \
     uu_shadow-*/shadow-rs /usr/local/bin/shadow-rs
 for tool in passwd chfn chsh newgrp chage chpasswd groupadd groupdel \
@@ -127,7 +146,8 @@ done
 ```
 
 Mode `4755` makes every applet run `euid=root`; see the setuid trade-off noted
-above. Run `shadow-rs --list` to see the applets a given build contains.
+above. Run `shadow-rs --list` to see the applets a given build contains, and
+`sha256sum -c uu_shadow-*.tar.gz.sha256` to verify a download.
 
 ### Test
 
@@ -184,10 +204,11 @@ merge is frictionless.
 | `alpine` | `rust:alpine` | musl | Linux-PAM | none |
 | `fedora` | `fedora:latest` | glibc | Linux-PAM | enforcing |
 
-musl is covered by the test matrix but is not a release target: a static musl
-build loses PAM, NSS and yescrypt. See
-[docs/PLATFORM-SUPPORT.md](docs/PLATFORM-SUPPORT.md) for what that means and
-why.
+The `alpine` image tests musl with dynamic linking, PAM included. The static
+musl release archive is a different build — no PAM, no NSS, no yescrypt — and
+has its own CI job that builds it and runs `shadow-core`'s unit tests against
+static musl on every pull request. See
+[docs/PLATFORM-SUPPORT.md](docs/PLATFORM-SUPPORT.md).
 
 ## Credits
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -15,7 +15,7 @@ We take security issues extremely seriously.
 Instead, please report vulnerabilities via GitHub's private vulnerability
 reporting feature:
 
-1. Go to https://github.com/uutils/shadow-rs/security/advisories
+1. Go to https://github.com/uutils/shadow/security/advisories
 2. Click "New draft security advisory"
 3. Fill in the details
 

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -26,10 +26,22 @@ features = ["pam"]
 [dist.binaries]
 "*" = ["shadow-rs"]
 
-# `shadow-core::crypt` links crypt(3) via `#[link(name = "crypt")]`, which on
-# Debian/Ubuntu lives in libxcrypt rather than glibc; the `pam` feature above
-# links libpam. Both are why targets stay glibc-only: a static musl build loses
-# PAM, NSS and yescrypt — see docs/PLATFORM-SUPPORT.md and issue #224.
+# `shadow-core::crypt` links crypt(3), which on Debian/Ubuntu lives in
+# libxcrypt rather than glibc; the `pam` feature above links libpam.
 [dist.dependencies.apt]
 libcrypt-dev = "*"
 libpam0g-dev = "*"
+
+# Static musl archive (issue #224). It cannot be a regular target: `features`
+# is not per-target in dist, and `pam` must be off for musl (Linux-PAM needs
+# dlopen, which a static binary has not got). So it is built as an extra
+# artifact by `make dist-musl`, which runs in the global-artifacts job on a
+# plain Ubuntu runner — no apt dependencies needed, the musl sysroot is
+# self-contained. The "-static" suffix labels it as the reduced build it is;
+# docs/PLATFORM-SUPPORT.md, shipped inside the archive, states the gaps.
+[[dist.extra-artifacts]]
+artifacts = [
+    "target/dist-musl/uu_shadow-x86_64-unknown-linux-musl-static.tar.gz",
+    "target/dist-musl/uu_shadow-x86_64-unknown-linux-musl-static.tar.gz.sha256",
+]
+build = ["make", "dist-musl"]

--- a/docs/PLATFORM-SUPPORT.md
+++ b/docs/PLATFORM-SUPPORT.md
@@ -1,54 +1,81 @@
 # Platform support
 
-What shadow-rs builds and runs on, and where a build differs in behaviour.
+What shadow-rs builds and runs on, which archives a release publishes, and
+exactly where one build behaves differently from another.
 
-The distinction that matters most is the C library. shadow-rs is tested on both
-glibc and musl, but *tested on* and *released for* are not the same thing:
-released archives are glibc, and a musl build is functionally reduced in three
-specific ways described below.
+The distinction that matters most is the C library. Every release publishes
+two archives, glibc and static musl, and they are **not interchangeable**: the
+glibc archive is the full build; the static musl archive is a self-contained
+binary for containers and embedded images that gives up three capabilities,
+each stated below. The archive name carries a `-static` suffix so the two are
+never confused.
 
-## Release artifacts
+## Release archives
 
-| Target | Published | Linking |
-|---|---|---|
-| `x86_64-unknown-linux-gnu` | yes | dynamic (libpam, libcrypt, libc) |
-| `x86_64-unknown-linux-musl` | no — see below | static |
-| `aarch64-unknown-linux-gnu` | no — tracked in #222 | dynamic |
+| Archive | libc | Linking | `pam` feature | Use it for |
+|---|---|---|---|---|
+| `uu_shadow-x86_64-unknown-linux-gnu.tar.gz` | glibc | dynamic (libpam, libcrypt, libc) | on | Any regular distribution install. The full build. |
+| `uu_shadow-x86_64-unknown-linux-musl-static.tar.gz` | musl | static, no runtime dependencies | off | Minimal containers and embedded images with a local `/etc/passwd`, no directory service and no PAM stack. |
+
+Both archives ship a `.sha256` file in `sha256sum -c` format and contain the
+`shadow-rs` multicall binary with `LICENSE`, `README.md` and `CHANGELOG.md`;
+the musl archive also carries this document, so the trade-off travels with the
+binary.
+
+The two are produced differently. The glibc archive is dist's regular target
+build with `features = ["pam"]`. dist cannot vary features per target, and
+`pam` must be off for musl (see below), so the musl archive is built by
+`make dist-musl` and attached by dist as an extra artifact of the same release.
+Anyone can reproduce it with that one command.
+
+Only `x86_64` is published. aarch64 needs the target's crypt(3) and PAM
+libraries, hence a cross-compilation setup or a native runner; tracked in
+[#222](https://github.com/uutils/shadow/issues/222).
 
 ## Test matrix
 
-CI builds and runs the full suite on three images, so musl regressions are
-caught even though musl is not released:
+CI runs the full suite on three images:
 
 | Image | Base | libc | PAM | SELinux |
 |---|---|---|---|---|
 | `debian` | `rust:latest` (Trixie) | glibc | Linux-PAM | headers |
-| `alpine` | `rust:alpine` | musl | Linux-PAM | none |
+| `alpine` | `rust:alpine` | musl (dynamic) | Linux-PAM | none |
 | `fedora` | `fedora:latest` | glibc | Linux-PAM | enforcing |
 
-## musl
+The `alpine` image links musl dynamically and therefore *does* have PAM; it
+tests musl's libc behaviour (no NSS, no yescrypt), not the static archive. The
+static archive has its own job, `Static musl archive`, which on every pull
+request runs `make dist-musl`, smoke-tests the result, runs `shadow-core`'s
+unit tests against static musl, and checks that requesting `pam` there is
+rejected at compile time. A tag is never the first time the archive is built.
 
-A static musl binary **builds and runs**. What stops it being published is that
-it is not equivalent to the glibc build — it loses three things, and for
-account-management tools none of them is cosmetic.
+## What the static musl build gives up
+
+A static musl binary **builds and runs**; the whole test suite passes on musl.
+What it cannot do is inherent to static linking and to musl, not to shadow-rs,
+and for account-management tools none of it is cosmetic.
 
 ### 1. No PAM
 
-Linux-PAM loads its modules with `dlopen`. A fully static binary cannot do
+Linux-PAM loads its modules with `dlopen(3)`. A fully static binary cannot do
 that: musl's static `dlopen` is a stub that returns *"Dynamic loading not
-supported"*, and Alpine ships no `libpam.a` to link against in the first place.
+supported"*, and no distribution ships a `libpam.a` to link against in the
+first place. `shadow-core` refuses the `pam` feature on static musl with a
+compile-time error, so the build cannot be misconfigured into a binary whose
+authentication path never works.
 
 Effect, and this is the heaviest of the three gaps:
 
-- `passwd`'s interactive password change is unavailable.
+- `passwd`'s interactive password change is unavailable and says so
+  (*"PAM support is not compiled in"*).
 - `chfn` and `chsh` become **root-only**. They authenticate the caller through
   PAM before applying a change, and a setuid-root tool must fail closed rather
-  than apply an unverified one — so without PAM they refuse every non-root
+  than apply an unverified one, so without PAM they refuse every non-root
   invocation outright.
 
 Unaffected: `passwd -S/-l/-u/-d/-e/-n/-x/-w/-i`, `newgrp` (which authenticates
-against the group password via crypt(3), not PAM), and the other 11 tools,
-which are root-only anyway and reach `/etc/shadow` directly.
+against the group password through crypt(3), not PAM), and the other eleven
+tools, which are root-only anyway and reach `/etc/shadow` directly.
 
 ### 2. No NSS
 
@@ -57,54 +84,56 @@ which are root-only anyway and reach `/etc/shadow` directly.
 
 glibc answers such lookups through its NSS module system, so it sees users from
 LDAP, SSSD, Active Directory or systemd-userdb. musl has no NSS module system
-and reads `/etc/passwd` directly. On a directory-joined host, those five tools
-would not see network users at all.
+and reads `/etc/passwd` directly. On a directory-joined host those five tools
+do not see network users at all.
 
 ### 3. No yescrypt (`$y$`)
 
-musl's crypt(3) implements DES, MD5, SHA-256, SHA-512 (including
-`rounds=`) and bcrypt, and produces byte-identical output to libxcrypt for all
-of them. It does not implement yescrypt.
+musl's crypt(3) implements DES, MD5, SHA-256, SHA-512 (including `rounds=`)
+and bcrypt, byte-identical to libxcrypt for all of them. It does not implement
+yescrypt.
 
 This is not a marginal format: **Debian 12+ and Ubuntu 24.04 use yescrypt as
 the default password hash.** A musl build can neither verify nor produce `$y$`
-hashes, so `newgrp` fails against a `$y$` group password and `chpasswd`
-produces SHA-512 where the system default is yescrypt. The prefix guard in
-`shadow_core::crypt` rejects the format explicitly rather than silently
-falling back.
+hashes, so `newgrp` fails against a `$y$` group password and `chpasswd -c
+YESCRYPT` is rejected. The prefix guard in `shadow_core::crypt` reports the
+unsupported method explicitly; it never falls back to a weaker hash silently.
+The default method is SHA-512, which is unaffected.
 
-### Where musl is nonetheless the right choice
+### Where the static build is the right choice
 
 Minimal containers and embedded images: a local `/etc/passwd`, no directory
-service, no PAM stack. There, none of the three gaps costs anything, and a
-single static binary with no runtime dependencies is worth having.
+service, no PAM stack. There none of the three gaps costs anything, and a
+single binary with no runtime dependencies is worth having. Anywhere one of
+them matters, use the glibc archive.
 
-If a musl archive is published it must be labelled as static, PAM-less,
-NSS-less and without `$y$` — never presented as an alternative to the glibc
-archive. Tracked in #224.
+## Building for musl
 
-### Building for musl
-
-The `#[link(name = "crypt")]` attribute in `shadow_core::crypt` emits
-`-lcrypt`. Rust's self-contained musl sysroot has no `libcrypt.a`, so the
-linker falls through to the host's glibc-built libxcrypt and fails on
-glibc-only symbols. musl implements `crypt()` inside libc itself, so the
-attribute simply should not be emitted for that target:
-
-```rust
-#[cfg_attr(not(target_env = "musl"), link(name = "crypt"))]
+```shell
+make dist-musl
 ```
 
-Alpine builds work today without this because `musl-dev` ships an empty
-`libcrypt.a` that absorbs the flag.
+The target adds the `x86_64-unknown-linux-musl` toolchain component, builds the
+multicall binary in release mode with the lockfile enforced and without `pam`,
+verifies that the binary has no `DT_NEEDED` entry, and writes the archive and
+its checksum to `target/dist-musl/`.
 
-Note that libxcrypt is **LGPL-2.1+**, so it cannot be vendored to fill the gap:
-shadow-rs takes no GPL or LGPL dependencies. Pure-Rust alternatives exist
-(`sha-crypt`, `yescrypt`, both MIT/Apache-2.0), but the yescrypt crate is
-self-declared unaudited, which rules it out of a setuid-root path for now.
+Two details in the code make that work:
 
-## Architectures
+- **crypt(3) linkage.** On glibc systems crypt(3) lives in libcrypt (libxcrypt
+  on Debian, Fedora and derivatives), so `shadow_core::crypt` asks for
+  `-lcrypt`. musl implements `crypt()` inside libc and ships no libcrypt;
+  Rust's self-contained musl sysroot has no `libcrypt.a` either, so the request
+  would fall through to the host's glibc-built libxcrypt and fail on glibc-only
+  symbols. The attribute is therefore `#[cfg_attr(not(target_env = "musl"),
+  link(name = "crypt"))]`. (Alpine builds never hit this because `musl-dev`
+  ships an empty `libcrypt.a` that absorbs the flag.)
+- **`pam` guard.** `shadow_core::pam` emits `compile_error!` when built for
+  musl with `crt-static`, the default for the musl target. Dynamic musl, as in
+  the Alpine test image, is unaffected and links libpam normally.
 
-Only `x86_64` is published. aarch64 needs the target's system libraries for
-crypt(3) and PAM, so it requires a cross-compilation setup or a native runner —
-tracked in #222.
+libxcrypt itself is **LGPL-2.1+** and cannot be vendored to fill the yescrypt
+gap: shadow-rs takes no GPL or LGPL dependencies. Pure-Rust alternatives exist
+(`sha-crypt`, `yescrypt`, both MIT/Apache-2.0) and match libxcrypt output, but
+the yescrypt crate is self-declared unaudited, which rules it out of a
+setuid-root path for now.

--- a/src/shadow-core/src/cli.rs
+++ b/src/shadow-core/src/cli.rs
@@ -20,7 +20,7 @@ use uucore::error::{UError, UResult};
 pub const VERSION: &str = concat!("(uutils shadow-rs) ", env!("CARGO_PKG_VERSION"));
 
 /// Footer appended to `--help` to identify the project.
-pub const AFTER_HELP: &str = "Part of the uutils project: https://github.com/uutils/shadow-rs";
+pub const AFTER_HELP: &str = "Part of the uutils project: https://github.com/uutils/shadow";
 
 /// Error whose message has already been written to the terminal; it carries
 /// only the exit code.

--- a/src/shadow-core/src/crypt.rs
+++ b/src/shadow-core/src/crypt.rs
@@ -5,8 +5,21 @@
 
 //! Safe wrapper around POSIX `crypt(3)` for password hashing and verification.
 //!
-//! This is one of only two modules (along with `pam`) where `unsafe_code`
-//! is permitted, because `crypt(3)` is a C library function.
+//! This is one of the three FFI boundary modules (with `pam` and `process`)
+//! where `unsafe_code` is permitted, because `crypt(3)` is a C library
+//! function.
+//!
+//! # Where crypt(3) comes from
+//!
+//! On glibc systems it lives in libcrypt (libxcrypt on Debian, Fedora and
+//! their derivatives), hence the `-lcrypt` link request. musl implements
+//! `crypt()` inside libc itself and ships no `libcrypt`, so the request must
+//! not be emitted there: Rust's self-contained musl sysroot has no
+//! `libcrypt.a`, and the linker would fall through to the host's glibc-built
+//! one and fail on glibc-only symbols. The two implementations produce
+//! byte-identical hashes for DES, MD5, `$5$`, `$6$` (with `rounds=`) and
+//! `$2b$`; musl has no yescrypt (`$y$`), which [`hash_password`] reports as
+//! an error rather than a wrong hash.
 
 use std::ffi::CString;
 
@@ -14,7 +27,7 @@ use subtle::ConstantTimeEq;
 
 use crate::error::ShadowError;
 
-#[link(name = "crypt")]
+#[cfg_attr(not(target_env = "musl"), link(name = "crypt"))]
 unsafe extern "C" {
     fn crypt(key: *const libc::c_char, salt: *const libc::c_char) -> *mut libc::c_char;
 }
@@ -97,9 +110,9 @@ pub fn hash_password(
     let c_salt = CString::new(salt.as_str())
         .map_err(|_| ShadowError::Auth("salt contains null byte".into()))?;
 
-    // SAFETY: crypt() is provided by libcrypt/glibc. Both arguments are valid
-    // null-terminated C strings. The returned pointer is to a static/thread-local
-    // buffer managed by crypt().
+    // SAFETY: crypt() is provided by libcrypt (glibc) or libc (musl). Both
+    // arguments are valid null-terminated C strings. The returned pointer is to
+    // a static/thread-local buffer managed by crypt().
     let result = unsafe { crypt(c_password.as_ptr(), c_salt.as_ptr()) };
 
     if result.is_null() {
@@ -143,9 +156,9 @@ pub fn verify_password(password: &str, hash: &str) -> Result<bool, ShadowError> 
     let c_hash =
         CString::new(hash).map_err(|_| ShadowError::Auth("hash contains null byte".into()))?;
 
-    // SAFETY: crypt() is provided by libcrypt/glibc. Both arguments are valid
-    // null-terminated C strings. The returned pointer is to a static/thread-local
-    // buffer managed by crypt().
+    // SAFETY: crypt() is provided by libcrypt (glibc) or libc (musl). Both
+    // arguments are valid null-terminated C strings. The returned pointer is to
+    // a static/thread-local buffer managed by crypt().
     let result = unsafe { crypt(c_password.as_ptr(), c_hash.as_ptr()) };
 
     if result.is_null() {
@@ -201,12 +214,11 @@ mod tests {
     }
 
     #[test]
+    #[cfg(not(target_env = "musl"))]
     fn test_hash_verify_yescrypt() {
         let _guard = CRYPT_LOCK.lock().expect("lock");
-        // musl libc doesn't support yescrypt — skip gracefully.
-        let Ok(hash) = hash_password("secret", CryptMethod::Yescrypt, None) else {
-            return;
-        };
+        let hash = hash_password("secret", CryptMethod::Yescrypt, None)
+            .expect("libxcrypt implements yescrypt");
         assert!(
             hash.starts_with("$y$"),
             "yescrypt hash should start with $y$"
@@ -214,13 +226,27 @@ mod tests {
         assert!(verify_password("secret", &hash).expect("verify should succeed"));
     }
 
+    // musl's crypt(3) has no yescrypt and falls back to DES for an unknown
+    // prefix; the prefix guard must turn that into an error, never a hash the
+    // caller would store as `$y$`.
+    #[test]
+    #[cfg(target_env = "musl")]
+    fn test_yescrypt_rejected_on_musl() {
+        let _guard = CRYPT_LOCK.lock().expect("lock");
+        let err = hash_password("secret", CryptMethod::Yescrypt, None)
+            .expect_err("musl has no yescrypt; the prefix guard must reject it");
+        assert!(
+            err.to_string().contains("Yescrypt"),
+            "error should name the unsupported method: {err}"
+        );
+    }
+
+    // libxcrypt and musl both honour `rounds=` for the SHA methods.
     #[test]
     fn test_sha_rounds_applied() {
         let _guard = CRYPT_LOCK.lock().expect("lock");
-        // musl libc doesn't support SHA rounds — skip gracefully.
-        let Ok(hash) = hash_password("secret", CryptMethod::Sha512, Some(10000)) else {
-            return;
-        };
+        let hash = hash_password("secret", CryptMethod::Sha512, Some(10000))
+            .expect("rounds= is supported by every crypt(3) we build against");
         assert!(
             hash.starts_with("$6$rounds=10000$"),
             "rounds should appear in hash"

--- a/src/shadow-core/src/pam.rs
+++ b/src/shadow-core/src/pam.rs
@@ -20,7 +20,19 @@
 //!
 //! # Feature gate
 //!
-//! This module is only available when the `pam` feature is enabled.
+//! This module is only available when the `pam` feature is enabled, and it
+//! cannot be built into a statically linked musl binary: Linux-PAM loads its
+//! modules with `dlopen(3)`, which static musl does not support, and no
+//! distribution ships a `libpam.a`. Requesting the feature there is a
+//! configuration error and is rejected at compile time rather than producing
+//! a binary whose authentication path can never work.
+
+#[cfg(all(target_env = "musl", target_feature = "crt-static"))]
+compile_error!(
+    "the `pam` feature cannot be used in a statically linked musl build: Linux-PAM loads its \
+     modules with dlopen(3), which static musl does not support. Build without `pam` — see \
+     docs/PLATFORM-SUPPORT.md for what that changes."
+);
 
 use std::ffi::{CStr, CString};
 use std::fs::File;


### PR DESCRIPTION
Closes #224.

## What ships

Every release now publishes two archives:

| Archive | libc | Linking | `pam` |
|---|---|---|---|
| `uu_shadow-x86_64-unknown-linux-gnu.tar.gz` | glibc | dynamic | on |
| `uu_shadow-x86_64-unknown-linux-musl-static.tar.gz` | musl | static | off |

The static one is for minimal containers and embedded images. It is labelled by its name, by the README table, and by `PLATFORM-SUPPORT.md` shipped inside the archive, which states the three things it gives up (PAM, NSS, yescrypt) and what still works.

## How

- **`shadow-core`**: `-lcrypt` is requested only where libcrypt exists (`#[cfg_attr(not(target_env = "musl"), link(name = "crypt"))]`); musl has `crypt()` in libc. This is the link failure from the issue. The crypt tests now assert the real per-target behaviour (musl honours `rounds=`, lacks `$y$`) instead of skipping with a wrong comment.
- **`shadow-core::pam`**: `compile_error!` on `musl` + `crt-static`. Linux-PAM needs `dlopen`; a static binary with `pam` on would build and then never authenticate.
- **`make dist-musl`**: builds `--locked` for the musl target without `pam`, refuses a binary with any `DT_NEEDED`, packs it with LICENSE/README/CHANGELOG/PLATFORM-SUPPORT and writes a `sha256sum -c` checksum.
- **dist**: `features` is not per-target, so the archive is a `[[dist.extra-artifacts]]` built by that make target in the global-artifacts job. No apt dependencies there; the musl sysroot is self-contained.
- **CI**: new `Static musl archive` job runs the same target on every PR, smoke-tests the archive, runs `shadow-core`'s unit tests against static musl, and asserts the `pam` guard fires.
- **Docs**: README archive table, PLATFORM-SUPPORT rewritten, CONTRIBUTING (three unsafe modules, not two), CHANGELOG. Package metadata and `--help` footer now use the canonical `uutils/shadow` URL.

## Verified (Debian image)

- `fmt`, `clippy -D warnings` with and without `pam`: clean.
- `make dist-musl`: 1.4 MB binary, `readelf -d` shows no `NEEDED`, no `INTERP`; `sha256sum -c` OK; `--version`, `--list` fine.
- `cargo test --target x86_64-unknown-linux-musl -p shadow-core`: 158 passed, including `test_yescrypt_rejected_on_musl` and `test_sha_rounds_applied`.
- `cargo check --target x86_64-unknown-linux-musl -p shadow-core --features pam`: fails with the intended message.
- `cargo test --workspace` on glibc: green, yescrypt test included. Alpine (dynamic musl) runs the musl branch of the crypt tests: green.

The release-time path (`dist build --artifacts=global` running the make target) is exercised for real at the next tag; the CI job runs the identical command on every PR until then.
