### PR TITLE
chfn, chsh: enforce CHFN_RESTRICT and refuse to change a restricted account's shell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- `chfn` now honours `CHFN_RESTRICT` from login.defs: a non-root user may
+  change only the GECOS sub-fields it lists (unset means none, per
+  login.defs(5)), instead of any field. GECOS values are also rejected if they
+  contain `=` or control characters, not only `:` and commas (#247)
+- `chsh` refuses to change the shell of a restricted account — one whose
+  current shell is not listed in `/etc/shells` — for a non-root caller, so a
+  deliberately confined login cannot escape by pointing itself at a normal
+  shell (#247)
 - `pwck -s` and `grpck -s` no longer rewrite the files when a line failed to
   parse. Sorting works on the entries that parsed, so the write silently
   dropped every line the tool had just reported as invalid, along with all

--- a/src/uu/chfn/Cargo.toml
+++ b/src/uu/chfn/Cargo.toml
@@ -20,7 +20,7 @@ path = "src/main.rs"
 [dependencies]
 clap = { workspace = true }
 rustix = { workspace = true }
-shadow-core = { workspace = true }
+shadow-core = { workspace = true, features = ["login-defs"] }
 uucore = { workspace = true }
 
 [features]

--- a/src/uu/chfn/src/chfn.rs
+++ b/src/uu/chfn/src/chfn.rs
@@ -112,21 +112,35 @@ fn resolve_target_user(matches: &clap::ArgMatches) -> Result<String, ChfnError> 
     shadow_core::hardening::current_username().map_err(|e| ChfnError::Error(e.to_string()))
 }
 
-/// Validate that a GECOS sub-field does not contain illegal characters.
-/// Colons and newlines are forbidden; commas are forbidden in all fields
-/// except "other" which is the last sub-field.
+/// Validate a GECOS sub-field. Colons, newlines and other control characters
+/// are forbidden everywhere (they would break the record); commas and equal
+/// signs are additionally forbidden in every field except "other", the last
+/// sub-field (chfn(1): the other fields "should not contain any comma or equal
+/// sign"). `allow_comma` is true only for the "other" field.
 fn validate_gecos_field(value: &str, field_name: &str, allow_comma: bool) -> Result<(), ChfnError> {
-    if value.contains(':') || value.contains('\n') || value.contains('\0') {
+    shadow_core::validate::validate_field(field_name, value)
+        .map_err(|e| ChfnError::Error(e.to_string()))?;
+    if !allow_comma && (value.contains(',') || value.contains('=')) {
         return Err(ChfnError::Error(format!(
-            "{field_name}: invalid characters"
-        )));
-    }
-    if !allow_comma && value.contains(',') {
-        return Err(ChfnError::Error(format!(
-            "{field_name}: must not contain commas"
+            "{field_name}: must not contain ',' or '='"
         )));
     }
     Ok(())
+}
+
+/// The GECOS fields a non-root caller may change, from `CHFN_RESTRICT` in
+/// login.defs. `yes` means `rwh`; an explicit letter set is taken verbatim;
+/// unset (or unreadable) means none — chfn(1)/login.defs(5): "If not
+/// specified, only the superuser can make any changes." Letters: `f` full
+/// name, `r` room, `w` work phone, `h` home phone.
+fn chfn_restrict(root: &SysRoot) -> String {
+    shadow_core::login_defs::LoginDefs::load(&root.login_defs_path())
+        .ok()
+        .map_or_else(String::new, |d| match d.get("CHFN_RESTRICT") {
+            Some("yes") => "rwh".to_string(),
+            Some(set) => set.to_string(),
+            None => String::new(),
+        })
 }
 
 /// Perform `chroot(2)` into the specified directory.
@@ -286,9 +300,26 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         validate_gecos_field(v, "other", true)?;
     }
 
-    // Non-root users may not set the "other" field (matches GNU behavior).
-    if !shadow_core::hardening::caller_is_root() && new_other.is_some() {
-        return Err(ChfnError::Error("only root may change the 'other' field".into()).into());
+    // Non-root users may not set the "other" field, and may change the rest
+    // only within CHFN_RESTRICT (login.defs). Root is unrestricted.
+    if !shadow_core::hardening::caller_is_root() {
+        if new_other.is_some() {
+            return Err(ChfnError::Error("only root may change the 'other' field".into()).into());
+        }
+        let allowed = chfn_restrict(&root);
+        for (present, letter, name) in [
+            (has_full_name, 'f', "full name"),
+            (has_room, 'r', "room number"),
+            (has_work_phone, 'w', "work phone"),
+            (has_home_phone, 'h', "home phone"),
+        ] {
+            if present && !allowed.contains(letter) {
+                return Err(ChfnError::Error(format!(
+                    "you may not change the {name} (restricted by CHFN_RESTRICT)"
+                ))
+                .into());
+            }
+        }
     }
 
     mutate_passwd(&root, &target_user, |entry| {
@@ -508,6 +539,36 @@ mod tests {
     #[test]
     fn test_validate_gecos_field_accepts_normal() {
         assert!(validate_gecos_field("John Doe", "test", false).is_ok());
+    }
+
+    #[test]
+    fn test_validate_gecos_field_rejects_equal_sign() {
+        assert!(validate_gecos_field("a=b", "test", false).is_err());
+        // The trailing "other" field may contain '=' and ','.
+        assert!(validate_gecos_field("a=b,c", "other", true).is_ok());
+    }
+
+    #[test]
+    fn test_validate_gecos_field_rejects_control_char() {
+        assert!(validate_gecos_field("foo\tbar", "test", false).is_err());
+        assert!(validate_gecos_field("foo\x1bbar", "test", true).is_err());
+    }
+
+    #[test]
+    fn test_chfn_restrict_reading() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let etc = dir.path().join("etc");
+        std::fs::create_dir_all(&etc).expect("etc");
+        let root = SysRoot::new(Some(dir.path()));
+
+        std::fs::write(etc.join("login.defs"), "CHFN_RESTRICT rwh\n").unwrap();
+        assert_eq!(chfn_restrict(&root), "rwh");
+
+        std::fs::write(etc.join("login.defs"), "CHFN_RESTRICT yes\n").unwrap();
+        assert_eq!(chfn_restrict(&root), "rwh");
+
+        std::fs::write(etc.join("login.defs"), "UID_MIN 1000\n").unwrap();
+        assert_eq!(chfn_restrict(&root), "", "unset means nothing for non-root");
     }
 
     // -----------------------------------------------------------------------

--- a/src/uu/chsh/src/chsh.rs
+++ b/src/uu/chsh/src/chsh.rs
@@ -120,6 +120,29 @@ fn read_shells(path: &Path) -> Result<Vec<String>, ChshError> {
     Ok(shells)
 }
 
+/// Whether the user's *current* login shell is listed in `/etc/shells`.
+///
+/// A user whose shell is not listed is a restricted account (shells(5)); such
+/// an account may not change its shell. A user with no passwd entry, or whose
+/// current shell cannot be read, is treated as restricted (fail closed). An
+/// empty current shell means the default `/bin/sh`, which is not restricted.
+fn current_shell_is_listed(root: &SysRoot, user: &str) -> bool {
+    let Ok(entries) = passwd::read_passwd_file(&root.passwd_path()) else {
+        return false;
+    };
+    let Some(entry) = entries.iter().find(|e| e.name == user) else {
+        return false;
+    };
+    if entry.shell.is_empty() {
+        return true;
+    }
+    match read_shells(&root.shells_path()) {
+        Ok(shells) if shells.is_empty() => entry.shell == "/bin/sh",
+        Ok(shells) => shells.contains(&entry.shell),
+        Err(_) => false,
+    }
+}
+
 /// Check if a shell is valid: must be an absolute path, must exist as a
 /// regular file, and must be listed in `/etc/shells` (unless caller is root).
 fn validate_shell(shell: &str, shells_path: &Path) -> Result<(), ChshError> {
@@ -270,6 +293,15 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
             .map_err(|e| ChshError::Error(e.to_string()))?;
         if current_user != target_user {
             return Err(ChshError::Error("you may only change your own login shell".into()).into());
+        }
+        // chsh(1): an account whose current shell is not in /etc/shells is
+        // restricted and may not change it. Otherwise a deliberately confined
+        // account (e.g. /bin/rbash, kept out of /etc/shells) could escape.
+        if !current_shell_is_listed(&root, &current_user) {
+            return Err(ChshError::Error(format!(
+                "you may not change the shell for '{current_user}'"
+            ))
+            .into());
         }
         authenticate_caller(&current_user)?;
     }
@@ -454,6 +486,40 @@ mod tests {
         std::fs::write(&shells_path, "/bin/sh\n").expect("write");
         let result = validate_shell("bin/sh", &shells_path);
         assert!(result.is_err());
+    }
+
+    // -----------------------------------------------------------------------
+    // Restricted-account check
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_current_shell_is_listed() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let etc = dir.path().join("etc");
+        std::fs::create_dir_all(&etc).expect("etc");
+        std::fs::write(etc.join("shells"), "/bin/sh\n/bin/bash\n").unwrap();
+        std::fs::write(
+            etc.join("passwd"),
+            "free:x:1000:1000::/home/free:/bin/bash\n\
+             restricted:x:1001:1001::/home/r:/bin/rbash\n\
+             defaulted:x:1002:1002::/home/d:\n",
+        )
+        .unwrap();
+        let root = SysRoot::new(Some(dir.path()));
+
+        assert!(current_shell_is_listed(&root, "free"), "listed shell");
+        assert!(
+            !current_shell_is_listed(&root, "restricted"),
+            "shell not in /etc/shells is restricted"
+        );
+        assert!(
+            current_shell_is_listed(&root, "defaulted"),
+            "empty shell means the default /bin/sh"
+        );
+        assert!(
+            !current_shell_is_listed(&root, "ghost"),
+            "unknown user fails closed"
+        );
     }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
Part of #247 — the two security items (CHFN_RESTRICT, restricted shells) plus the GECOS character rules. The interactive prompt mode and the `chsh -s ""` default-shell handling stay on the issue.

## chfn ignored CHFN_RESTRICT

Any non-root user could change **every** GECOS sub-field. `login.defs(5)` `CHFN_RESTRICT` says which fields a regular user may change: `yes` ≡ `rwh`, an explicit letter set (`f` full name, `r` room, `w` work phone, `h` home phone), and — unset — *"only the superuser can make any changes."* chfn now reads it and refuses a field a non-root caller isn't allowed; root is unrestricted. The `other` field stays root-only.

GECOS values were checked only for `:`, newline, NUL and comma. `chfn(1)` also forbids `=` in the non-`other` fields, and any control character corrupts downstream consumers (`finger`, `getent`). Validation now goes through `shadow-core`'s field validator (all control chars + `:`) plus a `,`/`=` check for the non-`other` fields.

chfn gains the `login-defs` feature of `shadow-core` it now needs.

## chsh let restricted accounts change their shell

`chsh(1)`/`shells(5)`: an account whose **current** shell is not in `/etc/shells` is restricted and may not change it. chsh only validated the *new* shell, so a login deliberately confined to `/bin/rbash` (kept out of `/etc/shells`) could `chsh -s /bin/bash` and escape. A non-root caller whose current shell is not listed is now refused. An empty current shell means the default `/bin/sh` (not restricted); an unknown user fails closed.

## Verified (Debian image)

- `fmt`, `clippy -D warnings` ±`pam`, `cargo test --workspace` green.
- chfn unit tests: `CHFN_RESTRICT` reading (`rwh`, `yes`→`rwh`, unset→none), `=`/control-character rejection, comma rules.
- chsh unit test: current shell listed / not listed (`/bin/rbash`) / empty→default / unknown user.
- Root chfn/chsh in the e2e suite unaffected (root bypasses the restrictions).
