### PR TITLE
shadow-rs: drop the setuid privilege for applets that are not meant to have it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- In the multicall layout, applets other than `passwd`, `chfn`, `chsh` and
+  `newgrp` drop to the caller's uid before running. The setuid binary let any
+  local user run `pwck -s` or `grpck -s` with euid 0 and rewrite
+  `/etc/passwd`, `/etc/shadow`, `/etc/group` and `/etc/gshadow`. The two
+  install layouts now have the same privilege model
 - Rewritten account files keep their owner, group and SELinux label. The
   atomic writer created the replacement file as `root:<effective gid>`, so
   any administrative change turned `/etc/shadow` from `root:shadow` into

--- a/Makefile
+++ b/Makefile
@@ -69,10 +69,10 @@ install: build
 	@echo "  setuid (4755): $(SETUID_TOOLS)"
 	@echo "  root-only (0755): $(ROOT_TOOLS)"
 
-# Opt-in install: single multicall binary with symlinks. Smaller footprint but
-# larger setuid attack surface — the binary is installed setuid-root, so all 14
-# applets run with euid=root when invoked via symlink. Intended for
-# container/embedded use where disk savings matter and attack surface does not.
+# Opt-in install: single multicall binary with symlinks. Smaller footprint.
+# The binary is installed setuid-root for passwd/chfn/chsh/newgrp; the other
+# applets drop back to the caller's uid before running, so the privilege model
+# matches the per-tool layout. Intended for container/embedded use.
 install-multicall: build-multicall
 	install -Dm4755 target/release/shadow-rs $(DESTDIR)$(BINDIR)/shadow-rs
 	@for tool in $(ALL_TOOLS); do \

--- a/README.md
+++ b/README.md
@@ -96,9 +96,10 @@ sudo make install PREFIX=/usr/local
 ```
 
 Alternative: single multicall binary with symlinks. Smaller footprint (~14×
-disk savings) but larger setuid attack surface — the binary is installed
-setuid-root, so all 14 applets run with `euid=root` when invoked via symlink.
-Intended for container/embedded use cases.
+disk savings). The binary is installed setuid-root so that `passwd`, `chfn`,
+`chsh` and `newgrp` can serve unprivileged callers; every other applet drops
+back to the caller's uid before it runs, so the privilege model is the same
+as the per-tool layout. Intended for container/embedded use cases.
 
 ```shell
 sudo make install-multicall PREFIX=/usr/local
