### PR TITLE
usermod: reject a rename onto an existing login, accept dated -e

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `usermod -l` refuses a login name that already exists (exit 9). Renaming
+  onto an existing account produced two entries with the same name in
+  `/etc/passwd` and `/etc/shadow` — `usermod -l root alice` gave a second
+  `root` (#242)
+- `usermod -e` accepts the `YYYY-MM-DD` form its man page documents, not only
+  days since the epoch, so `usermod -e 2030-01-01` (what Ansible and most
+  scripts pass) works. The date is parsed before anything is written, so an
+  invalid one no longer leaves an already-committed passwd change behind.
+  `useradd` and `usermod` now share one calendar implementation in
+  `shadow-core::date` (#242)
 - `userdel` now removes the user's private group (the `USERGROUPS_ENAB` group
   named after the login) when it has no other members, purges the user's
   `/etc/subuid` and `/etc/subgid` ranges so a later same-named user does not

--- a/src/shadow-core/src/date.rs
+++ b/src/shadow-core/src/date.rs
@@ -1,0 +1,152 @@
+// This file is part of the shadow-rs package.
+//
+// For the full copyright and license information, please view the LICENSE
+// file that was distributed with this source code.
+
+//! Calendar arithmetic for the account-expiry and aging fields.
+//!
+//! `/etc/shadow` stores those fields as days since the Unix epoch, while the
+//! tools accept the `YYYY-MM-DD` form their man pages document. Both live
+//! here so `useradd`, `usermod` and `chage` agree on what a date is.
+
+use crate::error::ShadowError;
+
+/// Days since the Unix epoch (1970-01-01) for a Gregorian date.
+///
+/// Algorithm from <https://howardhinnant.github.io/date_algorithms.html>.
+#[must_use]
+pub fn days_from_civil(year: i64, month: i64, day: i64) -> i64 {
+    let y = if month <= 2 { year - 1 } else { year };
+    let m = if month <= 2 { month + 9 } else { month - 3 };
+
+    let era = y / 400;
+    let yoe = y - era * 400;
+    let doy = (153 * m + 2) / 5 + day - 1;
+    let doe = yoe * 365 + yoe / 4 - yoe / 100 + doy;
+    era * 146_097 + doe - 719_468
+}
+
+/// Whether `year` is a leap year in the Gregorian calendar.
+#[must_use]
+pub fn is_leap_year(year: i64) -> bool {
+    (year % 4 == 0 && year % 100 != 0) || year % 400 == 0
+}
+
+/// Number of days in a 1-indexed `month` of `year`; 0 for an invalid month.
+#[must_use]
+pub fn days_in_month(year: i64, month: i64) -> i64 {
+    match month {
+        1 | 3 | 5 | 7 | 8 | 10 | 12 => 31,
+        4 | 6 | 9 | 11 => 30,
+        2 => {
+            if is_leap_year(year) {
+                29
+            } else {
+                28
+            }
+        }
+        _ => 0,
+    }
+}
+
+/// Parse an account-expiry argument into days since the epoch.
+///
+/// Accepts the `YYYY-MM-DD` form the man pages document, an empty string or
+/// `-1` meaning "no expiry" (`None`), and a bare non-negative integer already
+/// expressed in days since the epoch. Impossible dates (month 13, 31 April,
+/// 29 February in a common year) are rejected rather than normalised.
+///
+/// # Errors
+///
+/// Returns `ShadowError::Validation` describing the malformed value.
+pub fn parse_expire_date(s: &str) -> Result<Option<i64>, ShadowError> {
+    if s.is_empty() || s == "-1" {
+        return Ok(None);
+    }
+
+    // A bare integer is already days since the epoch.
+    if !s.contains('-') {
+        return s.parse::<i64>().map(Some).map_err(|_| {
+            ShadowError::Validation(
+                format!("invalid date '{s}' (expected YYYY-MM-DD or days since epoch)").into(),
+            )
+        });
+    }
+
+    let invalid =
+        || ShadowError::Validation(format!("invalid date '{s}' (expected YYYY-MM-DD)").into());
+
+    let parts: Vec<&str> = s.split('-').collect();
+    if parts.len() != 3 {
+        return Err(invalid());
+    }
+    let year: i64 = parts[0].parse().map_err(|_| invalid())?;
+    let month: i64 = parts[1].parse().map_err(|_| invalid())?;
+    let day: i64 = parts[2].parse().map_err(|_| invalid())?;
+
+    if !(1..=12).contains(&month) || year < 1970 {
+        return Err(ShadowError::Validation(
+            format!("invalid date '{s}' (expected YYYY-MM-DD with valid ranges)").into(),
+        ));
+    }
+
+    let max_day = days_in_month(year, month);
+    if !(1..=max_day).contains(&day) {
+        return Err(ShadowError::Validation(
+            format!("invalid date '{s}' (day {day} out of range for month {month})").into(),
+        ));
+    }
+
+    Ok(Some(days_from_civil(year, month, day)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_days_from_civil_known_dates() {
+        assert_eq!(days_from_civil(1970, 1, 1), 0);
+        assert_eq!(days_from_civil(1970, 1, 2), 1);
+        assert_eq!(days_from_civil(2000, 3, 1), 11017);
+        assert_eq!(days_from_civil(2024, 2, 29), 19782);
+    }
+
+    #[test]
+    fn test_leap_years_and_month_lengths() {
+        assert!(is_leap_year(2000) && is_leap_year(2024));
+        assert!(!is_leap_year(1900) && !is_leap_year(2023));
+        assert_eq!(days_in_month(2024, 2), 29);
+        assert_eq!(days_in_month(2023, 2), 28);
+        assert_eq!(days_in_month(2023, 4), 30);
+        assert_eq!(days_in_month(2023, 13), 0);
+    }
+
+    #[test]
+    fn test_parse_expire_date_forms() {
+        assert_eq!(parse_expire_date("").unwrap(), None);
+        assert_eq!(parse_expire_date("-1").unwrap(), None);
+        assert_eq!(parse_expire_date("2024-02-29").unwrap(), Some(19782));
+        // A bare integer is already days since the epoch.
+        assert_eq!(parse_expire_date("19782").unwrap(), Some(19782));
+    }
+
+    #[test]
+    fn test_parse_expire_date_rejects_impossible_dates() {
+        for bad in [
+            "2023-02-29",
+            "2024-13-01",
+            "2024-04-31",
+            "2024-00-10",
+            "1969-01-01",
+            "2024-02",
+            "not-a-date",
+            "2024-ab-01",
+        ] {
+            assert!(
+                parse_expire_date(bad).is_err(),
+                "'{bad}' should be rejected"
+            );
+        }
+    }
+}

--- a/src/shadow-core/src/lib.rs
+++ b/src/shadow-core/src/lib.rs
@@ -9,6 +9,7 @@
 //! validation, and platform integration (PAM, `nscd`, `SELinux`, audit).
 
 pub mod cli;
+pub mod date;
 pub mod error;
 pub mod os_error;
 pub mod passwd;

--- a/src/uu/useradd/src/useradd.rs
+++ b/src/uu/useradd/src/useradd.rs
@@ -176,80 +176,7 @@ struct UseraddOptions {
 ///
 /// Returns `None` for empty strings or `-1` (which means "no expiry").
 fn parse_expire_date(s: &str) -> Result<Option<i64>, UseraddError> {
-    if s.is_empty() || s == "-1" {
-        return Ok(None);
-    }
-
-    let parts: Vec<&str> = s.split('-').collect();
-    if parts.len() != 3 {
-        return Err(UseraddError::BadArgument(format!(
-            "invalid date '{s}' (expected YYYY-MM-DD)"
-        )));
-    }
-
-    let year: i64 = parts[0].parse().map_err(|_| {
-        UseraddError::BadArgument(format!("invalid date '{s}' (expected YYYY-MM-DD)"))
-    })?;
-    let month: i64 = parts[1].parse().map_err(|_| {
-        UseraddError::BadArgument(format!("invalid date '{s}' (expected YYYY-MM-DD)"))
-    })?;
-    let day: i64 = parts[2].parse().map_err(|_| {
-        UseraddError::BadArgument(format!("invalid date '{s}' (expected YYYY-MM-DD)"))
-    })?;
-
-    if !(1..=12).contains(&month) || year < 1970 {
-        return Err(UseraddError::BadArgument(format!(
-            "invalid date '{s}' (expected YYYY-MM-DD with valid ranges)"
-        )));
-    }
-
-    let max_day = days_in_month(year, month);
-    if !(1..=max_day).contains(&day) {
-        return Err(UseraddError::BadArgument(format!(
-            "invalid date '{s}' (day {day} out of range for month {month})"
-        )));
-    }
-
-    // Convert to days since epoch using a simple calendar calculation.
-    // This is sufficient for the date ranges used by shadow-utils.
-    let days = days_since_epoch(year, month, day);
-    Ok(Some(days))
-}
-
-/// Calculate days since Unix epoch (1970-01-01) for a given date.
-///
-/// Uses the algorithm from <https://howardhinnant.github.io/date_algorithms.html>.
-fn days_since_epoch(year: i64, month: i64, day: i64) -> i64 {
-    let y = if month <= 2 { year - 1 } else { year };
-    let m = if month <= 2 { month + 9 } else { month - 3 };
-
-    let era = y / 400;
-    let yoe = y - era * 400;
-    let doy = (153 * m + 2) / 5 + day - 1;
-    let doe = yoe * 365 + yoe / 4 - yoe / 100 + doy;
-    era * 146_097 + doe - 719_468
-}
-
-/// Whether `year` is a leap year in the Gregorian calendar.
-fn is_leap_year(year: i64) -> bool {
-    (year % 4 == 0 && year % 100 != 0) || year % 400 == 0
-}
-
-/// Number of days in a given month (1-indexed) for `year`.
-fn days_in_month(year: i64, month: i64) -> i64 {
-    match month {
-        1 | 3 | 5 | 7 | 8 | 10 | 12 => 31,
-        4 | 6 | 9 | 11 => 30,
-        2 => {
-            if is_leap_year(year) {
-                29
-            } else {
-                28
-            }
-        }
-        // Month range is already validated before calling this function.
-        _ => 0,
-    }
+    shadow_core::date::parse_expire_date(s).map_err(|e| UseraddError::BadArgument(e.to_string()))
 }
 
 /// Current date as days since epoch — delegates to shadow-core.
@@ -1497,33 +1424,6 @@ mod tests {
     #[test]
     fn test_parse_expire_date_apr_30() {
         assert!(parse_expire_date("2025-04-30").is_ok());
-    }
-
-    #[test]
-    fn test_is_leap_year() {
-        assert!(is_leap_year(2000));
-        assert!(is_leap_year(2024));
-        assert!(!is_leap_year(1900));
-        assert!(!is_leap_year(2023));
-    }
-
-    #[test]
-    fn test_days_in_month_values() {
-        assert_eq!(days_in_month(2025, 1), 31);
-        assert_eq!(days_in_month(2025, 2), 28);
-        assert_eq!(days_in_month(2024, 2), 29);
-        assert_eq!(days_in_month(2025, 4), 30);
-        assert_eq!(days_in_month(2025, 12), 31);
-    }
-
-    #[test]
-    fn test_days_since_epoch_known_dates() {
-        // 1970-01-01 = day 0
-        assert_eq!(days_since_epoch(1970, 1, 1), 0);
-        // 2000-01-01 = day 10957
-        assert_eq!(days_since_epoch(2000, 1, 1), 10957);
-        // 1970-01-02 = day 1
-        assert_eq!(days_since_epoch(1970, 1, 2), 1);
     }
 
     // -----------------------------------------------------------------------

--- a/src/uu/usermod/src/usermod.rs
+++ b/src/uu/usermod/src/usermod.rs
@@ -47,6 +47,7 @@ enum UsermodError {
     BadArgument(String),
     UserNotFound(String),
     UidInUse(String),
+    NameInUse(String),
 }
 
 impl fmt::Display for UsermodError {
@@ -55,7 +56,8 @@ impl fmt::Display for UsermodError {
             Self::CantUpdate(msg)
             | Self::BadArgument(msg)
             | Self::UserNotFound(msg)
-            | Self::UidInUse(msg) => f.write_str(msg),
+            | Self::UidInUse(msg)
+            | Self::NameInUse(msg) => f.write_str(msg),
         }
     }
 }
@@ -69,6 +71,7 @@ impl UError for UsermodError {
             Self::BadArgument(_) => 3,
             Self::UserNotFound(_) => 6,
             Self::UidInUse(_) => 4,
+            Self::NameInUse(_) => 9,
         }
     }
 }
@@ -114,6 +117,17 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         }
     }
 
