### PR TITLE
chage, passwd: bound the aging fields and let -1 clear them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- The password-aging fields reject a negative day count other than `-1`.
+  `chage -M -5` and `passwd -x -5` stored the value verbatim and left a
+  nonsensical policy behind; they now exit 2 and 6 respectively, the codes
+  their man pages give for an invalid option argument. `passwd -n/-x/-w/-i`
+  also accept `-1` at last (clap rejected the leading hyphen) and treat it as
+  "clear the field", the way `chage` already did (#248)
 - `chpasswd` hashes before taking the `/etc/shadow` lock. A batch of yescrypt
   or high-`rounds=` hashes held the lock, with signals blocked, for the whole
   run (#248)

--- a/src/uu/chage/src/chage.rs
+++ b/src/uu/chage/src/chage.rs
@@ -64,6 +64,8 @@ enum ChageError {
     FileBusy(String),
     /// Exit 15 — shadow entry not found for user.
     ShadowNotFound(String),
+    /// Exit 2 — a numeric option was given a value outside its range.
+    InvalidArgument(String),
 }
 
 impl fmt::Display for ChageError {
@@ -72,7 +74,8 @@ impl fmt::Display for ChageError {
             Self::PermissionDenied(msg)
             | Self::UnexpectedFailure(msg)
             | Self::FileBusy(msg)
-            | Self::ShadowNotFound(msg) => f.write_str(msg),
+            | Self::ShadowNotFound(msg)
+            | Self::InvalidArgument(msg) => f.write_str(msg),
         }
     }
 }
@@ -86,6 +89,7 @@ impl UError for ChageError {
             Self::UnexpectedFailure(_) => 3,
             Self::FileBusy(_) => 5,
             Self::ShadowNotFound(_) => 15,
+            Self::InvalidArgument(_) => 2,
         }
     }
 }
@@ -285,6 +289,25 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
             "no aging fields specified (interactive mode not yet supported)".into(),
         )
         .into());
+    }
+
+    // The aging fields count days: only -1, meaning "unset", may be negative.
+    // A value such as -5 was accepted and written, and every later reader then
+    // saw a nonsensical policy.
+    for (value, flag) in [
+        (inactive, "--inactive"),
+        (mindays, "--mindays"),
+        (maxdays, "--maxdays"),
+        (warndays, "--warndays"),
+    ] {
+        if let Some(&days) = value
+            && days < -1
+        {
+            return Err(ChageError::InvalidArgument(format!(
+                "invalid value '{days}' for {flag}: expected -1 or a day count"
+            ))
+            .into());
+        }
     }
 
     // Parse date-valued arguments before acquiring locks.

--- a/src/uu/passwd/src/passwd.rs
+++ b/src/uu/passwd/src/passwd.rs
@@ -78,6 +78,8 @@ enum PasswdError {
     /// Exit 10 — PAM returned an error.
     #[cfg_attr(not(feature = "pam"), allow(dead_code))]
     PamError(String),
+    /// Exit 6 — a numeric option was given a value outside its range.
+    InvalidArgument(String),
 }
 
 impl fmt::Display for PasswdError {
@@ -87,7 +89,8 @@ impl fmt::Display for PasswdError {
             | Self::UnexpectedFailure(msg)
             | Self::FileMissing(msg)
             | Self::FileBusy(msg)
-            | Self::PamError(msg) => f.write_str(msg),
+            | Self::PamError(msg)
+            | Self::InvalidArgument(msg) => f.write_str(msg),
         }
     }
 }
@@ -102,6 +105,7 @@ impl UError for PasswdError {
             Self::FileMissing(_) => 4,
             Self::FileBusy(_) => 5,
             Self::PamError(_) => 10,
+            Self::InvalidArgument(_) => 6,
         }
     }
 }
@@ -229,6 +233,20 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let inactive = matches.get_one::<i64>(options::INACTIVE).copied();
     let has_aging = min.is_some() || max.is_some() || warn.is_some() || inactive.is_some();
 
+    // The aging fields count days: only -1, meaning "unset", may be negative.
+    // passwd(1) documents `-x -1` for "no maximum"; anything below that was
+    // stored verbatim and left a nonsensical policy behind.
+    for (value, flag) in [(min, "-n"), (max, "-x"), (warn, "-w"), (inactive, "-i")] {
+        if let Some(days) = value
+            && days < -1
+        {
+            return Err(PasswdError::InvalidArgument(format!(
+                "invalid value '{days}' for {flag}: expected -1 or a day count"
+            ))
+            .into());
+        }
+    }
+
     // Admin operations (lock/unlock/delete/expire/aging) require the real
     // caller to be root. Non-root users can only change their own password
     // (the default PAM path below).
@@ -267,18 +285,20 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
                 entry.expire();
             }
 
-            // Apply aging fields.
+            // Apply aging fields. -1 clears the field (passwd(1) documents
+            // `-x -1` as "no maximum"), matching how chage writes them.
+            let field = |v: i64| if v == -1 { None } else { Some(v) };
             if let Some(v) = min {
-                entry.min_age = Some(v);
+                entry.min_age = field(v);
             }
             if let Some(v) = max {
-                entry.max_age = Some(v);
+                entry.max_age = field(v);
             }
             if let Some(v) = warn {
-                entry.warn_days = Some(v);
+                entry.warn_days = field(v);
             }
             if let Some(v) = inactive {
-                entry.inactive_days = Some(v);
+                entry.inactive_days = field(v);
             }
 
             Ok(())
