### PR TITLE
shadow-core: stop deleting comments and NIS compat lines when rewriting account files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Rewriting an account file no longer deletes its comments, blank lines and
+  NIS compatibility lines. Every tool dropped them on read, so the first
+  `useradd`, `usermod`, `groupadd`… erased every comment in `/etc/passwd` and
+  `/etc/group`; and because `+user`, `+@netgroup` and `-user` do not parse as
+  records, on a host using `compat` in `nsswitch.conf` every tool failed
+  outright. Those lines are now preserved and each one stays anchored to the
+  entry it preceded, so a comment follows its account even when `pwck -s`
+  reorders the file (#241)
 - The lock loop no longer spins at 100% CPU when a stale `.lock` cannot be
   removed (e.g. made immutable), and a filesystem without hard links now fails
   immediately instead of waiting out the full 15-second timeout (#240)

--- a/src/shadow-core/src/group.rs
+++ b/src/shadow-core/src/group.rs
@@ -18,6 +18,7 @@ use std::path::Path;
 use std::str::FromStr;
 
 use crate::error::ShadowError;
+pub use crate::records::Layout;
 use crate::validate::{validate_field, validate_list_item};
 
 /// A single entry from `/etc/group`.
@@ -117,8 +118,9 @@ pub fn read_group_file(path: &Path) -> Result<Vec<GroupEntry>, ShadowError> {
 
     for line in reader.lines() {
         let line = line?;
-        let trimmed = line.trim_start();
-        if trimmed.is_empty() || trimmed.starts_with('#') {
+        // Comments, blank lines and NIS compat lines are not entries. Use
+        // read_*_with_layout when they must survive a rewrite.
+        if crate::records::is_raw_line(&line) {
             continue;
         }
         entries.push(line.parse()?);
@@ -138,6 +140,44 @@ pub fn write_group<W: Write>(entries: &[GroupEntry], mut writer: W) -> Result<()
         writeln!(writer, "{entry}")?;
     }
     Ok(())
+}
+
+impl crate::records::Named for GroupEntry {
+    fn name(&self) -> &str {
+        &self.name
+    }
+}
+
+/// Read `/etc/group` keeping comments, blank lines and NIS compat lines.
+///
+/// Returns the entries plus the [`crate::records::Layout`] that
+/// [`write_group_with_layout`] needs to put those lines back.
+///
+/// # Errors
+///
+/// Returns `ShadowError` if the file cannot be opened or an entry is malformed.
+pub fn read_group_with_layout(
+    path: &Path,
+) -> Result<(Vec<GroupEntry>, crate::records::Layout), ShadowError> {
+    crate::records::read_with_layout(path)
+}
+
+/// Write entries back, restoring the lines [`read_group_with_layout`] preserved.
+///
+/// # Errors
+///
+/// Returns `ShadowError` on a write failure or an entry that would corrupt the
+/// record format.
+pub fn write_group_with_layout<W: Write>(
+    entries: &[GroupEntry],
+    layout: &crate::records::Layout,
+    mut writer: W,
+) -> Result<(), ShadowError> {
+    crate::records::write_with_layout(entries, layout, &mut writer, |entry, w| {
+        entry.validate_fields()?;
+        writeln!(w, "{entry}")?;
+        Ok(())
+    })
 }
 
 #[cfg(test)]

--- a/src/shadow-core/src/gshadow.rs
+++ b/src/shadow-core/src/gshadow.rs
@@ -19,6 +19,7 @@ use std::path::Path;
 use std::str::FromStr;
 
 use crate::error::ShadowError;
+pub use crate::records::Layout;
 use crate::validate::{validate_field, validate_list_item};
 
 /// A single entry from `/etc/gshadow`.
@@ -127,8 +128,9 @@ pub fn read_gshadow_file(path: &Path) -> Result<Vec<GshadowEntry>, ShadowError> 
 
     for line in reader.lines() {
         let line = line?;
-        let trimmed = line.trim_start();
-        if trimmed.is_empty() || trimmed.starts_with('#') {
+        // Comments, blank lines and NIS compat lines are not entries. Use
+        // read_*_with_layout when they must survive a rewrite.
+        if crate::records::is_raw_line(&line) {
             continue;
         }
         entries.push(line.parse()?);
@@ -148,6 +150,44 @@ pub fn write_gshadow<W: Write>(entries: &[GshadowEntry], mut writer: W) -> Resul
         writeln!(writer, "{entry}")?;
     }
     Ok(())
+}
+
+impl crate::records::Named for GshadowEntry {
+    fn name(&self) -> &str {
+        &self.name
+    }
+}
+
+/// Read `/etc/gshadow` keeping comments, blank lines and NIS compat lines.
+///
+/// Returns the entries plus the [`crate::records::Layout`] that
+/// [`write_gshadow_with_layout`] needs to put those lines back.
+///
+/// # Errors
+///
+/// Returns `ShadowError` if the file cannot be opened or an entry is malformed.
+pub fn read_gshadow_with_layout(
+    path: &Path,
+) -> Result<(Vec<GshadowEntry>, crate::records::Layout), ShadowError> {
+    crate::records::read_with_layout(path)
+}
+
+/// Write entries back, restoring the lines [`read_gshadow_with_layout`] preserved.
+///
+/// # Errors
+///
+/// Returns `ShadowError` on a write failure or an entry that would corrupt the
+/// record format.
+pub fn write_gshadow_with_layout<W: Write>(
+    entries: &[GshadowEntry],
+    layout: &crate::records::Layout,
+    mut writer: W,
+) -> Result<(), ShadowError> {
+    crate::records::write_with_layout(entries, layout, &mut writer, |entry, w| {
+        entry.validate_fields()?;
+        writeln!(w, "{entry}")?;
+        Ok(())
+    })
 }
 
 #[cfg(test)]

--- a/src/shadow-core/src/lib.rs
+++ b/src/shadow-core/src/lib.rs
@@ -13,6 +13,7 @@ pub mod date;
 pub mod error;
 pub mod os_error;
 pub mod passwd;
+pub mod records;
 pub mod validate;
 
 #[cfg(feature = "shadow")]

--- a/src/shadow-core/src/passwd.rs
+++ b/src/shadow-core/src/passwd.rs
@@ -20,6 +20,7 @@ use std::path::Path;
 use std::str::FromStr;
 
 use crate::error::ShadowError;
+pub use crate::records::Layout;
 use crate::validate::validate_field;
 
 /// A single entry from `/etc/passwd`.
@@ -137,8 +138,9 @@ pub fn read_passwd_file(path: &Path) -> Result<Vec<PasswdEntry>, ShadowError> {
 
     for line in reader.lines() {
         let line = line?;
-        let trimmed = line.trim_start();
-        if trimmed.is_empty() || trimmed.starts_with('#') {
+        // Comments, blank lines and NIS compat lines are not entries. Use
+        // read_*_with_layout when they must survive a rewrite.
+        if crate::records::is_raw_line(&line) {
             continue;
         }
         // Parse the original untrimmed line to preserve field whitespace.
@@ -162,6 +164,44 @@ pub fn write_passwd<W: Write>(entries: &[PasswdEntry], mut writer: W) -> Result<
         writeln!(writer, "{entry}")?;
     }
     Ok(())
+}
+
+impl crate::records::Named for PasswdEntry {
+    fn name(&self) -> &str {
+        &self.name
+    }
+}
+
+/// Read `/etc/passwd` keeping comments, blank lines and NIS compat lines.
+///
+/// Returns the entries plus the [`crate::records::Layout`] that
+/// [`write_passwd_with_layout`] needs to put those lines back.
+///
+/// # Errors
+///
+/// Returns `ShadowError` if the file cannot be opened or an entry is malformed.
+pub fn read_passwd_with_layout(
+    path: &Path,
+) -> Result<(Vec<PasswdEntry>, crate::records::Layout), ShadowError> {
+    crate::records::read_with_layout(path)
+}
+
+/// Write entries back, restoring the lines [`read_passwd_with_layout`] preserved.
+///
+/// # Errors
+///
+/// Returns `ShadowError` on a write failure or an entry that would corrupt the
+/// record format.
+pub fn write_passwd_with_layout<W: Write>(
+    entries: &[PasswdEntry],
+    layout: &crate::records::Layout,
+    mut writer: W,
+) -> Result<(), ShadowError> {
+    crate::records::write_with_layout(entries, layout, &mut writer, |entry, w| {
+        entry.validate_fields()?;
+        writeln!(w, "{entry}")?;
+        Ok(())
+    })
 }
 
 #[cfg(test)]

--- a/src/shadow-core/src/records.rs
+++ b/src/shadow-core/src/records.rs
@@ -1,0 +1,270 @@
+// This file is part of the shadow-rs package.
+//
+// For the full copyright and license information, please view the LICENSE
+// file that was distributed with this source code.
+// spell-checker:ignore nsswitch netgroup
+
+//! Lossless reading and writing of the colon-separated account files.
+//!
+//! The parsers turn a file into a `Vec` of typed entries, which is what the
+//! tools want to work with. Everything that is *not* an entry — comments,
+//! blank lines, and the NIS compatibility lines `nsswitch.conf(5)` documents
+//! for `compat` mode (`+user`, `+@netgroup`, `-user`, a bare `+::::::`) — used
+//! to be dropped on read and therefore deleted the first time any tool
+//! rewrote the file. Worse, the compat lines did not parse, so on a host using
+//! `compat` every tool failed outright.
+//!
+//! [`read_with_layout`] returns the entries plus a [`Layout`] recording those
+//! lines and where they sat; [`write_with_layout`] puts them back. Each raw
+//! line is anchored to the **name of the entry it preceded**, not to a line
+//! number, so it stays with that entry even when the file is reordered (a
+//! comment above an account follows the account when `pwck -s` sorts) and
+//! survives entries being added or removed elsewhere.
+
+use std::fmt::Display;
+use std::io::{BufRead, Write};
+use std::path::Path;
+use std::str::FromStr;
+
+use crate::error::ShadowError;
+
+/// An entry that can be identified by name — the anchor a raw line uses.
+pub trait Named {
+    /// The entry's name (login or group name).
+    fn name(&self) -> &str;
+}
+
+/// Where a preserved raw line belongs.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum Anchor {
+    /// Immediately before the entry with this name.
+    Before(String),
+    /// After every entry.
+    End,
+}
+
+/// The non-entry lines of a record file, and where they belong.
+#[derive(Debug, Clone, Default)]
+pub struct Layout {
+    items: Vec<(Anchor, String)>,
+}
+
+impl Layout {
+    /// Whether the file carried anything besides entries.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.items.is_empty()
+    }
+}
+
+/// Whether a line is preserved verbatim rather than parsed.
+///
+/// Blank lines and `#` comments are obvious. A line whose first character is
+/// `+` or `-` is an NIS compat entry: `nsswitch.conf(5)` documents them for
+/// `compat` mode, they are not in the record format, and no username or group
+/// name may start with either character. Readers that return only entries skip
+/// these lines; [`read_with_layout`] keeps them.
+#[must_use]
+pub fn is_raw_line(line: &str) -> bool {
+    let trimmed = line.trim_start();
+    trimmed.is_empty() || trimmed.starts_with('#') || trimmed.starts_with(['+', '-'])
+}
+
+/// Read a record file, keeping the lines that are not entries.
+///
+/// # Errors
+///
+/// Returns `ShadowError` if the file cannot be opened or an entry line is
+/// malformed.
+pub fn read_with_layout<T>(path: &Path) -> Result<(Vec<T>, Layout), ShadowError>
+where
+    T: FromStr<Err = ShadowError> + Named,
+{
+    let file = std::fs::File::open(path).map_err(|e| ShadowError::IoPath(e, path.to_owned()))?;
+    let reader = std::io::BufReader::new(file);
+
+    let mut entries: Vec<T> = Vec::new();
+    let mut layout = Layout::default();
+    let mut pending: Vec<String> = Vec::new();
+
+    for line in reader.lines() {
+        let line = line?;
+        if is_raw_line(&line) {
+            pending.push(line);
+            continue;
+        }
+        // Parse the original untrimmed line to preserve field whitespace.
+        let entry: T = line.parse()?;
+        for raw in pending.drain(..) {
+            layout
+                .items
+                .push((Anchor::Before(entry.name().to_owned()), raw));
+        }
+        entries.push(entry);
+    }
+
+    for raw in pending {
+        layout.items.push((Anchor::End, raw));
+    }
+
+    Ok((entries, layout))
+}
+
+/// Write entries back, restoring the preserved lines around them.
+///
+/// A raw line whose anchor entry no longer exists is not dropped: it is
+/// written after the entries, so removing an account never silently deletes
+/// the comment that described it.
+///
+/// # Errors
+///
+/// Returns `ShadowError` on a write failure or if an entry holds a value that
+/// would corrupt the record (checked by the caller's writer).
+pub fn write_with_layout<T, W, F>(
+    entries: &[T],
+    layout: &Layout,
+    writer: &mut W,
+    mut write_entry: F,
+) -> Result<(), ShadowError>
+where
+    T: Display + Named,
+    W: Write,
+    F: FnMut(&T, &mut W) -> Result<(), ShadowError>,
+{
+    let mut emitted = vec![false; layout.items.len()];
+
+    for entry in entries {
+        for (i, (anchor, raw)) in layout.items.iter().enumerate() {
+            if !emitted[i] && *anchor == Anchor::Before(entry.name().to_owned()) {
+                writeln!(writer, "{raw}")?;
+                emitted[i] = true;
+            }
+        }
+        write_entry(entry, writer)?;
+    }
+
+    // End-anchored lines, then anything whose entry disappeared.
+    for (i, (anchor, raw)) in layout.items.iter().enumerate() {
+        if !emitted[i] && *anchor == Anchor::End {
+            writeln!(writer, "{raw}")?;
+            emitted[i] = true;
+        }
+    }
+    for (i, (_, raw)) in layout.items.iter().enumerate() {
+        if !emitted[i] {
+            writeln!(writer, "{raw}")?;
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fmt;
+
+    #[derive(Debug, PartialEq, Eq)]
+    struct Row {
+        name: String,
+        value: String,
+    }
+
+    impl Named for Row {
+        fn name(&self) -> &str {
+            &self.name
+        }
+    }
+
+    impl fmt::Display for Row {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            write!(f, "{}:{}", self.name, self.value)
+        }
+    }
+
+    impl FromStr for Row {
+        type Err = ShadowError;
+        fn from_str(s: &str) -> Result<Self, Self::Err> {
+            let (name, value) = s
+                .split_once(':')
+                .ok_or_else(|| ShadowError::Parse("missing ':'".into()))?;
+            Ok(Self {
+                name: name.to_string(),
+                value: value.to_string(),
+            })
+        }
+    }
+
+    fn render(entries: &[Row], layout: &Layout) -> String {
+        let mut out = Vec::new();
+        write_with_layout(entries, layout, &mut out, |e, w| {
+            writeln!(w, "{e}")?;
+            Ok(())
+        })
+        .expect("write");
+        String::from_utf8(out).expect("utf-8")
+    }
+
+    fn read(text: &str) -> (Vec<Row>, Layout) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("file");
+        std::fs::write(&path, text).expect("write");
+        read_with_layout::<Row>(&path).expect("read")
+    }
+
+    #[test]
+    fn test_round_trip_is_byte_identical() {
+        let text = "# leading comment\n\nalice:1\n# about bob\nbob:2\n\n# trailer\n";
+        let (entries, layout) = read(text);
+        assert_eq!(entries.len(), 2);
+        assert_eq!(render(&entries, &layout), text);
+    }
+
+    #[test]
+    fn test_nis_compat_lines_are_preserved_not_parsed() {
+        // These do not parse as records; before, every tool failed on them.
+        let text = "alice:1\n+@admins\n+::::::\n-guest\n";
+        let (entries, layout) = read(text);
+        assert_eq!(entries.len(), 1, "only alice is an entry");
+        assert_eq!(render(&entries, &layout), text);
+    }
+
+    #[test]
+    fn test_comment_follows_its_entry_when_reordered() {
+        let text = "# about zoe\nzoe:26\n# about amy\namy:1\n";
+        let (mut entries, layout) = read(text);
+        entries.sort_by(|a, b| a.name.cmp(&b.name));
+        assert_eq!(
+            render(&entries, &layout),
+            "# about amy\namy:1\n# about zoe\nzoe:26\n"
+        );
+    }
+
+    #[test]
+    fn test_removing_an_entry_keeps_its_comment() {
+        let text = "# about bob\nbob:2\nalice:1\n";
+        let (mut entries, layout) = read(text);
+        entries.retain(|e| e.name != "bob");
+        // The comment is kept rather than silently deleted, moved to the end.
+        assert_eq!(render(&entries, &layout), "alice:1\n# about bob\n");
+    }
+
+    #[test]
+    fn test_added_entry_appends_before_trailing_lines() {
+        let text = "alice:1\n# trailer\n";
+        let (mut entries, layout) = read(text);
+        entries.push(Row {
+            name: "bob".into(),
+            value: "2".into(),
+        });
+        assert_eq!(render(&entries, &layout), "alice:1\nbob:2\n# trailer\n");
+    }
+
+    #[test]
+    fn test_malformed_entry_still_errors() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("file");
+        std::fs::write(&path, "alice:1\nnot-a-record\n").expect("write");
+        assert!(read_with_layout::<Row>(&path).is_err());
+    }
+}

--- a/src/shadow-core/src/shadow.rs
+++ b/src/shadow-core/src/shadow.rs
@@ -19,6 +19,7 @@ use std::path::Path;
 use std::str::FromStr;
 
 use crate::error::ShadowError;
+pub use crate::records::Layout;
 use crate::validate::validate_field;
 
 /// A single entry from `/etc/shadow`.
@@ -242,8 +243,9 @@ pub fn read_shadow_file(path: &Path) -> Result<Vec<ShadowEntry>, ShadowError> {
 
     for line in reader.lines() {
         let line = line?;
-        let trimmed = line.trim_start();
-        if trimmed.is_empty() || trimmed.starts_with('#') {
+        // Comments, blank lines and NIS compat lines are not entries. Use
+        // read_*_with_layout when they must survive a rewrite.
+        if crate::records::is_raw_line(&line) {
             continue;
         }
         // Parse the original untrimmed line to preserve field whitespace.
@@ -264,6 +266,44 @@ pub fn write_shadow<W: Write>(entries: &[ShadowEntry], mut writer: W) -> Result<
         writeln!(writer, "{entry}")?;
     }
     Ok(())
+}
+
+impl crate::records::Named for ShadowEntry {
+    fn name(&self) -> &str {
+        &self.name
+    }
+}
+
+/// Read `/etc/shadow` keeping comments, blank lines and NIS compat lines.
+///
+/// Returns the entries plus the [`crate::records::Layout`] that
+/// [`write_shadow_with_layout`] needs to put those lines back.
+///
+/// # Errors
+///
+/// Returns `ShadowError` if the file cannot be opened or an entry is malformed.
+pub fn read_shadow_with_layout(
+    path: &Path,
+) -> Result<(Vec<ShadowEntry>, crate::records::Layout), ShadowError> {
+    crate::records::read_with_layout(path)
+}
+
+/// Write entries back, restoring the lines [`read_shadow_with_layout`] preserved.
+///
+/// # Errors
+///
+/// Returns `ShadowError` on a write failure or an entry that would corrupt the
+/// record format.
+pub fn write_shadow_with_layout<W: Write>(
+    entries: &[ShadowEntry],
+    layout: &crate::records::Layout,
+    mut writer: W,
+) -> Result<(), ShadowError> {
+    crate::records::write_with_layout(entries, layout, &mut writer, |entry, w| {
+        entry.validate_fields()?;
+        writeln!(w, "{entry}")?;
+        Ok(())
+    })
 }
 
 #[cfg(test)]

--- a/src/shadow-core/src/subid.rs
+++ b/src/shadow-core/src/subid.rs
@@ -22,6 +22,7 @@ use std::path::Path;
 use std::str::FromStr;
 
 use crate::error::ShadowError;
+pub use crate::records::Layout;
 use crate::validate::validate_field;
 
 /// A single entry from `/etc/subuid` or `/etc/subgid`.
@@ -102,8 +103,9 @@ pub fn read_subid_file(path: &Path) -> Result<Vec<SubIdEntry>, ShadowError> {
 
     for line in reader.lines() {
         let line = line?;
-        let trimmed = line.trim_start();
-        if trimmed.is_empty() || trimmed.starts_with('#') {
+        // Comments, blank lines and NIS compat lines are not entries. Use
+        // read_*_with_layout when they must survive a rewrite.
+        if crate::records::is_raw_line(&line) {
             continue;
         }
         entries.push(line.parse()?);
@@ -123,6 +125,44 @@ pub fn write_subid<W: Write>(entries: &[SubIdEntry], mut writer: W) -> Result<()
         writeln!(writer, "{entry}")?;
     }
     Ok(())
+}
+
+impl crate::records::Named for SubIdEntry {
+    fn name(&self) -> &str {
+        &self.name
+    }
+}
+
+/// Read `/etc/subuid` keeping comments, blank lines and NIS compat lines.
+///
+/// Returns the entries plus the [`crate::records::Layout`] that
+/// [`write_subid_with_layout`] needs to put those lines back.
+///
+/// # Errors
+///
+/// Returns `ShadowError` if the file cannot be opened or an entry is malformed.
+pub fn read_subid_with_layout(
+    path: &Path,
+) -> Result<(Vec<SubIdEntry>, crate::records::Layout), ShadowError> {
+    crate::records::read_with_layout(path)
+}
+
+/// Write entries back, restoring the lines [`read_subid_with_layout`] preserved.
+///
+/// # Errors
+///
+/// Returns `ShadowError` on a write failure or an entry that would corrupt the
+/// record format.
+pub fn write_subid_with_layout<W: Write>(
+    entries: &[SubIdEntry],
+    layout: &crate::records::Layout,
+    mut writer: W,
+) -> Result<(), ShadowError> {
+    crate::records::write_with_layout(entries, layout, &mut writer, |entry, w| {
+        entry.validate_fields()?;
+        writeln!(w, "{entry}")?;
+        Ok(())
+    })
 }
 
 #[cfg(test)]

--- a/src/uu/chage/src/chage.rs
+++ b/src/uu/chage/src/chage.rs
@@ -573,7 +573,7 @@ where
     })?;
 
     // Read current entries.
-    let mut entries = match shadow::read_shadow_file(&shadow_path) {
+    let (mut entries, layout) = match shadow::read_shadow_with_layout(&shadow_path) {
         Ok(e) => e,
         Err(e) => {
             drop(lock);
@@ -603,7 +603,7 @@ where
 
     // Write back atomically.
     let write_result = atomic::atomic_write(&shadow_path, |file| {
-        shadow::write_shadow(&entries, file)?;
+        shadow::write_shadow_with_layout(&entries, &layout, file)?;
         Ok(())
     });
 

--- a/src/uu/chfn/src/chfn.rs
+++ b/src/uu/chfn/src/chfn.rs
@@ -186,7 +186,7 @@ where
         ))
     })?;
 
