### PR TITLE
groupmod: renumber primary-group members in /etc/passwd on -g

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `groupmod -g` now updates `/etc/passwd`: users whose primary group is the
+  one being renumbered follow it, instead of being left with a primary GID
+  that no longer names a group. It also rejects GID `4294967295`
+  (`(gid_t)-1`, the "no change" sentinel), and takes the passwd lock before
+  the group lock so its lock order stays acyclic with `useradd`/`usermod`
+  (#245)
 - `groupadd -K` now honours any login.defs key, not only the four GID-range
   ones, and rejects malformed pairs the same way `useradd -K` does; both tools
   share one parser in `shadow-core` (#223)

--- a/src/uu/groupmod/src/groupmod.rs
+++ b/src/uu/groupmod/src/groupmod.rs
@@ -20,6 +20,7 @@ use shadow_core::group::{self};
 use shadow_core::gshadow::{self};
 use shadow_core::lock::FileLock;
 use shadow_core::nscd;
+use shadow_core::passwd;
 use shadow_core::sysroot::SysRoot;
 
 mod options {
@@ -125,11 +126,17 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
             .map_err(|e| GroupmodError::BadArgument(e.to_string()))?;
     }
 
-    // Parse new GID if provided.
+    // Parse new GID if provided. u32::MAX is (gid_t)-1, the "no change"
+    // sentinel of chown/setresgid, and must never be stored.
     let parsed_gid: Option<u32> = new_gid
         .map(|s| {
-            s.parse::<u32>()
-                .map_err(|_| GroupmodError::BadArgument(format!("invalid GID '{s}'")))
+            let gid = s
+                .parse::<u32>()
+                .map_err(|_| GroupmodError::BadArgument(format!("invalid GID '{s}'")))?;
+            if gid == u32::MAX {
+                return Err(GroupmodError::BadArgument(format!("invalid GID '{s}'")));
+            }
+            Ok(gid)
         })
         .transpose()?;
 
@@ -138,8 +145,22 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let _signals = shadow_core::hardening::SignalBlocker::block_critical()
         .map_err(|e| GroupmodError::CantUpdate(format!("cannot block signals: {e}")))?;
 
-    // Lock and read /etc/group.
+    // Lock order across the tools is passwd < group < gshadow < shadow, so
+    // take the passwd lock first when -g will need it (see below), never after
+    // group. This keeps the ordering acyclic with useradd/usermod.
     let group_path = root.group_path();
+    let passwd_path = root.passwd_path();
+    // Only the -g path touches passwd, and only if it exists (a --prefix tree
+    // may not carry one). Guarded like the gshadow write below.
+    let update_passwd = parsed_gid.is_some() && passwd_path.exists();
+    let passwd_lock = if update_passwd {
+        Some(FileLock::acquire(&passwd_path).map_err(|e| {
+            GroupmodError::CantUpdate(format!("cannot lock {}: {e}", passwd_path.display()))
+        })?)
+    } else {
+        None
+    };
+
     let group_lock = FileLock::acquire(&group_path).map_err(|e| {
         GroupmodError::CantUpdate(format!("cannot lock {}: {e}", group_path.display()))
     })?;
@@ -155,6 +176,8 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         .ok_or_else(|| {
             GroupmodError::GroupNotFound(format!("group '{group_name}' does not exist"))
         })?;
+
+    let old_gid = entries[idx].gid;
 
     // Check GID collision.
     if let Some(gid) = parsed_gid {
@@ -188,7 +211,37 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         GroupmodError::CantUpdate(format!("cannot write {}: {e}", group_path.display()))
     })?;
 
+    // groupmod(8): "Users who use the group as their primary group are updated
+    // to keep the group as their primary group." Do it while we still hold the
+    // passwd lock we took above, then release group then passwd.
+    if let Some(new_gid_val) = parsed_gid
+        && new_gid_val != old_gid
+        && update_passwd
+    {
+        let mut pw_entries = passwd::read_passwd_file(&passwd_path).map_err(|e| {
+            GroupmodError::CantUpdate(format!("cannot read {}: {e}", passwd_path.display()))
+        })?;
+        let mut changed = false;
+        for e in &mut pw_entries {
+            if e.gid == old_gid {
+                e.gid = new_gid_val;
+                changed = true;
+            }
+        }
+        if changed {
+            atomic::atomic_write(&passwd_path, |f| passwd::write_passwd(&pw_entries, f)).map_err(
+                |e| {
+                    GroupmodError::CantUpdate(format!(
+                        "cannot write {}: {e}",
+                        passwd_path.display()
+                    ))
+                },
+            )?;
+        }
+    }
+
     drop(group_lock);
+    drop(passwd_lock);
 
     // Update /etc/gshadow.
     let gshadow_path = root.gshadow_path();

--- a/tests/by-util/test_groupmod.rs
+++ b/tests/by-util/test_groupmod.rs
@@ -46,6 +46,11 @@ fn read_gshadow(dir: &tempfile::TempDir) -> String {
     std::fs::read_to_string(dir.path().join("etc/gshadow")).expect("failed to read gshadow file")
 }
 
+/// Read the passwd file content back from a prefix dir.
+fn read_passwd(dir: &tempfile::TempDir) -> String {
+    std::fs::read_to_string(dir.path().join("etc/passwd")).expect("failed to read passwd file")
+}
+
 // ---------------------------------------------------------------------------
 // Non-root tests — exercise clap parsing and error paths
 // ---------------------------------------------------------------------------
@@ -93,6 +98,56 @@ fn test_change_gid() {
         content.contains("testgrp:x:9999:"),
         "GID should be changed to 9999, got: {content}"
     );
+}
+
+// groupmod(8): changing a group's GID re-homes the users whose primary group
+// it is, so they are not left pointing at a GID that no longer names a group.
+#[test]
+fn test_change_gid_updates_primary_group_members_in_passwd() {
+    if common::skip_unless_root() {
+        return;
+    }
+
+    let dir = setup_root(
+        "devs:x:1000:\n",
+        "devs:!::\n",
+        "root:x:0:0:root:/root:/bin/bash\n\
+         alice:x:1500:1000:Alice:/home/alice:/bin/bash\n\
+         bob:x:1600:1000:Bob:/home/bob:/bin/bash\n\
+         carol:x:1700:1700:Carol:/home/carol:/bin/bash\n",
+    );
+
+    let prefix = dir.path().to_str().expect("temp dir path is valid UTF-8");
+    let code = run(&["groupmod", "-g", "2000", "-P", prefix, "devs"]);
+    assert_eq!(code, 0, "changing GID should exit 0");
+
+    assert!(read_group(&dir).contains("devs:x:2000:"));
+    let passwd = read_passwd(&dir);
+    assert!(
+        passwd.contains("alice:x:1500:2000:") && passwd.contains("bob:x:1600:2000:"),
+        "primary-group members should follow the GID, got: {passwd}"
+    );
+    assert!(
+        passwd.contains("carol:x:1700:1700:"),
+        "unrelated users must be untouched, got: {passwd}"
+    );
+}
+
+#[test]
+fn test_gid_minus_one_sentinel_is_rejected() {
+    if common::skip_unless_root() {
+        return;
+    }
+
+    let dir = setup_root(
+        "g:x:1000:\n",
+        "g:!::\n",
+        "root:x:0:0:root:/root:/bin/bash\n",
+    );
+    let prefix = dir.path().to_str().expect("temp dir path is valid UTF-8");
+    let code = run(&["groupmod", "-g", "4294967295", "-P", prefix, "g"]);
+    assert_eq!(code, 3, "(gid_t)-1 must be a bad argument");
+    assert!(read_group(&dir).contains("g:x:1000:"), "group unchanged");
 }
 
 #[test]


