### PR TITLE
ci: run the root suite on pull requests, fix the trace guard's false positives

### DIFF
--- a/.github/scripts/no-ai-traces.sh
+++ b/.github/scripts/no-ai-traces.sh
@@ -16,14 +16,19 @@ BASE="${1:-origin/main}"
 status=0
 
 # Tool names that must not appear in commit messages, PR text, or added lines.
-# Word-boundaried to avoid matching unrelated substrings.
-TOOLS='claude|copilot|anthropic|chatgpt|openai|gemini|codex|llm|ai[ -]generated|ai[ -]assisted'
+# Genuinely word-boundaried: without \b, "llm" matched "smallmap" and
+# "anthropic" matched "philanthropic", failing unrelated changes. The trailing
+# alternatives carry their own boundaries.
+TOOLS='\b(claude|copilot|anthropic|chatgpt|openai|gemini|codex|llms?)\b'
+TOOLS="$TOOLS"'|\bgpt-?[0-9o]|\bai[ -](generated|assisted)\b|co-authored-by:.*\[bot\]'
 
-# Paths deliberately exempt from the content scan:
+# Paths deliberately exempt from the added-lines scan:
 #   - this script (it necessarily contains the patterns)
 #   - the clean-room audit records, which must disclose their own methodology
 #     to be usable as compliance evidence
-EXEMPT='^(\.github/scripts/no-ai-traces\.sh|\.github/workflows/ci\.yml|docs/CLEAN-ROOM-AUDIT-.*\.md)$'
+#   - CONTRIBUTING.md, which states the project's policy on these tools and so
+#     must be able to name them
+EXEMPT='^(\.github/scripts/no-ai-traces\.sh|CONTRIBUTING\.md|docs/CLEAN-ROOM-AUDIT-.*\.md)$'
 
 fail() { printf '::error::%s\n' "$1"; status=1; }
 

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -9,6 +9,11 @@ on:
     paths:
       - "**/Cargo.toml"
       - "**/Cargo.lock"
+permissions:
+  contents: read
+  checks: write
+  issues: write
+
 jobs:
   audit:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
   # Ride out transient crates.io/registry blips instead of failing the job.
@@ -104,7 +107,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@1.94.0
       - uses: Swatinem/rust-cache@v2
       - run: sudo apt-get update && sudo apt-get install -y libpam0g-dev libselinux1-dev libaudit-dev libcrypt-dev
-      - run: cargo check --workspace
+      - run: cargo check --workspace --all-targets
 
   deny:
     name: Cargo Deny
@@ -137,7 +140,9 @@ jobs:
 
   test-docker:
     name: Test (${{ matrix.target }})
-    if: github.event_name == 'push'
+    # Runs on pull requests as well: roughly three quarters of the integration
+    # suite is root-only and skips silently off-root, so a host-only run proves
+    # little. Each distro takes a couple of minutes.
     runs-on: ubuntu-latest
     strategy:
       # One distro's transient registry timeout must not cancel the others.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,7 +98,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "473c7e07f409a8d772161724aa8db6a765a2532a70f9667eeb7b49d3d02fbdca"
 dependencies = [
  "clap_builder",
- "clap_derive",
 ]
 
 [[package]]
@@ -121,18 +120,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3be2ad0423bdbbb0e25bc89add796f3559706d4a95e1bc98e4d9662a957b6a19"
 dependencies = [
  "clap",
-]
-
-[[package]]
-name = "clap_derive"
-version = "4.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d012d2b9d65aca7f18f4d9878a045bc17899bba951561ba5ec3c2ba1eed9a061"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "syn 3.0.3",
 ]
 
 [[package]]
@@ -273,12 +260,6 @@ name = "glob"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
-
-[[package]]
-name = "heck"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "intl-memoizer"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ categories = ["command-line-utilities"]
 shadow-core = { path = "src/shadow-core", version = "0.2.2" }
 
 # CLI
-clap = { version = "4", features = ["derive", "wrap_help"] }
+clap = { version = "4", features = ["wrap_help"] }
 clap_complete = "4"
 
 # uutils integration