-    let mut entries = match passwd::read_passwd_file(&passwd_path) {
+    let (mut entries, layout) = match passwd::read_passwd_with_layout(&passwd_path) {
         Ok(e) => e,
         Err(e) => {
             drop(lock);
@@ -211,7 +211,7 @@ where
     }
 
     let write_result = atomic::atomic_write(&passwd_path, |file| {
-        passwd::write_passwd(&entries, file)?;
+        passwd::write_passwd_with_layout(&entries, &layout, file)?;
         Ok(())
     });
 

--- a/src/uu/chpasswd/src/chpasswd.rs
+++ b/src/uu/chpasswd/src/chpasswd.rs
@@ -357,7 +357,7 @@ fn apply_password_changes(
     })?;
 
     // Read current entries.
-    let mut entries = match shadow::read_shadow_file(&shadow_path) {
+    let (mut entries, layout) = match shadow::read_shadow_with_layout(&shadow_path) {
         Ok(e) => e,
         Err(e) => {
             drop(lock);
@@ -388,7 +388,7 @@ fn apply_password_changes(
 
     // Write back atomically.
     let write_result = atomic::atomic_write(&shadow_path, |file| {
-        shadow::write_shadow(&entries, file)?;
+        shadow::write_shadow_with_layout(&entries, &layout, file)?;
         Ok(())
     });
 

--- a/src/uu/chsh/src/chsh.rs
+++ b/src/uu/chsh/src/chsh.rs
@@ -209,7 +209,7 @@ where
         ))
     })?;
 
-    let mut entries = match passwd::read_passwd_file(&passwd_path) {
+    let (mut entries, layout) = match passwd::read_passwd_with_layout(&passwd_path) {
         Ok(e) => e,
         Err(e) => {
             drop(lock);
@@ -234,7 +234,7 @@ where
     }
 
     let write_result = atomic::atomic_write(&passwd_path, |file| {
-        passwd::write_passwd(&entries, file)?;
+        passwd::write_passwd_with_layout(&entries, &layout, file)?;
         Ok(())
     });
 

--- a/src/uu/groupadd/src/groupadd.rs
+++ b/src/uu/groupadd/src/groupadd.rs
@@ -233,16 +233,19 @@ fn write_group_entry(group_path: &Path, name: &str, gid: u32) -> Result<(), Grou
         GroupaddError::CantUpdate(format!("cannot lock {}: {e}", group_path.display()))
     })?;
 
-    let mut entries = if group_path.exists() {
-        group::read_group_file(group_path).map_err(|e| {
+    let (mut entries, group_layout) = if group_path.exists() {
+        group::read_group_with_layout(group_path).map_err(|e| {
             GroupaddError::CantUpdate(format!("cannot read {}: {e}", group_path.display()))
         })?
     } else {
-        Vec::new()
+        (Vec::new(), group::Layout::default())
     };
     entries.push(new_group);
 
-    atomic::atomic_write(group_path, |f| group::write_group(&entries, f)).map_err(|e| {
+    atomic::atomic_write(group_path, |f| {
+        group::write_group_with_layout(&entries, &group_layout, f)
+    })
+    .map_err(|e| {
         GroupaddError::CantUpdate(format!("cannot write {}: {e}", group_path.display()))
     })?;
 
@@ -271,14 +274,18 @@ fn write_gshadow_entry(
         GroupaddError::CantUpdate(format!("cannot lock {}: {e}", gshadow_path.display()))
     })?;
 
-    let mut gs_entries = gshadow::read_gshadow_file(gshadow_path).map_err(|e| {
-        GroupaddError::CantUpdate(format!("cannot read {}: {e}", gshadow_path.display()))
-    })?;
+    let (mut gs_entries, gshadow_layout) = gshadow::read_gshadow_with_layout(gshadow_path)
+        .map_err(|e| {
+            GroupaddError::CantUpdate(format!("cannot read {}: {e}", gshadow_path.display()))
+        })?;
     gs_entries.push(new_gshadow);
 
-    atomic::atomic_write(gshadow_path, |f| gshadow::write_gshadow(&gs_entries, f)).map_err(
-        |e| GroupaddError::CantUpdate(format!("cannot write {}: {e}", gshadow_path.display())),
-    )?;
+    atomic::atomic_write(gshadow_path, |f| {
+        gshadow::write_gshadow_with_layout(&gs_entries, &gshadow_layout, f)
+    })
+    .map_err(|e| {
+        GroupaddError::CantUpdate(format!("cannot write {}: {e}", gshadow_path.display()))
+    })?;
 
     drop(gshadow_lock);
     Ok(())

--- a/src/uu/groupdel/src/groupdel.rs
+++ b/src/uu/groupdel/src/groupdel.rs
@@ -111,7 +111,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         GroupdelError::CantUpdate(format!("cannot lock {}: {e}", group_path.display()))
     })?;
 
-    let entries = group::read_group_file(&group_path).map_err(|e| {
+    let (entries, group_layout) = group::read_group_with_layout(&group_path).map_err(|e| {
         GroupdelError::CantUpdate(format!("cannot read {}: {e}", group_path.display()))
     })?;
 
@@ -147,7 +147,10 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         .filter(|g| g.name != *group_name)
         .collect();
 
-    atomic::atomic_write(&group_path, |f| group::write_group(&new_entries, f)).map_err(|e| {
+    atomic::atomic_write(&group_path, |f| {
+        group::write_group_with_layout(&new_entries, &group_layout, f)
+    })
+    .map_err(|e| {
         GroupdelError::CantUpdate(format!("cannot write {}: {e}", group_path.display()))
     })?;
 
@@ -160,9 +163,10 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
             GroupdelError::CantUpdate(format!("cannot lock {}: {e}", gshadow_path.display()))
         })?;
 
-        let gs_entries = gshadow::read_gshadow_file(&gshadow_path).map_err(|e| {
-            GroupdelError::CantUpdate(format!("cannot read {}: {e}", gshadow_path.display()))
-        })?;
+        let (gs_entries, gshadow_layout) = gshadow::read_gshadow_with_layout(&gshadow_path)
+            .map_err(|e| {
+                GroupdelError::CantUpdate(format!("cannot read {}: {e}", gshadow_path.display()))
+            })?;
 
         let new_gs: Vec<GshadowEntry> = gs_entries
             .into_iter()
@@ -171,14 +175,12 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 
         // Only write if we actually had gshadow entries to begin with.
         if !new_gs.is_empty() {
-            atomic::atomic_write(&gshadow_path, |f| gshadow::write_gshadow(&new_gs, f)).map_err(
-                |e| {
-                    GroupdelError::CantUpdate(format!(
-                        "cannot write {}: {e}",
-                        gshadow_path.display()
-                    ))
-                },
-            )?;
+            atomic::atomic_write(&gshadow_path, |f| {
+                gshadow::write_gshadow_with_layout(&new_gs, &gshadow_layout, f)
+            })
+            .map_err(|e| {
+                GroupdelError::CantUpdate(format!("cannot write {}: {e}", gshadow_path.display()))
+            })?;
         }
 
         drop(gs_lock);

--- a/src/uu/groupmod/src/groupmod.rs
+++ b/src/uu/groupmod/src/groupmod.rs
@@ -165,7 +165,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         GroupmodError::CantUpdate(format!("cannot lock {}: {e}", group_path.display()))
     })?;
 
-    let mut entries = group::read_group_file(&group_path).map_err(|e| {
+    let (mut entries, group_layout) = group::read_group_with_layout(&group_path).map_err(|e| {
         GroupmodError::CantUpdate(format!("cannot read {}: {e}", group_path.display()))
     })?;
 
@@ -207,7 +207,10 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let modified_gid = entries[idx].gid;
 
     // Write /etc/group.
-    atomic::atomic_write(&group_path, |f| group::write_group(&entries, f)).map_err(|e| {
+    atomic::atomic_write(&group_path, |f| {
+        group::write_group_with_layout(&entries, &group_layout, f)
+    })
+    .map_err(|e| {
         GroupmodError::CantUpdate(format!("cannot write {}: {e}", group_path.display()))
     })?;
 
@@ -218,9 +221,10 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         && new_gid_val != old_gid
         && update_passwd
     {
-        let mut pw_entries = passwd::read_passwd_file(&passwd_path).map_err(|e| {
-            GroupmodError::CantUpdate(format!("cannot read {}: {e}", passwd_path.display()))
-        })?;
+        let (mut pw_entries, passwd_layout) = passwd::read_passwd_with_layout(&passwd_path)
+            .map_err(|e| {
+                GroupmodError::CantUpdate(format!("cannot read {}: {e}", passwd_path.display()))
+            })?;
         let mut changed = false;
         for e in &mut pw_entries {
             if e.gid == old_gid {
@@ -229,14 +233,12 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
             }
         }
         if changed {
-            atomic::atomic_write(&passwd_path, |f| passwd::write_passwd(&pw_entries, f)).map_err(
-                |e| {
-                    GroupmodError::CantUpdate(format!(
-                        "cannot write {}: {e}",
-                        passwd_path.display()
-                    ))
-                },
-            )?;
+            atomic::atomic_write(&passwd_path, |f| {
+                passwd::write_passwd_with_layout(&pw_entries, &passwd_layout, f)
+            })
+            .map_err(|e| {
+                GroupmodError::CantUpdate(format!("cannot write {}: {e}", passwd_path.display()))
+            })?;
         }
     }
 
@@ -250,9 +252,10 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
             GroupmodError::CantUpdate(format!("cannot lock {}: {e}", gshadow_path.display()))
         })?;
 
-        let mut gs_entries = gshadow::read_gshadow_file(&gshadow_path).map_err(|e| {
-            GroupmodError::CantUpdate(format!("cannot read {}: {e}", gshadow_path.display()))
-        })?;
+        let (mut gs_entries, gshadow_layout) = gshadow::read_gshadow_with_layout(&gshadow_path)
+            .map_err(|e| {
+                GroupmodError::CantUpdate(format!("cannot read {}: {e}", gshadow_path.display()))
+            })?;
 
         if let Some(gs) = gs_entries.iter_mut().find(|g| g.name == *group_name) {
             if let Some(name) = new_name {
@@ -263,9 +266,12 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
             }
         }
 
-        atomic::atomic_write(&gshadow_path, |f| gshadow::write_gshadow(&gs_entries, f)).map_err(
-            |e| GroupmodError::CantUpdate(format!("cannot write {}: {e}", gshadow_path.display())),
-        )?;
+        atomic::atomic_write(&gshadow_path, |f| {
+            gshadow::write_gshadow_with_layout(&gs_entries, &gshadow_layout, f)
+        })
+        .map_err(|e| {
+            GroupmodError::CantUpdate(format!("cannot write {}: {e}", gshadow_path.display()))
+        })?;
 
         drop(gs_lock);
     }

--- a/src/uu/grpck/src/grpck.rs
+++ b/src/uu/grpck/src/grpck.rs
@@ -172,12 +172,7 @@ fn run_checks(opts: &GrpckOptions) -> UResult<()> {
     // Sort by GID if requested. `-r` and `-s` cannot be combined (rejected by
     // clap), so the read-only guard is defensive.
     if opts.sort && !opts.read_only {
-        sort_and_write(
-            &opts.group_path,
-            &opts.gshadow_path,
-            &group_entries,
-            &gshadow_entries,
-        )?;
+        sort_and_write(&opts.group_path, &opts.gshadow_path)?;
     }
 
     Ok(())
@@ -191,8 +186,9 @@ fn read_raw_lines(path: &Path) -> Result<Vec<String>, std::io::Error> {
 
     for line in reader.lines() {
         let line = line?;
-        let trimmed = line.trim_start();
-        if trimmed.is_empty() || trimmed.starts_with('#') {
+        // Comments, blank lines and NIS compat lines are not entries to check;
+        // they are preserved verbatim when -s rewrites the file.
+        if shadow_core::records::is_raw_line(&line) {
             continue;
         }
         lines.push(line);
@@ -292,38 +288,50 @@ fn load_gshadow_file(path: &Path, quiet: bool) -> Vec<GshadowEntry> {
 /// blank lines from the original file. A lossless (comment-preserving)
 /// sort would require a significantly different parser that tracks raw
 /// lines alongside parsed entries. This matches GNU `grpck -s` behavior.
-fn sort_and_write(
-    group_path: &Path,
-    gshadow_path: &Path,
-    group_entries: &[GroupEntry],
-    gshadow_entries: &[GshadowEntry],
-) -> UResult<()> {
-    let mut sorted_groups = group_entries.to_vec();
-    sorted_groups.sort_by_key(|g| g.gid);
-
-    if sorted_groups == group_entries {
-        return Ok(());
-    }
-
+fn sort_and_write(group_path: &Path, gshadow_path: &Path) -> UResult<()> {
     let group_lock = FileLock::acquire(group_path)
         .map_err(|e| GrpckError::CantLock(format!("cannot lock {}: {e}", group_path.display())))?;
 
-    atomic::atomic_write(group_path, |f| group::write_group(&sorted_groups, f)).map_err(|e| {
-        GrpckError::CantUpdate(format!("cannot update {}: {e}", group_path.display()))
-    })?;
+    // Re-read under the lock: the entries checked above were read before it.
+    // The layout keeps comments, blank lines and NIS compat lines, each
+    // anchored to the entry it preceded, so a comment follows its group.
+    let (mut sorted_groups, group_layout) =
+        group::read_group_with_layout(group_path).map_err(|e| {
+            GrpckError::CantUpdate(format!("cannot read {}: {e}", group_path.display()))
+        })?;
+    let original = sorted_groups.clone();
+    sorted_groups.sort_by_key(|g| g.gid);
+
+    if sorted_groups == original {
+        drop(group_lock);
+        return Ok(());
+    }
+
+    atomic::atomic_write(group_path, |f| {
+        group::write_group_with_layout(&sorted_groups, &group_layout, f)
+    })
+    .map_err(|e| GrpckError::CantUpdate(format!("cannot update {}: {e}", group_path.display())))?;
 
     // Sort gshadow to match the new group order.
-    if gshadow_path.exists() && !gshadow_entries.is_empty() {
+    if gshadow_path.exists() {
         let gs_lock = FileLock::acquire(gshadow_path).map_err(|e| {
             GrpckError::CantLock(format!("cannot lock {}: {e}", gshadow_path.display()))
         })?;
 
-        let sorted_gshadow = sort_gshadow_by_group(&sorted_groups, gshadow_entries);
+        let (gshadow_entries, gshadow_layout) = gshadow::read_gshadow_with_layout(gshadow_path)
+            .map_err(|e| {
+                GrpckError::CantUpdate(format!("cannot read {}: {e}", gshadow_path.display()))
+            })?;
 
-        atomic::atomic_write(gshadow_path, |f| gshadow::write_gshadow(&sorted_gshadow, f))
+        if !gshadow_entries.is_empty() {
+            let sorted_gshadow = sort_gshadow_by_group(&sorted_groups, &gshadow_entries);
+            atomic::atomic_write(gshadow_path, |f| {
+                gshadow::write_gshadow_with_layout(&sorted_gshadow, &gshadow_layout, f)
+            })
             .map_err(|e| {
                 GrpckError::CantUpdate(format!("cannot update {}: {e}", gshadow_path.display()))
             })?;
+        }
 
         drop(gs_lock);
     }

--- a/src/uu/passwd/src/passwd.rs
+++ b/src/uu/passwd/src/passwd.rs
@@ -714,7 +714,7 @@ where
     })?;
 
     // Read current entries.
-    let mut entries = match shadow::read_shadow_file(&shadow_path) {
+    let (mut entries, layout) = match shadow::read_shadow_with_layout(&shadow_path) {
         Ok(e) => e,
         Err(e) => {
             drop(lock);
@@ -744,7 +744,7 @@ where
 
     // Write back atomically.
     let write_result = atomic::atomic_write(&shadow_path, |file| {
-        shadow::write_shadow(&entries, file)?;
+        shadow::write_shadow_with_layout(&entries, &layout, file)?;
         Ok(())
     });
 

--- a/src/uu/pwck/src/pwck.rs
+++ b/src/uu/pwck/src/pwck.rs
@@ -202,13 +202,7 @@ fn run_checks(opts: &PwckOptions) -> UResult<()> {
     }
 
     if opts.sort {
-        sort_and_write(
-            &opts.passwd_path,
-            &opts.shadow_path,
-            &passwd_entries,
-            &shadow_entries,
-            opts.read_only,
-        )?;
+        sort_and_write(&opts.passwd_path, &opts.shadow_path, opts.read_only)?;
     } else {
         uucore::show_error!("no changes");
     }
@@ -251,20 +245,7 @@ fn load_group_file(path: &Path, quiet: bool) -> Vec<GroupEntry> {
 /// comments or blank lines. Comment preservation is tracked in #241; until
 /// then a `-s` that reorders the file drops them. This only runs when there
 /// were no parse errors.
-fn sort_and_write(
-    passwd_path: &Path,
-    shadow_path: &Path,
-    passwd_entries: &[PasswdEntry],
-    shadow_entries: &[ShadowEntry],
-    read_only: bool,
-) -> UResult<()> {
-    let mut sorted_passwd = passwd_entries.to_vec();
-    sorted_passwd.sort_by_key(|e| e.uid);
-
-    if sorted_passwd == passwd_entries {
-        return Ok(());
-    }
-
+fn sort_and_write(passwd_path: &Path, shadow_path: &Path, read_only: bool) -> UResult<()> {
     if read_only {
         return Ok(());
     }
@@ -272,20 +253,46 @@ fn sort_and_write(
     let passwd_lock = FileLock::acquire(passwd_path)
         .map_err(|e| PwckError::CantLock(format!("cannot lock {}: {e}", passwd_path.display())))?;
 
-    atomic::atomic_write(passwd_path, |f| passwd::write_passwd(&sorted_passwd, f)).map_err(
-        |e| PwckError::CantUpdate(format!("cannot update {}: {e}", passwd_path.display())),
-    )?;
+    // Re-read under the lock: the entries checked above were read before it,
+    // so sorting those would overwrite anything that changed in between. The
+    // layout keeps comments, blank lines and NIS compat lines, each anchored
+    // to the entry it preceded, so a comment follows its account.
+    let (mut sorted_passwd, passwd_layout) =
+        passwd::read_passwd_with_layout(passwd_path).map_err(|e| {
+            PwckError::CantUpdate(format!("cannot read {}: {e}", passwd_path.display()))
+        })?;
+    let original = sorted_passwd.clone();
+    sorted_passwd.sort_by_key(|e| e.uid);
 
-    if shadow_path.exists() && !shadow_entries.is_empty() {
+    if sorted_passwd == original {
+        drop(passwd_lock);
+        return Ok(());
+    }
+
+    atomic::atomic_write(passwd_path, |f| {
+        passwd::write_passwd_with_layout(&sorted_passwd, &passwd_layout, f)
+    })
+    .map_err(|e| PwckError::CantUpdate(format!("cannot update {}: {e}", passwd_path.display())))?;
+
+    if shadow_path.exists() {
         let shadow_lock = FileLock::acquire(shadow_path).map_err(|e| {
             PwckError::CantLock(format!("cannot lock {}: {e}", shadow_path.display()))
         })?;
 
-        let sorted_shadow = sort_shadow_by_passwd(&sorted_passwd, shadow_entries);
+        let (shadow_entries, shadow_layout) = shadow::read_shadow_with_layout(shadow_path)
+            .map_err(|e| {
+                PwckError::CantUpdate(format!("cannot read {}: {e}", shadow_path.display()))
+            })?;
 
-        atomic::atomic_write(shadow_path, |f| shadow::write_shadow(&sorted_shadow, f)).map_err(
-            |e| PwckError::CantUpdate(format!("cannot update {}: {e}", shadow_path.display())),
-        )?;
+        if !shadow_entries.is_empty() {
+            let sorted_shadow = sort_shadow_by_passwd(&sorted_passwd, &shadow_entries);
+            atomic::atomic_write(shadow_path, |f| {
+                shadow::write_shadow_with_layout(&sorted_shadow, &shadow_layout, f)
+            })
+            .map_err(|e| {
+                PwckError::CantUpdate(format!("cannot update {}: {e}", shadow_path.display()))
+            })?;
+        }
 
         drop(shadow_lock);
     }
@@ -579,8 +586,9 @@ fn read_raw_lines(path: &Path) -> Result<Vec<String>, std::io::Error> {
 
     for line in reader.lines() {
         let line = line?;
-        let trimmed = line.trim_start();
-        if trimmed.is_empty() || trimmed.starts_with('#') {
+        // Comments, blank lines and NIS compat lines are not entries to check;
+        // they are preserved verbatim when -s rewrites the file.
+        if shadow_core::records::is_raw_line(&line) {
             continue;
         }
         lines.push(line);

--- a/src/uu/useradd/src/useradd.rs
+++ b/src/uu/useradd/src/useradd.rs
@@ -445,7 +445,7 @@ fn do_useradd(opts: &UseraddOptions) -> UResult<()> {
         .map_err(|e| UseraddError::CannotUpdateGroup(format!("cannot lock group: {e}")))?;
 
     // Step 3: Read passwd under lock and check username not already in use.
-    let passwd_entries = passwd::read_passwd_file(&passwd_path)
+    let (passwd_entries, passwd_layout) = passwd::read_passwd_with_layout(&passwd_path)
         .map_err(|e| UseraddError::CannotUpdatePasswd(format!("{e}")))?;
 
     if passwd_entries.iter().any(|e| e.name == opts.login) {
@@ -467,7 +467,7 @@ fn do_useradd(opts: &UseraddOptions) -> UResult<()> {
 
     // Step 6: Read group entries under lock (needed for GID resolution and
     // user group creation).
-    let mut group_entries = group::read_group_file(&group_path)
+    let (mut group_entries, group_layout) = group::read_group_with_layout(&group_path)
         .map_err(|e| UseraddError::CannotUpdateGroup(format!("{e}")))?;
 
     // Step 7: Determine primary GID.
@@ -475,11 +475,11 @@ fn do_useradd(opts: &UseraddOptions) -> UResult<()> {
 
     // Step 8: Read gshadow entries.
     let gshadow_path = opts.root.gshadow_path();
-    let mut gshadow_entries = if gshadow_path.exists() {
-        gshadow::read_gshadow_file(&gshadow_path)
+    let (mut gshadow_entries, gshadow_layout) = if gshadow_path.exists() {
+        gshadow::read_gshadow_with_layout(&gshadow_path)
             .map_err(|e| UseraddError::CannotUpdateGroup(format!("{e}")))?
     } else {
-        Vec::new()
+        (Vec::new(), gshadow::Layout::default())
     };
 
     // Step 9: Validate supplementary groups exist.
@@ -506,13 +506,18 @@ fn do_useradd(opts: &UseraddOptions) -> UResult<()> {
 
     // Step 11: Create user group if needed (group lock already held).
     if let Some(ref new_grp) = new_group {
-        write_new_group(&group_path, &mut group_entries, new_grp)?;
+        write_new_group(&group_path, &mut group_entries, &group_layout, new_grp)?;
         if gshadow_path.exists() {
             // Acquire gshadow lock — group.lock does NOT protect gshadow.
             let _gs_lock = FileLock::acquire(&gshadow_path).map_err(|e| {
                 UseraddError::CannotUpdateGroup(format!("cannot lock gshadow: {e}"))
             })?;
-            write_new_gshadow(&gshadow_path, &mut gshadow_entries, new_grp)?;
+            write_new_gshadow(
+                &gshadow_path,
+                &mut gshadow_entries,
+                &gshadow_layout,
+                new_grp,
+            )?;
         }
     }
 
@@ -526,7 +531,7 @@ fn do_useradd(opts: &UseraddOptions) -> UResult<()> {
         home: home_dir.clone(),
         shell: opts.shell.clone(),
     };
-    write_passwd_entry(&passwd_path, &passwd_entries, &passwd_entry)?;
+    write_passwd_entry(&passwd_path, &passwd_entries, &passwd_layout, &passwd_entry)?;
 
     // Step 13: Write /etc/shadow entry (passwd+group locks still held).
     let shadow_path = opts.root.shadow_path();
@@ -720,12 +725,15 @@ fn resolve_group(gid_arg: &str, group_entries: &[GroupEntry]) -> Result<u32, Use
 fn write_new_group(
     group_path: &Path,
     group_entries: &mut Vec<GroupEntry>,
+    layout: &group::Layout,
     new_group: &GroupEntry,
 ) -> UResult<()> {
     group_entries.push(new_group.clone());
 
-    atomic::atomic_write(group_path, |f| group::write_group(group_entries, f))
-        .map_err(|e| UseraddError::CannotUpdateGroup(format!("{e}")))?;
+    atomic::atomic_write(group_path, |f| {
+        group::write_group_with_layout(group_entries, layout, f)
+    })
+    .map_err(|e| UseraddError::CannotUpdateGroup(format!("{e}")))?;
 
     Ok(())
 }
@@ -737,6 +745,7 @@ fn write_new_group(
 fn write_new_gshadow(
     gshadow_path: &Path,
     gshadow_entries: &mut Vec<GshadowEntry>,
+    layout: &gshadow::Layout,
     new_group: &GroupEntry,
 ) -> UResult<()> {
     gshadow_entries.push(GshadowEntry {
@@ -746,8 +755,10 @@ fn write_new_gshadow(
         members: Vec::new(),
     });
 
-    atomic::atomic_write(gshadow_path, |f| gshadow::write_gshadow(gshadow_entries, f))
-        .map_err(|e| UseraddError::CannotUpdateGroup(format!("{e}")))?;
+    atomic::atomic_write(gshadow_path, |f| {
+        gshadow::write_gshadow_with_layout(gshadow_entries, layout, f)
+    })
+    .map_err(|e| UseraddError::CannotUpdateGroup(format!("{e}")))?;
 
     Ok(())
 }
@@ -758,13 +769,16 @@ fn write_new_gshadow(
 fn write_passwd_entry(
     passwd_path: &Path,
     existing: &[PasswdEntry],
+    layout: &passwd::Layout,
     new_entry: &PasswdEntry,
 ) -> UResult<()> {
     let mut entries: Vec<PasswdEntry> = existing.to_vec();
     entries.push(new_entry.clone());
 
-    atomic::atomic_write(passwd_path, |f| passwd::write_passwd(&entries, f))
-        .map_err(|e| UseraddError::CannotUpdatePasswd(format!("{e}")))?;
+    atomic::atomic_write(passwd_path, |f| {
+        passwd::write_passwd_with_layout(&entries, layout, f)
+    })
+    .map_err(|e| UseraddError::CannotUpdatePasswd(format!("{e}")))?;
 
     Ok(())
 }
@@ -775,17 +789,19 @@ fn write_shadow_entry(shadow_path: &Path, new_entry: &ShadowEntry) -> UResult<()
         .map_err(|e| UseraddError::CannotUpdatePasswd(format!("{e}")))?;
 
     // Read existing entries; if the file does not exist, start fresh.
-    let mut entries = if shadow_path.exists() {
-        shadow::read_shadow_file(shadow_path)
+    let (mut entries, layout) = if shadow_path.exists() {
+        shadow::read_shadow_with_layout(shadow_path)
             .map_err(|e| UseraddError::CannotUpdatePasswd(format!("{e}")))?
     } else {
-        Vec::new()
+        (Vec::new(), shadow::Layout::default())
     };
 
     entries.push(new_entry.clone());
 
-    atomic::atomic_write(shadow_path, |f| shadow::write_shadow(&entries, f))
-        .map_err(|e| UseraddError::CannotUpdatePasswd(format!("{e}")))?;
+    atomic::atomic_write(shadow_path, |f| {
+        shadow::write_shadow_with_layout(&entries, &layout, f)
+    })
+    .map_err(|e| UseraddError::CannotUpdatePasswd(format!("{e}")))?;
 
     Ok(())
 }
@@ -799,7 +815,7 @@ fn add_to_supplementary_groups(
     let _lock = FileLock::acquire(group_path)
         .map_err(|e| UseraddError::CannotUpdateGroup(format!("{e}")))?;
 
-    let mut entries = group::read_group_file(group_path)
+    let (mut entries, layout) = group::read_group_with_layout(group_path)
         .map_err(|e| UseraddError::CannotUpdateGroup(format!("{e}")))?;
 
     for entry in &mut entries {
@@ -808,15 +824,17 @@ fn add_to_supplementary_groups(
         }
     }
 
-    atomic::atomic_write(group_path, |f| group::write_group(&entries, f))
-        .map_err(|e| UseraddError::CannotUpdateGroup(format!("{e}")))?;
+    atomic::atomic_write(group_path, |f| {
+        group::write_group_with_layout(&entries, &layout, f)
+    })
+    .map_err(|e| UseraddError::CannotUpdateGroup(format!("{e}")))?;
 
     // Also update gshadow if it exists.
     if gshadow_path.exists() {
         let _gs_lock = FileLock::acquire(gshadow_path)
             .map_err(|e| UseraddError::CannotUpdateGroup(format!("{e}")))?;
 
-        let mut gs_entries = gshadow::read_gshadow_file(gshadow_path)
+        let (mut gs_entries, gs_layout) = gshadow::read_gshadow_with_layout(gshadow_path)
             .map_err(|e| UseraddError::CannotUpdateGroup(format!("{e}")))?;
 
         for entry in &mut gs_entries {
@@ -825,8 +843,10 @@ fn add_to_supplementary_groups(
             }
         }
 
-        atomic::atomic_write(gshadow_path, |f| gshadow::write_gshadow(&gs_entries, f))
-            .map_err(|e| UseraddError::CannotUpdateGroup(format!("{e}")))?;
+        atomic::atomic_write(gshadow_path, |f| {
+            gshadow::write_gshadow_with_layout(&gs_entries, &gs_layout, f)
+        })
+        .map_err(|e| UseraddError::CannotUpdateGroup(format!("{e}")))?;
     }
 
     Ok(())
@@ -847,7 +867,7 @@ fn append_subid_entry(path: &Path, name: &str, count: u64) -> UResult<()> {
         UseraddError::CannotUpdatePasswd(format!("cannot lock {}: {e}", path.display()))
     })?;
 
-    let mut entries = match subid::read_subid_file(path) {
+    let (mut entries, layout) = match subid::read_subid_with_layout(path) {
         Ok(e) => e,
         Err(e) => {
             uucore::show_error!("warning: cannot read {}: {e}", path.display());
@@ -880,8 +900,10 @@ fn append_subid_entry(path: &Path, name: &str, count: u64) -> UResult<()> {
         count,
     });
 
-    atomic::atomic_write(path, |f| subid::write_subid(&entries, f))
-        .map_err(|e| UseraddError::CannotUpdatePasswd(format!("{e}")))?;
+    atomic::atomic_write(path, |f| {
+        subid::write_subid_with_layout(&entries, &layout, f)
+    })
+    .map_err(|e| UseraddError::CannotUpdatePasswd(format!("{e}")))?;
 
     drop(lock);
     Ok(())
@@ -1445,7 +1467,8 @@ mod tests {
         fs::write(root.shadow_path(), "existing:!:19000:0:99999:7:::\n").expect("write shadow");
         fs::write(root.group_path(), "existing:x:1000:\n").expect("write group");
 
-        let passwd_entries = passwd::read_passwd_file(&root.passwd_path()).expect("read passwd");
+        let (passwd_entries, _) =
+            passwd::read_passwd_with_layout(&root.passwd_path()).expect("read passwd");
         assert!(passwd_entries.iter().any(|e| e.name == "existing"));
     }
 
@@ -1619,7 +1642,8 @@ mod tests {
 
         let defs = LoginDefs::load(&root.login_defs_path()).expect("defs");
 
-        let passwd_entries = passwd::read_passwd_file(&root.passwd_path()).expect("passwd");
+        let (passwd_entries, passwd_layout) =
+            passwd::read_passwd_with_layout(&root.passwd_path()).expect("passwd");
         let _group_entries = group::read_group_file(&root.group_path()).expect("group");
 
         // Allocate UID.
@@ -1638,7 +1662,13 @@ mod tests {
             shell: "/bin/bash".into(),
         };
 
-        write_passwd_entry(&root.passwd_path(), &passwd_entries, &new_entry).expect("write passwd");
+        write_passwd_entry(
+            &root.passwd_path(),
+            &passwd_entries,
+            &passwd_layout,
+            &new_entry,
+        )
+        .expect("write passwd");
 
         // Verify.
         let updated = passwd::read_passwd_file(&root.passwd_path()).expect("re-read");
@@ -1656,9 +1686,10 @@ mod tests {
 
         let (_dir, root) = setup_test_root();
 
-        let mut group_entries = group::read_group_file(&root.group_path()).expect("group");
-        let mut gshadow_entries =
-            gshadow::read_gshadow_file(&root.gshadow_path()).expect("gshadow");
+        let (mut group_entries, group_layout) =
+            group::read_group_with_layout(&root.group_path()).expect("group");
+        let (mut gshadow_entries, gshadow_layout) =
+            gshadow::read_gshadow_with_layout(&root.gshadow_path()).expect("gshadow");
 
         // Create user group.
         let new_group = GroupEntry {
@@ -1668,9 +1699,20 @@ mod tests {
             members: Vec::new(),
         };
 
-        write_new_group(&root.group_path(), &mut group_entries, &new_group).expect("write group");
-        write_new_gshadow(&root.gshadow_path(), &mut gshadow_entries, &new_group)
-            .expect("write gshadow");
+        write_new_group(
+            &root.group_path(),
+            &mut group_entries,
+            &group_layout,
+            &new_group,
+        )
+        .expect("write group");
+        write_new_gshadow(
+            &root.gshadow_path(),
+            &mut gshadow_entries,
+            &gshadow_layout,
+            &new_group,
+        )
+        .expect("write gshadow");
 
         // Verify group.
         let updated_groups = group::read_group_file(&root.group_path()).expect("re-read");
@@ -1721,14 +1763,21 @@ mod tests {
         let (_dir, root) = setup_test_root();
 
         // Add a "wheel" group.
-        let mut group_entries = group::read_group_file(&root.group_path()).expect("group");
+        let (mut group_entries, group_layout) =
+            group::read_group_with_layout(&root.group_path()).expect("group");
         let wheel = GroupEntry {
             name: "wheel".into(),
             passwd: "x".into(),
             gid: 10,
             members: Vec::new(),
         };
-        write_new_group(&root.group_path(), &mut group_entries, &wheel).expect("add wheel");
+        write_new_group(
+            &root.group_path(),
+            &mut group_entries,
+            &group_layout,
+            &wheel,
+        )
+        .expect("add wheel");
 
         // Now add "testuser" to "wheel" and "users".
         let opts = UseraddOptions {

--- a/src/uu/userdel/src/userdel.rs
+++ b/src/uu/userdel/src/userdel.rs
@@ -413,8 +413,8 @@ where
 fn remove_from_group_members(path: &Path, login: &str) -> Result<(), String> {
     let lock = FileLock::acquire(path).map_err(|e| format!("cannot lock group file: {e}"))?;
 
-    let mut entries =
-        group::read_group_file(path).map_err(|e| format!("cannot read {}: {e}", path.display()))?;
+    let (mut entries, layout) = group::read_group_with_layout(path)
+        .map_err(|e| format!("cannot read {}: {e}", path.display()))?;
 
     let mut changed = false;
     for entry in &mut entries {
@@ -426,8 +426,10 @@ fn remove_from_group_members(path: &Path, login: &str) -> Result<(), String> {
     }
 
     if changed {
-        atomic::atomic_write(path, |f| group::write_group(&entries, f))
-            .map_err(|e| format!("cannot write {}: {e}", path.display()))?;
+        atomic::atomic_write(path, |f| {
+            group::write_group_with_layout(&entries, &layout, f)
+        })
+        .map_err(|e| format!("cannot write {}: {e}", path.display()))?;
     }
 
     drop(lock);
@@ -438,7 +440,7 @@ fn remove_from_group_members(path: &Path, login: &str) -> Result<(), String> {
 fn remove_from_gshadow_members(path: &Path, login: &str) -> Result<(), String> {
     let lock = FileLock::acquire(path).map_err(|e| format!("cannot lock gshadow file: {e}"))?;
 
-    let mut entries = gshadow::read_gshadow_file(path)
+    let (mut entries, layout) = gshadow::read_gshadow_with_layout(path)
         .map_err(|e| format!("cannot read {}: {e}", path.display()))?;
 
     let mut changed = false;
@@ -453,8 +455,10 @@ fn remove_from_gshadow_members(path: &Path, login: &str) -> Result<(), String> {
     }
 
     if changed {
-        atomic::atomic_write(path, |f| gshadow::write_gshadow(&entries, f))
-            .map_err(|e| format!("cannot write {}: {e}", path.display()))?;
+        atomic::atomic_write(path, |f| {
+            gshadow::write_gshadow_with_layout(&entries, &layout, f)
+        })
+        .map_err(|e| format!("cannot write {}: {e}", path.display()))?;
     }
 
     drop(lock);
@@ -482,8 +486,8 @@ fn remove_user_private_group(
 
     let group_lock =
         FileLock::acquire(&group_path).map_err(|e| format!("cannot lock group file: {e}"))?;
-    let mut entries =
-        group::read_group_file(&group_path).map_err(|e| format!("cannot read group: {e}"))?;
+    let (mut entries, group_layout) = group::read_group_with_layout(&group_path)
+        .map_err(|e| format!("cannot read group: {e}"))?;
 
     let Some(idx) = entries.iter().position(|g| g.name == login) else {
         return Ok(());
@@ -504,7 +508,8 @@ fn remove_user_private_group(
     }
 
     entries.remove(idx);
-    write_group_or_empty(&group_path, &entries).map_err(|e| format!("cannot write group: {e}"))?;
+    write_group_or_empty(&group_path, &entries, &group_layout)
+        .map_err(|e| format!("cannot write group: {e}"))?;
     drop(group_lock);
 
     // Mirror the removal in gshadow.
@@ -512,11 +517,11 @@ fn remove_user_private_group(
     if gshadow_path.exists() {
         let gs_lock =
             FileLock::acquire(&gshadow_path).map_err(|e| format!("cannot lock gshadow: {e}"))?;
-        if let Ok(mut gs) = gshadow::read_gshadow_file(&gshadow_path) {
+        if let Ok((mut gs, gshadow_layout)) = gshadow::read_gshadow_with_layout(&gshadow_path) {
             let before = gs.len();
             gs.retain(|g| g.name != login);
             if gs.len() != before {
-                write_gshadow_or_empty(&gshadow_path, &gs)
+                write_gshadow_or_empty(&gshadow_path, &gs, &gshadow_layout)
                     .map_err(|e| format!("cannot write gshadow: {e}"))?;
             }
         }
@@ -540,14 +545,16 @@ fn remove_subid_rows(path: &Path, login: &str) {
     let Ok(lock) = FileLock::acquire(path) else {
         return;
     };
-    if let Ok(mut entries) = subid::read_subid_file(path) {
+    if let Ok((mut entries, layout)) = subid::read_subid_with_layout(path) {
         let before = entries.len();
         entries.retain(|e| e.name != login);
         if entries.len() != before {
-            if entries.is_empty() {
+            if entries.is_empty() && layout.is_empty() {
                 let _ = std::fs::remove_file(path);
             } else {
-                let _ = atomic::atomic_write(path, |f| subid::write_subid(&entries, f));
+                let _ = atomic::atomic_write(path, |f| {
+                    subid::write_subid_with_layout(&entries, &layout, f)
+                });
             }
         }
     }
@@ -560,24 +567,28 @@ fn remove_subid_rows(path: &Path, login: &str) {
 fn write_group_or_empty(
     path: &Path,
     entries: &[group::GroupEntry],
+    layout: &group::Layout,
 ) -> Result<(), shadow_core::error::ShadowError> {
-    if entries.is_empty() {
+    if entries.is_empty() && layout.is_empty() {
         let _ = std::fs::remove_file(path);
         Ok(())
     } else {
-        atomic::atomic_write(path, |f| group::write_group(entries, f))
+        atomic::atomic_write(path, |f| group::write_group_with_layout(entries, layout, f))
     }
 }
 
 fn write_gshadow_or_empty(
     path: &Path,
     entries: &[gshadow::GshadowEntry],
+    layout: &gshadow::Layout,
 ) -> Result<(), shadow_core::error::ShadowError> {
-    if entries.is_empty() {
+    if entries.is_empty() && layout.is_empty() {
         let _ = std::fs::remove_file(path);
         Ok(())
     } else {
-        atomic::atomic_write(path, |f| gshadow::write_gshadow(entries, f))
+        atomic::atomic_write(path, |f| {
+            gshadow::write_gshadow_with_layout(entries, layout, f)
+        })
     }
 }
 

--- a/src/uu/usermod/src/usermod.rs
+++ b/src/uu/usermod/src/usermod.rs
@@ -133,7 +133,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let lock = FileLock::acquire(&passwd_path)
         .map_err(|e| UsermodError::CantUpdate(format!("cannot lock: {e}")))?;
 
-    let mut entries = passwd::read_passwd_file(&passwd_path)
+    let (mut entries, passwd_layout) = passwd::read_passwd_with_layout(&passwd_path)
         .map_err(|e| UsermodError::CantUpdate(format!("{e}")))?;
 
     let Some(idx) = entries.iter().position(|e| e.name == *login) else {
@@ -187,8 +187,10 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 
     let new_uid = entries[idx].uid;
 
-    atomic::atomic_write(&passwd_path, |f| passwd::write_passwd(&entries, f))
-        .map_err(|e| UsermodError::CantUpdate(format!("{e}")))?;
+    atomic::atomic_write(&passwd_path, |f| {
+        passwd::write_passwd_with_layout(&entries, &passwd_layout, f)
+    })
+    .map_err(|e| UsermodError::CantUpdate(format!("{e}")))?;
     drop(lock);
 
     // Restore signals before potentially long-running recursive chown.
@@ -224,7 +226,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         let slock = FileLock::acquire(&shadow_path)
             .map_err(|e| UsermodError::CantUpdate(format!("cannot lock shadow: {e}")))?;
 
-        let mut se = shadow::read_shadow_file(&shadow_path)
+        let (mut se, shadow_layout) = shadow::read_shadow_with_layout(&shadow_path)
             .map_err(|e| UsermodError::CantUpdate(format!("{e}")))?;
 
         let Some(s) = se.iter_mut().find(|e| e.name == *login) else {
@@ -257,8 +259,10 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
             s.name.clone_from(new_name);
         }
 
-        atomic::atomic_write(&shadow_path, |f| shadow::write_shadow(&se, f))
-            .map_err(|e| UsermodError::CantUpdate(format!("{e}")))?;
+        atomic::atomic_write(&shadow_path, |f| {
+            shadow::write_shadow_with_layout(&se, &shadow_layout, f)
+        })
+        .map_err(|e| UsermodError::CantUpdate(format!("{e}")))?;
         drop(slock);
     }
 
@@ -269,7 +273,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
             let glock = FileLock::acquire(&group_path)
                 .map_err(|e| UsermodError::CantUpdate(format!("cannot lock group: {e}")))?;
 
-            let mut ge = group::read_group_file(&group_path)
+            let (mut ge, group_layout) = group::read_group_with_layout(&group_path)
                 .map_err(|e| UsermodError::CantUpdate(format!("{e}")))?;
 
             let mut changed = false;
@@ -281,8 +285,10 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
             }
 
             if changed {
-                atomic::atomic_write(&group_path, |f| group::write_group(&ge, f))
-                    .map_err(|e| UsermodError::CantUpdate(format!("{e}")))?;
+                atomic::atomic_write(&group_path, |f| {
+                    group::write_group_with_layout(&ge, &group_layout, f)
+                })
+                .map_err(|e| UsermodError::CantUpdate(format!("{e}")))?;
             }
             drop(glock);
         }
@@ -298,7 +304,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
             let glock = FileLock::acquire(&group_path)
                 .map_err(|e| UsermodError::CantUpdate(format!("cannot lock group: {e}")))?;
 
-            let mut ge = group::read_group_file(&group_path)
+            let (mut ge, group_layout) = group::read_group_with_layout(&group_path)
                 .map_err(|e| UsermodError::CantUpdate(format!("{e}")))?;
 
             // Validate all requested groups exist before mutating anything.
@@ -325,8 +331,10 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
                 }
             }
 
-            atomic::atomic_write(&group_path, |f| group::write_group(&ge, f))
-                .map_err(|e| UsermodError::CantUpdate(format!("{e}")))?;
+            atomic::atomic_write(&group_path, |f| {
+                group::write_group_with_layout(&ge, &group_layout, f)
+            })
+            .map_err(|e| UsermodError::CantUpdate(format!("{e}")))?;
             drop(glock);
         }
     }

--- a/tests/by-util/test_pwck.rs
+++ b/tests/by-util/test_pwck.rs
@@ -422,3 +422,33 @@ fn test_read_only_and_sort_conflict() {
     let code = run(&["pwck", "-r", "-s", "-R", prefix]);
     assert_ne!(code, 0, "-r and -s cannot be combined");
 }
+
+#[test]
+fn test_sort_keeps_each_comment_with_its_entry() {
+    let dir = setup_root(
+        "# top comment\n\
+         z:x:3000:3000::/home/z:/bin/sh\n\
+         # about a\n\
+         a:x:1000:1000::/home/a:/bin/sh\n\
+         +@staff\n",
+        "z:!:1::::::\na:!:1::::::\n",
+        "z:x:3000:\na:x:1000:\n",
+    );
+    // Home directories, so the checks report nothing and -s may write.
+    std::fs::create_dir_all(dir.path().join("home/a")).unwrap();
+    std::fs::create_dir_all(dir.path().join("home/z")).unwrap();
+    std::fs::write(dir.path().join("etc/shells"), "/bin/sh\n").unwrap();
+
+    let prefix = dir.path().to_str().unwrap();
+    assert_eq!(run(&["pwck", "-s", "-R", prefix]), 0, "clean file sorts");
+
+    assert_eq!(
+        read_etc(&dir, "passwd"),
+        "# about a\n\
+         a:x:1000:1000::/home/a:/bin/sh\n\
+         # top comment\n\
+         z:x:3000:3000::/home/z:/bin/sh\n\
+         +@staff\n",
+        "each comment follows the entry it described, and the compat line stays last"
+    );
+}

--- a/tests/by-util/test_useradd.rs
+++ b/tests/by-util/test_useradd.rs
@@ -611,3 +611,47 @@ fn test_key_missing_equals_exits_error() {
     let code = run_with_root(&dir, &["-K", "UID_MIN", "-M", "-N", "badkeyuser"]);
     assert_eq!(code, 3, "invalid KEY=VALUE should exit 3 (bad argument)");
 }
+
+// ---------------------------------------------------------------------------
+// Comments and NIS compat lines survive a rewrite
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_comments_and_compat_lines_survive_useradd() {
+    if common::skip_unless_root() {
+        return;
+    }
+
+    let dir = setup_root_dir();
+    let etc = dir.path().join("etc");
+    std::fs::write(
+        etc.join("passwd"),
+        "# System accounts\n\
+         root:x:0:0:root:/root:/bin/bash\n\
+         \n\
+         # pulled from the directory\n\
+         +@staff\n\
+         +::::::\n",
+    )
+    .unwrap();
+    std::fs::write(etc.join("group"), "# Local groups\nroot:x:0:\n+:::\n").unwrap();
+
+    let code = run_with_root(&dir, &["-N", "alice"]);
+    assert_eq!(code, 0, "useradd must work on a compat host");
+
+    let passwd = read_passwd(&dir);
+    assert!(passwd.contains("alice:"), "the account was added");
+    assert!(
+        passwd.contains("# System accounts") && passwd.contains("# pulled from the directory"),
+        "comments must survive the rewrite, got: {passwd}"
+    );
+    assert!(
+        passwd.contains("+@staff") && passwd.contains("+::::::"),
+        "NIS compat lines must survive the rewrite, got: {passwd}"
+    );
+    let group = read_group(&dir);
+    assert!(
+        group.contains("# Local groups") && group.contains("+:::"),
+        "group comments and compat lines must survive, got: {group}"
+    );
+}


### PR DESCRIPTION
Closes #241.

## Two bugs, one cause

A record file holds more than entries. The parsers returned only entries, so everything else was lost the moment any tool rewrote the file:

- **Comments and blank lines were deleted.** The first `useradd`, `usermod`, `groupadd`… erased every comment in `/etc/passwd` and `/etc/group`. Admins annotate those files; we were silently throwing the annotations away.
- **NIS compat lines broke every tool.** `+user`, `+@netgroup`, `-user` and a bare `+::::::` are what `nsswitch.conf(5)` documents for `compat` mode. They are not in the record format, so they did not parse — on such a host *every* tool failed on the first one it met.

## Fix

`shadow_core::records` reads a file into entries **plus a `Layout`** holding the non-entry lines, and writes them back. Each raw line is anchored to the **name of the entry it preceded**, not to a line number, so:

- it stays with that entry when the file is reordered — a comment describing an account follows the account when `pwck -s` sorts;
- it survives entries being added or removed elsewhere;
- a line whose anchor entry disappears is written at the end rather than dropped.

The entry-only readers (`read_passwd_file` and friends) now *skip* raw lines instead of failing on them, so every read-only caller works on a compat host with no signature change. Every read-then-write path in the eleven mutating tools moved to the layout-preserving pair.

`pwck` and `grpck` additionally **re-read under the lock** before sorting. They were sorting entries read *before* the lock was taken, so a concurrent change could be silently overwritten — a TOCTOU that came out of the same audit.

## Verified (Debian image)

On a tree carrying comments and compat lines, a full `useradd → usermod → groupadd → groupmod → userdel → groupdel` cycle now exits 0 at every step (before: `groupadd` and `userdel` failed with `invalid GID ''` / `missing passwd`), and afterwards:

```
# System accounts
root:x:0:0:root:/root:/bin/bash
# Service accounts below
svc:x:999:999::/srv:/usr/sbin/nologin

# NIS compat: pull the rest from the directory
+@staff
+::::::
```

— every comment, the blank line and both compat lines intact.

`pwck -s` on `# top comment / z(3000) / # about a / a(1000) / +@staff` produces `# about a / a / # top comment / z / +@staff`: sorted by UID with each comment carried along and the compat line still last.

`fmt`, `clippy -D warnings` ±`pam`, `cargo test --workspace` green, plus six new unit tests for the layout (byte-identical round trip, compat preservation, reorder, removal, append, malformed still errors) and two integration tests pinning the tool-level behaviour.