@@ -353,6 +373,7 @@ pub fn uu_app() -> Command {
                 .long("inactive")
                 .help("disable the password INACTIVE days past its expiry")
                 .value_name("INACTIVE")
+                .allow_hyphen_values(true)
                 .value_parser(clap::value_parser!(i64)),
         )
         .arg(
@@ -369,6 +390,7 @@ pub fn uu_app() -> Command {
                 .long("mindays")
                 .help("require at least MIN_DAYS between password changes")
                 .value_name("MIN_DAYS")
+                .allow_hyphen_values(true)
                 .value_parser(clap::value_parser!(i64)),
         )
         .arg(
@@ -421,6 +443,7 @@ pub fn uu_app() -> Command {
                 .long("warndays")
                 .help("warn the user WARN_DAYS before password expiry")
                 .value_name("WARN_DAYS")
+                .allow_hyphen_values(true)
                 .value_parser(clap::value_parser!(i64)),
         )
         .arg(
@@ -429,6 +452,7 @@ pub fn uu_app() -> Command {
                 .long("maxdays")
                 .help("require a password change at least every MAX_DAYS")
                 .value_name("MAX_DAYS")
+                .allow_hyphen_values(true)
                 .value_parser(clap::value_parser!(i64)),
         )
         .arg(

--- a/tests/by-util/test_chage.rs
+++ b/tests/by-util/test_chage.rs
@@ -290,3 +290,25 @@ fn test_remove_expiredate() {
         "expire_date should be empty after removal, got: {content}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Aging-field bounds (chage(1))
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_negative_aging_values_are_rejected() {
+    if common::skip_unless_root() {
+        return;
+    }
+
+    // The range check runs before any file is opened, so this touches nothing
+    // even though chage has no prefix option: a day count may only be -1
+    // ("unset") or non-negative.
+    for flag in ["-m", "-M", "-W", "-I"] {
+        assert_eq!(
+            run(&["chage", flag, "-5", "no_such_user_for_chage_test"]),
+            2,
+            "{flag} -5 must be an invalid argument"
+        );
+    }
+}

--- a/tests/by-util/test_passwd.rs
+++ b/tests/by-util/test_passwd.rs
@@ -469,3 +469,43 @@ fn test_gnu_compat_lock_unlock() {
         "unlock should remove ! — got: {content}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Aging-field bounds (passwd(1))
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_maxdays_minus_one_clears_the_field() {
+    if common::skip_unless_root() {
+        return;
+    }
+
+    // passwd(1) documents `-x -1` as "no maximum": the field is cleared, not
+    // stored as the literal -1.
+    let dir = setup_prefix("alice:$6$hash:19500:0:99999:7:::\n");
+    let code = run_with_prefix(&dir, &["-x", "-1", "alice"]);
+    assert_eq!(code, 0, "-x -1 should be accepted");
+    assert!(
+        read_shadow(&dir).starts_with("alice:$6$hash:19500:0::7:"),
+        "max-age should be empty, got: {}",
+        read_shadow(&dir)
+    );
+}
+
+#[test]
+fn test_negative_aging_values_are_rejected() {
+    if common::skip_unless_root() {
+        return;
+    }
+
+    let dir = setup_prefix("alice:$6$hash:19500:0:99999:7:::\n");
+    let before = read_shadow(&dir);
+    for flag in ["-n", "-x", "-w", "-i"] {
+        assert_eq!(
+            run_with_prefix(&dir, &[flag, "-5", "alice"]),
+            6,
+            "{flag} -5 must be an invalid argument"
+        );
+    }
+    assert_eq!(read_shadow(&dir), before, "nothing may be written");
+}


### PR DESCRIPTION
Part of #248 — the aging-field bounds. `chage -l` output formatting, the chage exit-code mapping and `newgrp -` stay on the issue.

## Any negative day count was accepted and written

`-m/-M/-W/-I` (chage) and `-n/-x/-w/-i` (passwd) count days. Only `-1`, meaning "unset", is meaningful as a negative. Everything else was stored verbatim: `chage -M -5 alice` wrote `:-5:` into `/etc/shadow` and exited 0, leaving a policy no consumer can interpret. Both tools now reject a value below `-1` and exit **2** (chage) / **6** (passwd) — the codes their man pages give for an invalid argument to an option — before any file is opened.

## `passwd -x -1` could not even be typed

`passwd(1)` documents `-x -1` as "no maximum", but the four options lacked `allow_hyphen_values`, so clap rejected the leading hyphen before the tool saw it. They accept it now, and `-1` **clears** the field rather than being stored literally — which is what `chage` already wrote and what every reader expects.

## Verified (Debian image, as root)

- `passwd -x -1 alice` → exit 0 and the max-age field is empty (`alice:$6$hash:19500:0::7:`).
- `passwd -n|-x|-w|-i -5 alice` → exit 6 each, `/etc/shadow` byte-for-byte unchanged.
- `chage -m|-M|-W|-I -5 …` → exit 2 each (the check precedes any file access).
- `fmt`, `clippy -D warnings` ±`pam`, `cargo test --workspace` green; passwd 20/20, chage 14/14.