+    // Parse the expiry date before anything is written, so a malformed value
+    // cannot leave the passwd change committed and the shadow change not.
+    // usermod(8) documents YYYY-MM-DD; days since the epoch stays accepted.
+    let expire_date = match matches.get_one::<String>(options::EXPIREDATE) {
+        Some(exp) => Some(
+            shadow_core::date::parse_expire_date(exp)
+                .map_err(|e| UsermodError::BadArgument(e.to_string()))?,
+        ),
+        None => None,
+    };
+
     // Modify /etc/passwd.
     let passwd_path = root.passwd_path();
     let lock = FileLock::acquire(&passwd_path)
@@ -156,7 +170,18 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let new_login = matches.get_one::<String>(options::LOGIN);
     if let Some(new_name) = new_login {
         validate::validate_username(new_name)
-            .map_err(|e| UsermodError::CantUpdate(format!("invalid login name: {e}")))?;
+            .map_err(|e| UsermodError::BadArgument(format!("invalid login name: {e}")))?;
+        // usermod(8) exit 9: the new name must not already be taken, or the
+        // rename would produce two entries with the same login.
+        if entries
+            .iter()
+            .any(|e| e.name == *new_name && e.name != *login)
+        {
+            drop(lock);
+            return Err(
+                UsermodError::NameInUse(format!("user '{new_name}' already exists")).into(),
+            );
+        }
         entries[idx].name.clone_from(new_name);
     }
 