### PR DESCRIPTION
Part of #245 — the `groupmod -g` correctness bug and the GID sentinel; the group/gshadow single-transaction refactor stays on the issue.

## `groupmod -g` left dangling primary GIDs

`groupmod(8)`: *"Users who use the group as their primary group are updated to keep the group as their primary group."* We rewrote only `/etc/group`, so after `groupmod -g 2000 devs`, `alice`, whose primary group was GID 1000, still read `alice:x:1500:1000:` — a GID no group names any more. `id alice` prints a number, `pwck` reports the group missing, and files she creates get an unnamed group.

`groupmod -g` now rewrites `/etc/passwd` too, moving exactly the users whose primary GID was the old one; unrelated users are untouched. The passwd lock is taken **before** the group lock, matching the tools' order (`passwd < group < gshadow < shadow`) so it cannot deadlock against `useradd`/`usermod`, and only when a passwd file is present (a `--prefix` tree may omit it).

Also: GID `4294967295` (`(gid_t)-1`, the "no change" sentinel of `chown`/`setresgid`) is rejected with exit 3.

## Verified (Debian image, as root)

- `groupmod -g 2000 devs` on a tree where `alice` and `bob` have primary GID 1000 and `carol` has 1700 → `devs` becomes 2000, `alice`/`bob` become `:2000:`, `carol` untouched.
- `groupmod -g 4294967295 g` → exit 3, group unchanged.
- `fmt`, `clippy -D warnings` ±`pam`, `cargo test --workspace` green; groupmod integration suite 13/13 including the two new tests.