@@ -145,9 +146,10 @@ for tool in passwd chfn chsh newgrp chage chpasswd groupadd groupdel \
 done
 ```
 
-Mode `4755` makes every applet run `euid=root`; see the setuid trade-off noted
-above. Run `shadow-rs --list` to see the applets a given build contains, and
-`sha256sum -c uu_shadow-*.tar.gz.sha256` to verify a download.
+Mode `4755` is what the four self-service applets need; the others give the
+privilege up before running. Run `shadow-rs --list` to see the applets a
+given build contains, and `sha256sum -c uu_shadow-*.tar.gz.sha256` to verify
+a download.
 
 ### Test
 

--- a/src/bin/shadow-rs.rs
+++ b/src/bin/shadow-rs.rs
@@ -7,19 +7,117 @@
 //!
 //! Dispatches to the appropriate utility based on `argv[0]`.
 //! When invoked as `shadow-rs <util>`, uses the first argument instead.
+//!
+//! # Privileges
+//!
+//! The per-tool install makes only `passwd`, `chfn`, `chsh` and `newgrp`
+//! setuid-root. A multicall install has to make the one binary setuid, which
+//! would hand euid 0 to every applet — an unprivileged `pwck -s` rewriting
+//! `/etc/passwd`. So before an applet outside that set runs, the binary drops
+//! back to the caller's uid, and the two layouts have the same privilege
+//! model.
 
+use std::ffi::OsString;
 use std::io::Write;
 use std::path::Path;
 use std::process::ExitCode;
 
+type Applet = fn(&[OsString]) -> i32;
+
+/// Applets that keep euid 0 for an unprivileged caller: the same four that
+/// `make install` marks setuid.
+const SETUID_APPLETS: [&str; 4] = ["passwd", "chfn", "chsh", "newgrp"];
+
+/// Every applet compiled into this binary, by name, in `--list` order.
+// `#[cfg]` is not accepted on the elements of a `vec![]` literal, so the
+// table is assembled push by push.
+#[allow(clippy::vec_init_then_push)]
+fn applets() -> Vec<(&'static str, Applet)> {
+    let mut table: Vec<(&'static str, Applet)> = Vec::with_capacity(14);
+    #[cfg(feature = "chage")]
+    table.push(("chage", |a| chage::uumain(a.iter().cloned())));
+    #[cfg(feature = "chfn")]
+    table.push(("chfn", |a| chfn::uumain(a.iter().cloned())));
+    #[cfg(feature = "chpasswd")]
+    table.push(("chpasswd", |a| chpasswd::uumain(a.iter().cloned())));
+    #[cfg(feature = "chsh")]
+    table.push(("chsh", |a| chsh::uumain(a.iter().cloned())));
+    #[cfg(feature = "groupadd")]
+    table.push(("groupadd", |a| groupadd::uumain(a.iter().cloned())));
+    #[cfg(feature = "groupdel")]
+    table.push(("groupdel", |a| groupdel::uumain(a.iter().cloned())));
+    #[cfg(feature = "groupmod")]
+    table.push(("groupmod", |a| groupmod::uumain(a.iter().cloned())));
+    #[cfg(feature = "grpck")]
+    table.push(("grpck", |a| grpck::uumain(a.iter().cloned())));
+    #[cfg(feature = "newgrp")]
+    table.push(("newgrp", |a| newgrp::uumain(a.iter().cloned())));
+    #[cfg(feature = "passwd")]
+    table.push(("passwd", |a| passwd::uumain(a.iter().cloned())));
+    #[cfg(feature = "pwck")]
+    table.push(("pwck", |a| pwck::uumain(a.iter().cloned())));
+    #[cfg(feature = "useradd")]
+    table.push(("useradd", |a| useradd::uumain(a.iter().cloned())));
+    #[cfg(feature = "userdel")]
+    table.push(("userdel", |a| userdel::uumain(a.iter().cloned())));
+    #[cfg(feature = "usermod")]
+    table.push(("usermod", |a| usermod::uumain(a.iter().cloned())));
+    table
+}
+
+fn find_applet(name: &str) -> Option<Applet> {
+    applets()
+        .into_iter()
+        .find(|(applet, _)| *applet == name)
+        .map(|(_, run)| run)
+}
+
+/// Whether `applet` may run with the setuid privilege on behalf of an
+/// unprivileged caller.
+fn keeps_privilege(applet: &str) -> bool {
+    SETUID_APPLETS.contains(&applet)
+}
+
+/// Give the setuid privilege up unless `applet` is one of the tools it exists
+/// for. Fails closed: if the kernel will not take the privilege away, the
+/// applet does not run.
+fn drop_privileges_for(applet: &str) -> Result<(), ExitCode> {
+    let real = rustix::process::getuid();
+    if real == rustix::process::geteuid() || keeps_privilege(applet) {
+        return Ok(());
+    }
+    // setuid(2) called with euid 0 sets the real, effective and saved uid,
+    // so the privilege is gone for good rather than parked in the saved uid.
+    let result = shadow_core::process::setuid(real.as_raw());
+    if result.is_err() || rustix::process::geteuid() != real {
+        let _ = writeln!(
+            std::io::stderr(),
+            "shadow-rs: cannot drop privileges for {applet}: {}",
+            result
+                .err()
+                .map_or_else(|| "effective uid unchanged".to_string(), |e| e.to_string())
+        );
+        return Err(ExitCode::FAILURE);
+    }
+    Ok(())
+}
+
 /// Convert a tool's `i32` exit code to `ExitCode`.
-#[allow(clippy::cast_sign_loss)] // clamp(0, 255) guarantees non-negative
 fn to_exit_code(code: i32) -> ExitCode {
-    ExitCode::from(code.clamp(0, 255) as u8)
+    // Every documented exit code fits; anything else is a bug and must not
+    // masquerade as success.
+    ExitCode::from(u8::try_from(code).unwrap_or(1))
+}
+
+fn run_applet(applet: &str, run: Applet, args: &[OsString]) -> ExitCode {
+    match drop_privileges_for(applet) {
+        Ok(()) => to_exit_code(run(args)),
+        Err(code) => code,
+    }
 }
 
 fn main() -> ExitCode {
-    let args: Vec<std::ffi::OsString> = std::env::args_os().collect();
+    let args: Vec<OsString> = std::env::args_os().collect();
 
     let binary_name = args
         .first()
@@ -43,8 +141,8 @@ fn main() -> ExitCode {
     }
 
     // Direct invocation via symlink (e.g., argv[0] = "passwd")
-    if let Some(code) = dispatch(&binary_name, &args) {
-        return to_exit_code(code);
+    if let Some(run) = find_applet(&binary_name) {
+        return run_applet(&binary_name, run, &args);
     }
 
     // Multicall: `shadow-rs <util> [args...]`
@@ -66,8 +164,8 @@ fn main() -> ExitCode {
             return ExitCode::SUCCESS;
         }
 
-        if let Some(code) = dispatch(&util_name, &args[1..]) {
-            return to_exit_code(code);
+        if let Some(run) = find_applet(&util_name) {
+            return run_applet(&util_name, run, &args[1..]);
         }
 
         let _ = writeln!(
@@ -110,70 +208,62 @@ fn print_multicall_help() {
     let _ = writeln!(out, "{}", shadow_core::cli::AFTER_HELP);
 }
 
-fn dispatch(name: &str, args: &[std::ffi::OsString]) -> Option<i32> {
-    match name {
-        #[cfg(feature = "chage")]
-        "chage" => Some(chage::uumain(args.iter().cloned())),
-        #[cfg(feature = "chfn")]
-        "chfn" => Some(chfn::uumain(args.iter().cloned())),
-        #[cfg(feature = "chpasswd")]
-        "chpasswd" => Some(chpasswd::uumain(args.iter().cloned())),
-        #[cfg(feature = "chsh")]
-        "chsh" => Some(chsh::uumain(args.iter().cloned())),
-        #[cfg(feature = "groupadd")]
-        "groupadd" => Some(groupadd::uumain(args.iter().cloned())),
-        #[cfg(feature = "groupdel")]
-        "groupdel" => Some(groupdel::uumain(args.iter().cloned())),
-        #[cfg(feature = "groupmod")]
-        "groupmod" => Some(groupmod::uumain(args.iter().cloned())),
-        #[cfg(feature = "grpck")]
-        "grpck" => Some(grpck::uumain(args.iter().cloned())),
-        #[cfg(feature = "newgrp")]
-        "newgrp" => Some(newgrp::uumain(args.iter().cloned())),
-        #[cfg(feature = "passwd")]
-        "passwd" => Some(passwd::uumain(args.iter().cloned())),
-        #[cfg(feature = "pwck")]
-        "pwck" => Some(pwck::uumain(args.iter().cloned())),
-        #[cfg(feature = "useradd")]
-        "useradd" => Some(useradd::uumain(args.iter().cloned())),
-        #[cfg(feature = "userdel")]
-        "userdel" => Some(userdel::uumain(args.iter().cloned())),
-        #[cfg(feature = "usermod")]
-        "usermod" => Some(usermod::uumain(args.iter().cloned())),
-        _ => None,
-    }
-}
-
 fn print_available_utils() {
     let mut out = std::io::stdout().lock();
     let _ = writeln!(out, "Available utilities:");
+    for (name, _) in applets() {
+        let _ = writeln!(out, "  {name}");
+    }
+}
 
-    #[cfg(feature = "chage")]
-    let _ = writeln!(out, "  chage");
-    #[cfg(feature = "chfn")]
-    let _ = writeln!(out, "  chfn");
-    #[cfg(feature = "chpasswd")]
-    let _ = writeln!(out, "  chpasswd");
-    #[cfg(feature = "chsh")]
-    let _ = writeln!(out, "  chsh");
-    #[cfg(feature = "groupadd")]
-    let _ = writeln!(out, "  groupadd");
-    #[cfg(feature = "groupdel")]
-    let _ = writeln!(out, "  groupdel");
-    #[cfg(feature = "groupmod")]
-    let _ = writeln!(out, "  groupmod");
-    #[cfg(feature = "grpck")]
-    let _ = writeln!(out, "  grpck");
-    #[cfg(feature = "newgrp")]
-    let _ = writeln!(out, "  newgrp");
-    #[cfg(feature = "passwd")]
-    let _ = writeln!(out, "  passwd");
-    #[cfg(feature = "pwck")]
-    let _ = writeln!(out, "  pwck");
-    #[cfg(feature = "useradd")]
-    let _ = writeln!(out, "  useradd");
-    #[cfg(feature = "userdel")]
-    let _ = writeln!(out, "  userdel");
-    #[cfg(feature = "usermod")]
-    let _ = writeln!(out, "  usermod");
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const ALL_TOOLS: [&str; 14] = [
+        "chage", "chfn", "chpasswd", "chsh", "groupadd", "groupdel", "groupmod", "grpck", "newgrp",
+        "passwd", "pwck", "useradd", "userdel", "usermod",
+    ];
+
+    // The table drives both dispatch and `--list`, so it must contain only
+    // real tools, each once, in a stable order.
+    #[test]
+    fn applet_table_is_sorted_unique_and_known() {
+        let names: Vec<&str> = applets().into_iter().map(|(n, _)| n).collect();
+        let mut sorted = names.clone();
+        sorted.sort_unstable();
+        sorted.dedup();
+        assert_eq!(names, sorted);
+        assert!(names.iter().all(|n| ALL_TOOLS.contains(n)));
+    }
+
+    // Exactly the four tools that the per-tool install marks setuid keep the
+    // privilege; every other applet gives it up before running.
+    #[test]
+    fn only_self_service_tools_keep_privilege() {
+        for tool in ALL_TOOLS {
+            assert_eq!(
+                keeps_privilege(tool),
+                matches!(tool, "passwd" | "chfn" | "chsh" | "newgrp"),
+                "{tool}"
+            );
+        }
+        assert!(!keeps_privilege("shadow-rs"));
+        assert!(!keeps_privilege(""));
+    }
+
+    // Without privilege to drop there is nothing to do; this must never fail
+    // for an ordinary process.
+    #[test]
+    fn dropping_is_a_no_op_when_not_setuid() {
+        assert!(drop_privileges_for("pwck").is_ok());
+    }
+
+    #[test]
+    fn exit_codes_out_of_range_are_not_success() {
+        assert_eq!(to_exit_code(0), ExitCode::from(0));
+        assert_eq!(to_exit_code(12), ExitCode::from(12));
+        assert_eq!(to_exit_code(-1), ExitCode::from(1));
+        assert_eq!(to_exit_code(300), ExitCode::from(1));
+    }
 }

--- a/tests/e2e/deploy-test.sh
+++ b/tests/e2e/deploy-test.sh
@@ -185,6 +185,25 @@ test_setuid() {
     # Non-root user should NOT be able to change another user's password
     assert_fail "testrunner cannot passwd root" \
         su -s /bin/bash testrunner -c "echo 'root:hacked' | $BINDIR/chpasswd -e"
+
+    # The binary is setuid for the four self-service tools only; every other
+    # applet must run with the caller's own privileges. An unprivileged
+    # `pwck -s` or `grpck -s` must neither rewrite a file nor change its owner.
+    local passwd_before group_before
+    passwd_before=$(stat -c '%i %U:%G' /etc/passwd)
+    group_before=$(stat -c '%i %U:%G' /etc/group)
+    assert_fail "testrunner cannot run shadow-rs pwck -s" \
+        su -s /bin/bash testrunner -c "$BINDIR/shadow-rs pwck -s"
+    assert_fail "testrunner cannot run pwck -s through the symlink" \
+        su -s /bin/bash testrunner -c "$BINDIR/pwck -s"
+    assert_fail "testrunner cannot run grpck -s" \
+        su -s /bin/bash testrunner -c "$BINDIR/grpck -s"
+    assert_ok "/etc/passwd untouched by unprivileged pwck -s" \
+        test "$(stat -c '%i %U:%G' /etc/passwd)" = "$passwd_before"
+    assert_ok "/etc/group untouched by unprivileged grpck -s" \
+        test "$(stat -c '%i %U:%G' /etc/group)" = "$group_before"
+    assert_ok "/etc/shadow is root:shadow 0640" \
+        test "$(stat -c '%U:%G %a' /etc/shadow)" = "root:shadow 640"
 }
 
 # ── User lifecycle ──────────────────────────────────────────────────


### PR DESCRIPTION
Second of the follow-ups announced in #238.

## Problem

`make install-multicall` (and the README recipe for the release archive) installs one `shadow-rs` binary mode 4755 so that `passwd`, `chfn`, `chsh` and `newgrp` can serve unprivileged callers. But the setuid bit applied to all fourteen applets, and `pwck`/`grpck` never check who is calling. Reproduced against a container's real `/etc`:

```
$ su attacker -c 'shadow-rs pwck -s'      # or: pwck -s through the symlink
```

rewrote `/etc/passwd` and `/etc/shadow` with euid 0 (sorted, comments dropped). Combined with the ownership bug fixed in #238, the rewritten `/etc/shadow` came back `root:attacker 0640` — readable by the attacker.

## Fix

Before dispatching, the binary now drops to the caller's uid for every applet outside the setuid set:

- `setuid(getuid())` from euid 0 sets the real, effective *and* saved uid, so the privilege is gone rather than parked; if the kernel does not take it away the applet does not run.
- The set is `passwd`, `chfn`, `chsh`, `newgrp` — exactly what `make install` marks setuid — so the multicall and per-tool layouts now have the same privilege model. README and Makefile no longer describe the multicall layout as having a "larger setuid attack surface".

While there: dispatch and `--list` are driven by one table instead of two hand-maintained lists (they could drift), and `to_exit_code` no longer clamps a negative code to 0 (success).

## Verified (Debian image, 4755 multicall, unprivileged `attacker`)

| Command | Before | After |
|---|---|---|
| `shadow-rs pwck -s` | rewrote passwd+shadow, exit 2 | `cannot open /etc/shadow: Permission denied`, exit 3, files untouched (same inode, same owner) |
| `pwck -s` via symlink | same | same |
| `grpck -s` | rewrote group, exit 0 | `cannot lock /etc/group`, exit 4, untouched |
| `useradd evil` | — | `Permission denied`, exit 1 |
| `passwd -S attacker` (control) | works | works — self-service keeps the privilege |
| root `pwck -s` (control) | works | works |

Unit tests cover the applet table (sorted, unique, known names), the privilege set, the no-op drop for an ordinary process, and the exit-code mapping. `tests/e2e/deploy-test.sh` gains the same assertions for `testrunner`; the e2e image itself is repaired and wired into CI in the next PR (PAM path).