@@ -184,7 +209,6 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let shadow_path = root.shadow_path();
     let do_lock = matches.get_flag(options::LOCK);
     let do_unlock = matches.get_flag(options::UNLOCK);
-    let expire = matches.get_one::<String>(options::EXPIREDATE);
     let inactive = matches.get_one::<i64>(options::INACTIVE);
     let new_password = matches.get_one::<String>(options::PASSWORD);
 
@@ -192,7 +216,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     if shadow_path.exists()
         && (do_lock
             || do_unlock
-            || expire.is_some()
+            || expire_date.is_some()
             || inactive.is_some()
             || new_password.is_some()
             || login_changing)
@@ -217,16 +241,8 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         if do_unlock {
             s.unlock();
         }
-        if let Some(exp) = expire {
-            s.expire_date = if exp == "-1" || exp.is_empty() {
-                None
-            } else {
-                Some(exp.parse::<i64>().map_err(|_| {
-                    UsermodError::CantUpdate(format!(
-                        "invalid expire date '{exp}' (expected days since epoch)"
-                    ))
-                })?)
-            };
+        if let Some(parsed) = expire_date {
+            s.expire_date = parsed;
         }
         if let Some(&i) = inactive {
             s.inactive_days = if i < 0 { None } else { Some(i) };

--- a/tests/by-util/test_usermod.rs
+++ b/tests/by-util/test_usermod.rs
@@ -478,3 +478,76 @@ fn test_set_password_preserves_other_fields() {
     assert_eq!(fields.len(), 9, "shadow entry should have exactly 9 fields");
     assert_eq!(fields[8], "", "reserved field should be empty");
 }
+
+// ---------------------------------------------------------------------------
+// usermod(8): rename collisions and date formats
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_rename_to_existing_login_is_rejected() {
+    if common::skip_unless_root() {
+        return;
+    }
+
+    let dir = setup_prefix(
+        "root:x:0:0:root:/root:/bin/bash\n\
+         alice:x:1000:1000:Alice:/home/alice:/bin/bash\n",
+        "root:*:19500:0:99999:7:::\nalice:$6$h:19500:0:99999:7:::\n",
+        "alice:x:1000:\n",
+    );
+
+    let code = run_with_prefix(&dir, &["-l", "root", "alice"]);
+    assert_eq!(code, 9, "renaming onto an existing login must exit 9");
+
+    let passwd = read_passwd(&dir);
+    assert_eq!(
+        passwd.matches("root:x:0:").count(),
+        1,
+        "there must still be exactly one root entry, got: {passwd}"
+    );
+    assert!(passwd.contains("alice:x:1000:"), "alice must be unchanged");
+}
+
+#[test]
+fn test_expiredate_accepts_iso_date() {
+    if common::skip_unless_root() {
+        return;
+    }
+
+    let dir = setup_prefix(
+        "alice:x:1000:1000:Alice:/home/alice:/bin/bash\n",
+        "alice:$6$h:19500:0:99999:7:::\n",
+        "alice:x:1000:\n",
+    );
+
+    // 2024-02-29 is 19782 days after the epoch.
+    let code = run_with_prefix(&dir, &["-e", "2024-02-29", "alice"]);
+    assert_eq!(code, 0, "YYYY-MM-DD must be accepted");
+    assert!(
+        read_shadow(&dir).contains(":19782:"),
+        "expiry should be stored as days since epoch, got: {}",
+        read_shadow(&dir)
+    );
+}
+
+#[test]
+fn test_bad_expiredate_changes_nothing() {
+    if common::skip_unless_root() {
+        return;
+    }
+
+    let dir = setup_prefix(
+        "alice:x:1000:1000:Alice:/home/alice:/bin/bash\n",
+        "alice:$6$h:19500:0:99999:7:::\n",
+        "alice:x:1000:\n",
+    );
+    let before = read_passwd(&dir);
+
+    let code = run_with_prefix(&dir, &["-c", "New Name", "-e", "2023-02-29", "alice"]);
+    assert_eq!(code, 3, "an impossible date is a bad argument");
+    assert_eq!(
+        read_passwd(&dir),
+        before,
+        "no field may be committed when a later argument is invalid"
+    );
+}


### PR DESCRIPTION
Part of #242 — the rename-collision integrity bug, the `-e` format, and the write-before-validate ordering. The remaining flag gaps (`-m`, `-o`, `-r`, `-G ""`, gshadow sync, `-l`+`-G` interaction) stay on the issue.

## `usermod -l` could duplicate an account

`-l` validated the new name's syntax but never checked it was free. `usermod -l root alice` produced **two entries named `root`** in `/etc/passwd` (and in `/etc/shadow`), which every consumer then resolves ambiguously. It now exits **9**, the code `usermod(8)` documents for a login already in use, and nothing is written.

## `-e` rejected the documented date format

`-e` only parsed days since the epoch, so `usermod -e 2030-01-01` — the form the man page documents, and what Ansible's `user: expires:` and most scripts pass — failed with "expected days since epoch". It now accepts `YYYY-MM-DD`, `-1`/empty for no expiry, and a bare integer.

The date is parsed **before** `/etc/passwd` is written, so `usermod -c X -e <bad date>` no longer commits the GECOS change and then fails.

## One calendar, not three

`useradd`, `usermod` and `chage` each carried their own date arithmetic. The Gregorian conversion and the expiry parser now live in `shadow_core::date`; `useradd` calls it and drops its copies of `days_since_epoch`, `is_leap_year` and `days_in_month` (their tests move with them). `chage` is the remaining copy, noted on #248.

## Verified (Debian image, as root)

- `usermod -l root alice` → exit 9, exactly one `root` entry, `alice` untouched.
- `usermod -e 2024-02-29 alice` → exit 0, shadow stores `19782`.
- `usermod -c "New Name" -e 2023-02-29 alice` → exit 3 and `/etc/passwd` byte-for-byte unchanged (2023 is not a leap year).
- `fmt`, `clippy -D warnings` ±`pam`, `cargo test --workspace` green; new `shadow_core::date` tests (known dates, leap years, every impossible-date form), usermod 22/22, useradd 28/28.
