### PR TITLE
pwck, grpck: never rewrite the files when a line failed to parse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- `pwck -s` and `grpck -s` no longer rewrite the files when a line failed to
+  parse. Sorting works on the entries that parsed, so the write silently
+  dropped every line the tool had just reported as invalid, along with all
+  comments. They now report the errors and exit 2 without writing. `-r` and
+  `-s` are also rejected together, as the man pages require (#246)
 - `userdel -r` no longer deletes a home directory that the user does not own
   or that another account shares, unless `-f` is given (`userdel(8)` ties both
   to `-f`). It could previously erase a service account's root-owned

--- a/src/uu/grpck/src/grpck.rs
+++ b/src/uu/grpck/src/grpck.rs
@@ -163,7 +163,14 @@ fn run_checks(opts: &GrpckOptions) -> UResult<()> {
         errors += check_group_gshadow_consistency(&group_entries, &gshadow_entries, opts.quiet);
     }
 
-    // Sort by GID if requested.
+    // Never rewrite the files when errors were found: sorting works on the
+    // entries that parsed, so writing would drop every line just reported.
+    if errors > 0 {
+        return Err(GrpckError::BadEntry(String::new()).into());
+    }
+
+    // Sort by GID if requested. `-r` and `-s` cannot be combined (rejected by
+    // clap), so the read-only guard is defensive.
     if opts.sort && !opts.read_only {
         sort_and_write(
             &opts.group_path,
@@ -173,11 +180,7 @@ fn run_checks(opts: &GrpckOptions) -> UResult<()> {
         )?;
     }
 
-    if errors > 0 {
-        Err(GrpckError::BadEntry(String::new()).into())
-    } else {
-        Ok(())
-    }
+    Ok(())
 }
 
 /// Read raw non-comment, non-blank lines from a file.
@@ -382,6 +385,8 @@ pub fn uu_app() -> Command {
                 .short('s')
                 .long("sort")
                 .help("Reorder entries by ascending GID")
+                // grpck(8): "The -r and -s options cannot be combined."
+                .conflicts_with(options::READ_ONLY)
                 .action(ArgAction::SetTrue),
         )
         .arg(

--- a/src/uu/pwck/src/pwck.rs
+++ b/src/uu/pwck/src/pwck.rs
@@ -194,6 +194,13 @@ fn run_checks(opts: &PwckOptions) -> UResult<()> {
     let shadow_result = check_shadow_entries(&shadow_entries, &passwd_entries, opts.quiet);
     errors += shadow_result.errors;
 
+    // Never rewrite the files when parse errors were found: sorting works on
+    // the entries that parsed, so writing would silently drop every line pwck
+    // just reported as invalid. Report the errors and stop.
+    if errors > 0 {
+        return Err(PwckError::BadEntry(String::new()).into());
+    }
+
     if opts.sort {
         sort_and_write(
             &opts.passwd_path,
@@ -206,12 +213,7 @@ fn run_checks(opts: &PwckOptions) -> UResult<()> {
         uucore::show_error!("no changes");
     }
 
-    if errors > 0 {
-        // GNU exits 2 silently (no additional message beyond the per-entry output).
-        Err(PwckError::BadEntry(String::new()).into())
-    } else {
-        Ok(())
-    }
+    Ok(())
 }
 
 /// Load shadow file, returning empty vec if file does not exist.
@@ -242,13 +244,13 @@ fn load_group_file(path: &Path, quiet: bool) -> Vec<GroupEntry> {
 
 /// Sort passwd entries by UID and write back atomically (for `--sort`).
 ///
-/// When `read_only` is true (i.e. `-r -s`), compute the sorted order but
-/// skip all file writes, matching GNU `pwck -r -s` behaviour.
+/// `-r` and `-s` cannot be combined (rejected by clap), so `read_only` is
+/// always false here; the parameter is kept as a defensive guard.
 ///
-/// NOTE: Sorting operates on parsed entries and discards any comments or
-/// blank lines from the original file. A lossless (comment-preserving)
-/// sort would require a significantly different parser that tracks raw
-/// lines alongside parsed entries. This matches GNU `pwck -s` behavior.
+/// NOTE: sorting operates on the parsed entries and does not yet preserve
+/// comments or blank lines. Comment preservation is tracked in #241; until
+/// then a `-s` that reorders the file drops them. This only runs when there
+/// were no parse errors.
 fn sort_and_write(
     passwd_path: &Path,
     shadow_path: &Path,
@@ -313,6 +315,8 @@ pub fn uu_app() -> Command {
                 .short('s')
                 .long("sort")
                 .help("Reorder entries by ascending UID")
+                // pwck(8): "The -r and -s options cannot be combined."
+                .conflicts_with(options::READ_ONLY)
                 .action(ArgAction::SetTrue),
         )
         .arg(

--- a/tests/by-util/test_grpck.rs
+++ b/tests/by-util/test_grpck.rs
@@ -209,3 +209,36 @@ fn test_valid_group_without_gshadow_file() {
     ]);
     assert_eq!(code, 0, "valid group without gshadow file should return 0");
 }
+
+// ---------------------------------------------------------------------------
+// -s must not rewrite the files when there are errors (data-loss guard)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_sort_with_parse_error_does_not_write() {
+    let (dir, gp, gsp) = setup_files(
+        "# keep this comment\n\
+         z:x:1000:\n\
+         broken:x:notanumber:\n\
+         a:x:500:\n",
+        "z:!::\na:!::\n",
+    );
+    let before = std::fs::read_to_string(&gp).unwrap();
+
+    let code = run(&["grpck", "-s", &gp, &gsp]);
+    assert_eq!(code, 2, "a parse error must make grpck exit 2");
+    assert_eq!(
+        std::fs::read_to_string(&gp).unwrap(),
+        before,
+        "the file must be left untouched when there are errors"
+    );
+    let _ = dir;
+}
+
+#[test]
+fn test_read_only_and_sort_conflict() {
+    let (dir, gp, gsp) = setup_files("root:x:0:\n", "root:!::\n");
+    let code = run(&["grpck", "-r", "-s", &gp, &gsp]);
+    assert_ne!(code, 0, "-r and -s cannot be combined");
+    let _ = dir;
+}

--- a/tests/by-util/test_pwck.rs
+++ b/tests/by-util/test_pwck.rs
@@ -378,3 +378,47 @@ fn test_nonexistent_passwd_exits_cant_open() {
         "nonexistent passwd file should return exit code 3 (cant open)"
     );
 }
+
+// ---------------------------------------------------------------------------
+// -s must not rewrite the files when there are errors (data-loss guard)
+// ---------------------------------------------------------------------------
+
+fn read_etc(dir: &tempfile::TempDir, name: &str) -> String {
+    std::fs::read_to_string(dir.path().join("etc").join(name)).expect("read etc file")
+}
+
+#[test]
+fn test_sort_with_parse_error_does_not_write() {
+    // A malformed line plus a comment and out-of-order entries: `-s` would
+    // reorder and, on the old code, drop the comment and the unparsable line.
+    let dir = setup_root(
+        "# keep this comment\n\
+         z:x:1000:1000::/home/z:/bin/sh\n\
+         broken:x:notanumber:0::/:/bin/sh\n\
+         a:x:500:500::/home/a:/bin/sh\n",
+        "z:!:19500::::::\na:!:19500::::::\n",
+        "z:x:1000:\na:x:500:\n",
+    );
+    let prefix = dir.path().to_str().unwrap();
+    let before = read_etc(&dir, "passwd");
+
+    let code = run(&["pwck", "-s", "-R", prefix]);
+    assert_eq!(code, 2, "a parse error must make pwck exit 2");
+    assert_eq!(
+        read_etc(&dir, "passwd"),
+        before,
+        "the file must be left untouched when there are errors"
+    );
+}
+
+#[test]
+fn test_read_only_and_sort_conflict() {
+    let dir = setup_root(
+        "root:x:0:0::/root:/bin/sh\n",
+        "root:!:19500::::::\n",
+        "root:x:0:\n",
+    );
+    let prefix = dir.path().to_str().unwrap();
+    let code = run(&["pwck", "-r", "-s", "-R", prefix]);
+    assert_ne!(code, 0, "-r and -s cannot be combined");
+}


### PR DESCRIPTION
Part of #246 — the data-loss guard and the `-r`/`-s` conflict. The remaining grpck items (empty/malformed gshadow handling, `-q` semantics, member validation) stay on the issue.

## The bug

`pwck -s` and `grpck -s` sort and rewrite the parsed entries. A line that fails to parse — the very thing these tools report — is not in that set, so the rewrite **silently dropped every invalid line and every comment**, then exited 2 as if it had only reported. A single stray colon in `/etc/passwd`, run through `pwck -s` to "tidy up", lost that account and all comments.

## Fix

Both tools now return exit 2 **without writing** when any parse error was counted. Sorting only runs on a clean file. `-r` and `-s` are made mutually exclusive (clap `conflicts_with`), which the man pages require ("The -r and -s options cannot be combined").

## Verified (Debian image)

- `pwck -s` / `grpck -s` on a file with a malformed line plus a comment and out-of-order entries → exit 2, file **byte-for-byte unchanged** (comment and bad line preserved).
- `pwck -r -s` / `grpck -r -s` → non-zero (rejected).
- `fmt`, `clippy -D warnings` ±`pam`, `cargo test --workspace` green; pwck 14/14, grpck 16/16 including the new guards.

Comment/blank-line preservation on a *clean* `-s` (so a legitimate reorder stops dropping comments) is the separate parser change tracked in #241.