--- a/deny.toml
+++ b/deny.toml
@@ -17,7 +17,8 @@ allow = [
     "CC0-1.0",
     "Unicode-3.0",
     "Zlib",
-    "MPL-2.0",
+    # No MPL-2.0: it is file-level copyleft, and this project ships MIT only.
+    # A dependency that needs it is a decision, not a default.
 ]
 confidence-threshold = 0.8
 
@@ -27,14 +28,17 @@ wildcards = "allow"
 highlight = "all"
 
 # Known duplicate dependencies from transitive deps.
-# Update this list when bumping clap/uucore.
 skip = [
-    # various crates
-    { name = "syn", version = "2.0.117", reason = "new major release v3 has been released" },
+    # Two independent transitive chains pull incompatible majors and neither is
+    # ours to move: syn 3 via uucore -> fluent -> unic-langid -> tinystr ->
+    # displaydoc, syn 2 via landlock -> enumflags2 -> enumflags2_derive.
+    { name = "syn", version = "2", reason = "landlock's enumflags2_derive still uses syn 2 while uucore's displaydoc uses syn 3" },
 ]
 
 [sources]
-unknown-registry = "warn"
-unknown-git = "warn"
+# A crate from anywhere but crates.io is a supply-chain decision, not a
+# warning to scroll past.
+unknown-registry = "deny"
+unknown-git = "deny"
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
 allow-git = []


### PR DESCRIPTION
Part of #250 — the contained CI, guard and dependency items. The test-architecture work (spawn the binary and assert on output, remove the tautological tests, one test binary) stays on the issue.

## The root suite did not run on pull requests

Roughly three quarters of the integration suite is root-only and `return`s silently when not root — libtest reports those as `ok`. The only job running as root was the Docker matrix, gated on `push`. So a pull request effectively exercised a quarter of the suite, and anything root-only surfaced only after merge. The matrix now runs on pull requests too; each distro is a couple of minutes (the last runs were 1m47–3m33). This PR is the first to be checked that way.

The MSRV job now checks `--all-targets`, so test code is covered at the minimum supported version too.

## Token permissions

Neither workflow declared `permissions`, so both ran with the default token scope. `ci.yml` is now `contents: read`; `audit.yml` gets the `checks`/`issues` writes its action actually needs.

## The tooling-artifact guard had false positives

The script's own comment claimed its patterns were word-boundaried. They were not — several matched as substrings inside ordinary identifiers and English words, so any change touching such a word failed the build. The alternation is now anchored with `\b`, and two forms that slipped through are covered: a model name carrying a version suffix, and the co-author trailer a bot appends to a commit.

`CONTRIBUTING.md` becomes exempt from the added-lines scan — it states the project's policy on such tools, so it has to be able to name them. The CI workflow no longer needs its exemption.

Verified by running the script and the pattern directly against a table of cases: the five substrings that used to match no longer do, and six genuine artifact forms all still match. (The guard also caught the first draft of this very PR, whose commit message and description spelled the patterns out — working as designed; the text was reworded rather than the guard weakened.)

## Dependencies

Nothing in the tree derives clap's `Parser`/`Args`/`Subcommand`/`ValueEnum`, so the `derive` feature only added `clap_derive` and `heck` to the graph; dropping it removes 19 lines from `Cargo.lock`. It is **not** the cause of the `syn` 2/3 duplicate, as the issue supposed — that comes from two transitive chains we do not control (`syn` 3 via `uucore → fluent → displaydoc`, `syn` 2 via `landlock → enumflags2`). The `deny.toml` skip now records that, and matches any `2.x` instead of one stale patch version that no longer existed in the lockfile.

`MPL-2.0` leaves the license allowlist: it is file-level copyleft and this project ships MIT only, so a dependency needing it should be a decision rather than a pre-approval. A crate from outside crates.io is now denied rather than warned about.

## Verified (Debian image)

`fmt`, `clippy -D warnings` ±`pam`, `cargo test --workspace` green; `cargo deny check` → *advisories ok, bans ok, licenses ok, sources ok* with the tightened policy; `cargo tree` confirms `clap_derive` is gone.
