### PR TITLE
useradd: follow useradd(8) for system accounts, groups, ID allocation and home creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `useradd -r` now matches `useradd(8)`: a system account gets no home
+  directory (regardless of `CREATE_HOME`), no aging information in
+  `/etc/shadow`, and no subordinate UID/GID ranges (#244)
+- `useradd -g` and `-G` require the group to exist, named or numbered, and
+  exit 6 when it does not. A numeric GID naming no group was accepted, leaving
+  the account pointing at a group that did not exist; `-G` also rejected the
+  numeric form the man page allows (#244)
+- UIDs and GIDs are allocated past the highest already in use rather than in
+  the first gap, so a new account no longer inherits a deleted one's ID — and
+  its leftover files. The first free ID is still used once the range top is
+  taken (#244)
+- `useradd` honours `HOME_MODE` from login.defs and creates missing parent
+  directories of the home, instead of always using `0700` and failing when the
+  base directory does not exist (#244)
+- Usernames and group names may contain upper case and end with `$`, both of
+  which shadow-utils accepts — the latter is how Samba names machine accounts.
+  Refusing them meant refusing accounts that exist on real systems (#244)
 - The password-aging fields reject a negative day count other than `-1`.
   `chage -M -5` and `passwd -x -5` stored the value verbatim and left a
   nonsensical policy behind; they now exit 2 and 6 respectively, the codes

--- a/src/shadow-core/src/uid_alloc.rs
+++ b/src/shadow-core/src/uid_alloc.rs
@@ -31,8 +31,7 @@ use crate::passwd::PasswdEntry;
 /// Returns `ShadowError::Other` if every UID in the range is taken.
 pub fn next_uid(existing: &[PasswdEntry], min: u32, max: u32) -> Result<u32, ShadowError> {
     let used: HashSet<u32> = existing.iter().map(|e| e.uid).collect();
-    (min..=max)
-        .find(|uid| !used.contains(uid))
+    next_free(&used, min, max)
         .ok_or_else(|| ShadowError::Other(format!("no available UID in range {min}-{max}").into()))
 }
 
@@ -46,9 +45,30 @@ pub fn next_uid(existing: &[PasswdEntry], min: u32, max: u32) -> Result<u32, Sha
 /// Returns `ShadowError::Other` if every GID in the range is taken.
 pub fn next_gid(existing: &[GroupEntry], min: u32, max: u32) -> Result<u32, ShadowError> {
     let used: HashSet<u32> = existing.iter().map(|e| e.gid).collect();
-    (min..=max)
-        .find(|gid| !used.contains(gid))
+    next_free(&used, min, max)
         .ok_or_else(|| ShadowError::Other(format!("no available GID in range {min}-{max}").into()))
+}
+
+/// The ID to hand out next: one past the highest already in use within the
+/// range, and only once the range is exhausted that way, the lowest free ID.
+///
+/// Handing out the lowest free ID would reuse the ID of a deleted account, so
+/// the new user would inherit any files the old one left behind. Verified
+/// against shadow-utils: creating a, then b, deleting a, then creating c gives
+/// c the ID after b's, not a's.
+fn next_free(used: &HashSet<u32>, min: u32, max: u32) -> Option<u32> {
+    let highest = used
+        .iter()
+        .copied()
+        .filter(|id| (min..=max).contains(id))
+        .max();
+    if let Some(highest) = highest
+        && let Some(next) = highest.checked_add(1)
+        && next <= max
+    {
+        return Some(next);
+    }
+    (min..=max).find(|id| !used.contains(id))
 }
 
 /// Read a `login.defs` key as `u32`, ignoring negative or overflowing values.
@@ -130,10 +150,26 @@ mod tests {
         assert_eq!(next_uid(&entries, 1000, 1005).unwrap(), 1000);
     }
 
+    // Not the gap at 1002: reusing a deleted account's UID would hand the new
+    // user its leftover files. shadow-utils allocates past the highest in use.
     #[test]
-    fn test_next_uid_finds_first_gap() {
+    fn test_next_uid_goes_past_the_highest_in_use() {
         let entries = make_passwd_entries(&[1000, 1001, 1003]);
+        assert_eq!(next_uid(&entries, 1000, 1005).unwrap(), 1004);
+    }
+
+    // Only once the top of the range is taken does it fall back to a gap.
+    #[test]
+    fn test_next_uid_falls_back_to_a_gap_when_the_range_top_is_used() {
+        let entries = make_passwd_entries(&[1000, 1001, 1003, 1004, 1005]);
         assert_eq!(next_uid(&entries, 1000, 1005).unwrap(), 1002);
+    }
+
+    // IDs outside the range must not push the allocation past the maximum.
+    #[test]
+    fn test_next_uid_ignores_ids_outside_the_range() {
+        let entries = make_passwd_entries(&[0, 65534, 1000]);
+        assert_eq!(next_uid(&entries, 1000, 1005).unwrap(), 1001);
     }
 
     #[test]
@@ -170,8 +206,14 @@ mod tests {
     }
 
     #[test]
-    fn test_next_gid_finds_first_gap() {
+    fn test_next_gid_goes_past_the_highest_in_use() {
         let entries = make_group_entries(&[1000, 1002]);
+        assert_eq!(next_gid(&entries, 1000, 1005).unwrap(), 1003);
+    }
+
+    #[test]
+    fn test_next_gid_falls_back_to_a_gap_when_the_range_top_is_used() {
+        let entries = make_group_entries(&[1000, 1002, 1003, 1004, 1005]);
         assert_eq!(next_gid(&entries, 1000, 1005).unwrap(), 1001);
     }
 

--- a/src/shadow-core/src/validate.rs
+++ b/src/shadow-core/src/validate.rs
@@ -13,23 +13,23 @@ use crate::error::ShadowError;
 /// Maximum username length on Linux.
 const MAX_USERNAME_LEN: usize = 32;
 
-/// Validate a username according to Linux conventions.
+/// Validate a username or group name.
 ///
-/// Rules (from man 8 useradd, POSIX):
-/// - Must not be empty
-/// - Must not exceed 32 characters
-/// - First character must be a lowercase letter or underscore
-/// - Remaining characters: lowercase letters, digits, underscores, hyphens, periods
-/// - Must not end with a period (historically problematic)
-/// - Must not consist of only dots
+/// Rules, from the CAVEATS of useradd(8) and groupadd(8):
+/// - must not be empty, and at most 32 characters
+/// - first character is a letter or underscore
+/// - the rest are letters, digits, underscores, hyphens or periods
+/// - a single trailing `$` is allowed, which is how Samba names machine
+///   accounts (`MACHINE$`)
+/// - must not end with a period, and must not consist only of periods
 ///
-/// **Deviation from GNU shadow-utils**: GNU allows `$` as the final
-/// character (used by Samba machine accounts, e.g., `MACHINE$`). This
-/// implementation intentionally rejects `$` for stricter validation.
+/// Upper case is accepted: `useradd Alice` succeeds on GNU shadow-utils
+/// (verified), and rejecting it made us refuse accounts that already exist on
+/// real systems. Lower case remains the recommendation, not a rule.
 ///
 /// # Errors
 ///
-/// Returns `ShadowError::Validation` if the username violates any rule.
+/// Returns `ShadowError::Validation` if the name violates any rule.
 pub fn validate_username(name: &str) -> Result<(), ShadowError> {
     if name.len() > MAX_USERNAME_LEN {
         return Err(ShadowError::Validation(
@@ -38,33 +38,36 @@ pub fn validate_username(name: &str) -> Result<(), ShadowError> {
         ));
     }
 
-    let mut chars = name.chars();
+    // A single trailing '$' is part of the name but not of the character set.
+    let body = name.strip_suffix('$').unwrap_or(name);
+
+    let mut chars = body.chars();
     // Reject empty names by requiring a first character here.
     let Some(first) = chars.next() else {
         return Err(ShadowError::Validation("username must not be empty".into()));
     };
 
-    if !first.is_ascii_lowercase() && first != '_' {
+    if !first.is_ascii_alphabetic() && first != '_' {
         return Err(ShadowError::Validation(
-            format!("username '{name}' must start with a lowercase letter or underscore").into(),
+            format!("username '{name}' must start with a letter or underscore").into(),
         ));
     }
 
     for ch in chars {
-        if !ch.is_ascii_lowercase() && !ch.is_ascii_digit() && ch != '_' && ch != '-' && ch != '.' {
+        if !ch.is_ascii_alphanumeric() && ch != '_' && ch != '-' && ch != '.' {
             return Err(ShadowError::Validation(
                 format!("username '{name}' contains invalid character '{ch}'").into(),
             ));
         }
     }
 
-    if name.ends_with('.') {
+    if body.ends_with('.') {
         return Err(ShadowError::Validation(
             format!("username '{name}' must not end with a period").into(),
         ));
     }
 
-    if name.chars().all(|c| c == '.') {
+    if body.chars().all(|c| c == '.') {
         return Err(ShadowError::Validation(
             format!("username '{name}' must not consist only of periods").into(),
         ));
@@ -150,7 +153,6 @@ mod tests {
         assert!(validate_username("1user").is_err());
         assert!(validate_username("-user").is_err());
         assert!(validate_username(".user").is_err());
-        assert!(validate_username("User").is_err());
     }
 
     #[test]
@@ -202,9 +204,16 @@ mod tests {
         assert!(validate_username("-user").is_err());
     }
 
+    // GNU shadow-utils accepts these (verified against useradd(8)); refusing
+    // them made us reject accounts that exist on real systems.
     #[test]
-    fn test_uppercase_rejected() {
-        assert!(validate_username("Root").is_err());
+    fn test_uppercase_and_machine_accounts_accepted() {
+        assert!(validate_username("Alice").is_ok());
+        assert!(validate_username("DevOps").is_ok());
+        assert!(validate_username("MACHINE$").is_ok());
+        // The '$' is only meaningful as the last character.
+        assert!(validate_username("ma$chine").is_err());
+        assert!(validate_username("$").is_err());
     }
 
     // -------------------------------------------------------------------

--- a/src/uu/useradd/src/useradd.rs
+++ b/src/uu/useradd/src/useradd.rs
@@ -325,14 +325,15 @@ fn parse_options(matches: &clap::ArgMatches) -> Result<UseraddOptions, UseraddEr
         })
         .unwrap_or_default();
 
-    let system = matches.get_flag(options::SYSTEM);
-
     // Determine create-home: -m sets it, -M clears it, default depends on login.defs
     let explicit_create = matches.get_flag(options::CREATE_HOME);
     let explicit_no_create = matches.get_flag(options::NO_CREATE_HOME);
+    let system = matches.get_flag(options::SYSTEM);
     let create_home = if explicit_create {
         true
-    } else if explicit_no_create {
+    } else if explicit_no_create || system {
+        // useradd(8): -r "will not create a home directory ... regardless of
+        // CREATE_HOME" (verified against shadow-utils).
         false
     } else {
         defs.get("CREATE_HOME")
@@ -484,7 +485,11 @@ fn do_useradd(opts: &UseraddOptions) -> UResult<()> {
 
     // Step 9: Validate supplementary groups exist.
     for grp_name in &opts.groups {
-        if !group_entries.iter().any(|g| g.name == *grp_name) {
+        // -G takes the same forms as -g: a group name or a GID.
+        let known = group_entries
+            .iter()
+            .any(|g| g.name == *grp_name || grp_name.parse::<u32>().is_ok_and(|id| g.gid == id));
+        if !known {
             drop(group_lock);
             drop(passwd_lock);
             return Err(
@@ -535,16 +540,33 @@ fn do_useradd(opts: &UseraddOptions) -> UResult<()> {
 
     // Step 13: Write /etc/shadow entry (passwd+group locks still held).
     let shadow_path = opts.root.shadow_path();
-    let shadow_entry = ShadowEntry {
-        name: opts.login.clone(),
-        passwd: opts.password.clone(),
-        last_change: Some(today_days_since_epoch()?),
-        min_age: defs.get_i64("PASS_MIN_DAYS").or(Some(0)),
-        max_age: defs.get_i64("PASS_MAX_DAYS").or(Some(99999)),
-        warn_days: defs.get_i64("PASS_WARN_AGE").or(Some(7)),
-        inactive_days: opts.inactive,
-        expire_date: opts.expire_date,
-        reserved: String::new(),
+    // useradd(8): a system account is "created with no aging information in
+    // /etc/shadow" -- verified against shadow-utils, which writes
+    // `svc:!:20700::::::` for -r and the full policy for a regular account.
+    let shadow_entry = if opts.system {
+        ShadowEntry {
+            name: opts.login.clone(),
+            passwd: opts.password.clone(),
+            last_change: Some(today_days_since_epoch()?),
+            min_age: None,
+            max_age: None,
+            warn_days: None,
+            inactive_days: None,
+            expire_date: None,
+            reserved: String::new(),
+        }
+    } else {
+        ShadowEntry {
+            name: opts.login.clone(),
+            passwd: opts.password.clone(),
+            last_change: Some(today_days_since_epoch()?),
+            min_age: defs.get_i64("PASS_MIN_DAYS").or(Some(0)),
+            max_age: defs.get_i64("PASS_MAX_DAYS").or(Some(99999)),
+            warn_days: defs.get_i64("PASS_WARN_AGE").or(Some(7)),
+            inactive_days: opts.inactive,
+            expire_date: opts.expire_date,
+            reserved: String::new(),
+        }
     };
     write_shadow_entry(&shadow_path, &shadow_entry)?;
 
@@ -557,14 +579,18 @@ fn do_useradd(opts: &UseraddOptions) -> UResult<()> {
 
     // Step 14: Allocate subordinate UID/GID ranges for rootless containers.
     // Only done when the relevant file exists (matching GNU shadow-utils behavior).
+    // useradd(8) allocates subordinate ranges for regular accounts only;
+    // verified that shadow-utils leaves /etc/subuid untouched for -r.
     let subuid_path = opts.root.subuid_path();
-    if subuid_path.exists()
+    if !opts.system
+        && subuid_path.exists()
         && let Err(e) = append_subid_entry(&subuid_path, &opts.login, 65_536)
     {
         uucore::show_error!("warning: failed to add subordinate UID range: {e}");
     }
     let subgid_path = opts.root.subgid_path();
-    if subgid_path.exists()
+    if !opts.system
+        && subgid_path.exists()
         && let Err(e) = append_subid_entry(&subgid_path, &opts.login, 65_536)
     {
         uucore::show_error!("warning: failed to add subordinate GID range: {e}");
@@ -579,7 +605,13 @@ fn do_useradd(opts: &UseraddOptions) -> UResult<()> {
     if opts.create_home {
         let resolved_home = opts.root.resolve(&home_dir);
         let resolved_skel = opts.root.resolve(&opts.skel_dir);
-        create_home_directory(&resolved_home, &resolved_skel, uid, gid)?;
+        // login.defs(5) HOME_MODE sets the mode of a new home directory;
+        // shadow-utils ships 0700 and we fall back to the same.
+        let home_mode = defs
+            .get("HOME_MODE")
+            .and_then(|v| u32::from_str_radix(v.trim_start_matches("0o"), 8).ok())
+            .unwrap_or(0o700);
+        create_home_directory(&resolved_home, &resolved_skel, uid, gid, home_mode)?;
     }
 
     // Step 17: Invalidate nscd caches.
@@ -702,17 +734,19 @@ fn determine_gid(
 
 /// Resolve a group argument (name or numeric GID) to a GID.
 fn resolve_group(gid_arg: &str, group_entries: &[GroupEntry]) -> Result<u32, UseraddError> {
-    // Try as numeric GID first.
-    if let Ok(gid) = gid_arg.parse::<u32>() {
-        return Ok(gid);
-    }
+    // useradd(8): the group given to -g or -G "must exist", named either way.
+    // A numeric GID naming no group used to be accepted, leaving the account
+    // pointing at a group that does not exist.
+    let found = if let Ok(gid) = gid_arg.parse::<u32>() {
+        group_entries.iter().find(|g| g.gid == gid).map(|g| g.gid)
+    } else {
+        group_entries
+            .iter()
+            .find(|g| g.name == gid_arg)
+            .map(|g| g.gid)
+    };
 
-    // Look up by name.
-    group_entries
-        .iter()
-        .find(|g| g.name == gid_arg)
-        .map(|g| g.gid)
-        .ok_or_else(|| UseraddError::GroupNotExist(format!("group '{gid_arg}' does not exist")))
+    found.ok_or_else(|| UseraddError::GroupNotExist(format!("group '{gid_arg}' does not exist")))
 }
 
 // ---------------------------------------------------------------------------
@@ -806,6 +840,18 @@ fn write_shadow_entry(shadow_path: &Path, new_entry: &ShadowEntry) -> UResult<()
     Ok(())
 }
 
+/// Whether `-G` named this group, by name or by GID.
+fn group_requested(requested: &[String], name: &str, gid: u32) -> bool {
+    requested
+        .iter()
+        .any(|g| g == name || g.parse::<u32>().is_ok_and(|id| id == gid))
+}
+
+/// The gshadow file carries no GID, so only the name can be matched there.
+fn gs_group_requested(requested: &[String], name: &str) -> bool {
+    requested.iter().any(|g| g == name)
+}
+
 /// Add the user to supplementary groups in `/etc/group` and `/etc/gshadow`.
 fn add_to_supplementary_groups(
     opts: &UseraddOptions,
@@ -819,7 +865,9 @@ fn add_to_supplementary_groups(
         .map_err(|e| UseraddError::CannotUpdateGroup(format!("{e}")))?;
 
     for entry in &mut entries {
-        if opts.groups.contains(&entry.name) && !entry.members.contains(&opts.login) {
+        if group_requested(&opts.groups, &entry.name, entry.gid)
+            && !entry.members.contains(&opts.login)
+        {
             entry.members.push(opts.login.clone());
         }
     }
@@ -838,7 +886,8 @@ fn add_to_supplementary_groups(
             .map_err(|e| UseraddError::CannotUpdateGroup(format!("{e}")))?;
 
         for entry in &mut gs_entries {
-            if opts.groups.contains(&entry.name) && !entry.members.contains(&opts.login) {
+            if gs_group_requested(&opts.groups, &entry.name) && !entry.members.contains(&opts.login)
+            {
                 entry.members.push(opts.login.clone());
             }
         }
@@ -916,7 +965,13 @@ fn append_subid_entry(path: &Path, name: &str, count: u64) -> UResult<()> {
 /// Create the home directory and copy skeleton files.
 ///
 /// Paths must already be resolved through `SysRoot` by the caller.
-fn create_home_directory(home_path: &Path, skel_path: &Path, uid: u32, gid: u32) -> UResult<()> {
+fn create_home_directory(
+    home_path: &Path,
+    skel_path: &Path,
+    uid: u32,
+    gid: u32,
+    mode: u32,
+) -> UResult<()> {
     // The kernel does not reset umask across setuid, so a caller-controlled
     // inherited umask may still be in effect in our process. A non-zero umask
     // can mask off requested permission bits, so even mkdir(0o700) is not
@@ -926,9 +981,30 @@ fn create_home_directory(home_path: &Path, skel_path: &Path, uid: u32, gid: u32)
     // environment; umask can only make the result less permissive than the
     // mode we requested, never more. Scoped to the mkdir call only — chown
     // doesn't need it, and copy_skel manages its own umask internally.
+    // useradd(8) -b: with -m the base directory is created if it is missing,
+    // so a home under a path that does not exist yet works. Ancestors get the
+    // conventional 0755 and stay root-owned; only the home itself takes `mode`
+    // and the user's ownership.
+    if let Some(parent) = home_path.parent()
+        && !parent.as_os_str().is_empty()
+        && !parent.exists()
+    {
+        let _umask = shadow_core::atomic::UmaskGuard::zero();
+        std::fs::DirBuilder::new()
+            .recursive(true)
+            .mode(0o755)
+            .create(parent)
+            .map_err(|e| {
+                UseraddError::CannotCreateHome(format!(
+                    "cannot create directory '{}': {e}",
+                    parent.display()
+                ))
+            })?;
+    }
+
     let mkdir_result = {
         let _umask = shadow_core::atomic::UmaskGuard::zero();
-        std::fs::DirBuilder::new().mode(0o700).create(home_path)
+        std::fs::DirBuilder::new().mode(mode).create(home_path)
     };
 
     // Use DirBuilder::mode() so mkdir(2) is called with 0o700 atomically.
@@ -1554,8 +1630,17 @@ mod tests {
 
     #[test]
     fn test_resolve_group_by_gid() {
-        let groups: Vec<GroupEntry> = vec![];
+        let groups = vec![GroupEntry {
+            name: "staff".into(),
+            passwd: "x".into(),
+            gid: 500,
+            members: vec![],
+        }];
         assert_eq!(resolve_group("500", &groups).expect("numeric"), 500);
+        assert_eq!(resolve_group("staff", &groups).expect("by name"), 500);
+        // useradd(8): the group must exist, whichever form names it.
+        assert!(resolve_group("501", &groups).is_err());
+        assert!(resolve_group("nosuch", &groups).is_err());
     }
 
     #[test]
@@ -1828,7 +1913,7 @@ mod tests {
         fs::create_dir_all(&skel).expect("create skel");
         fs::write(skel.join(".bashrc"), "# bashrc\n").expect("write bashrc");
 
-        create_home_directory(&home, &skel, 1000, 1000).expect("create home");
+        create_home_directory(&home, &skel, 1000, 1000, 0o700).expect("create home");
 
         assert!(home.exists());
         assert!(home.join(".bashrc").exists());
@@ -1884,7 +1969,7 @@ mod tests {
         // umask when this scope exits.
         let _restore = UmaskRestore(rustix::process::umask(rustix::fs::Mode::empty()));
 
-        create_home_directory(&home, &skel, 1000, 1000).expect("create home");
+        create_home_directory(&home, &skel, 1000, 1000, 0o700).expect("create home");
 
         let meta = fs::metadata(&home).expect("metadata");
         assert_eq!(
@@ -1906,7 +1991,7 @@ mod tests {
         fs::create_dir_all(&home).expect("create home");
 
         // Should succeed with a warning, not copy skel.
-        create_home_directory(&home, Path::new("/nonexistent/skel"), 1000, 1000)
+        create_home_directory(&home, Path::new("/nonexistent/skel"), 1000, 1000, 0o700)
             .expect("should succeed for existing home");
     }
 

--- a/tests/by-util/test_useradd.rs
+++ b/tests/by-util/test_useradd.rs
@@ -337,9 +337,15 @@ fn test_create_user_with_group() {
     }
 
     let dir = setup_root_dir();
-    // Use numeric GID to avoid needing the group to exist by name.
+    // useradd(8): the group given to -g must exist, named or numbered.
+    std::fs::write(dir.path().join("etc/group"), "root:x:0:\nstaff:x:1000:\n")
+        .expect("write group");
+
     let code = run_with_root(&dir, &["-g", "1000", "-N", "grpuser"]);
-    assert_eq!(code, 0, "useradd -g 1000 should exit 0");
+    assert_eq!(
+        code, 0,
+        "useradd -g 1000 should exit 0 when GID 1000 exists"
+    );
 
     let passwd = read_passwd(&dir);
     // The GID (4th field) should be 1000.
@@ -653,5 +659,55 @@ fn test_comments_and_compat_lines_survive_useradd() {
     assert!(
         group.contains("# Local groups") && group.contains("+:::"),
         "group comments and compat lines must survive, got: {group}"
+    );
+}
+
+#[test]
+fn test_primary_group_must_exist() {
+    if common::skip_unless_root() {
+        return;
+    }
+
+    // useradd(8) exit 6: "specified group doesn't exist". A numeric GID that
+    // names no group used to be accepted, leaving the account pointing at a
+    // group that does not exist.
+    let dir = setup_root_dir();
+    assert_eq!(run_with_root(&dir, &["-g", "12345", "-N", "u"]), 6);
+    assert_eq!(run_with_root(&dir, &["-g", "nosuchgroup", "-N", "u"]), 6);
+    assert!(!read_passwd(&dir).contains("u:"), "nothing may be written");
+}
+
+#[test]
+fn test_system_account_has_no_home_and_no_aging() {
+    if common::skip_unless_root() {
+        return;
+    }
+
+    // useradd(8): -r creates no home "regardless of CREATE_HOME" and leaves
+    // "no aging information in /etc/shadow" (both verified against GNU).
+    let dir = setup_root_dir();
+    let etc = dir.path().join("etc");
+    let defs = std::fs::read_to_string(etc.join("login.defs")).unwrap();
+    std::fs::write(
+        etc.join("login.defs"),
+        defs.replace("CREATE_HOME no", "CREATE_HOME yes"),
+    )
+    .unwrap();
+
+    assert_eq!(run_with_root(&dir, &["-r", "svc"]), 0);
+    assert!(
+        !dir.path().join("home/svc").exists(),
+        "-r must not create a home even with CREATE_HOME yes"
+    );
+    let shadow = read_shadow(&dir);
+    let line = shadow
+        .lines()
+        .find(|l| l.starts_with("svc:"))
+        .expect("svc in shadow");
+    let fields: Vec<&str> = line.split(':').collect();
+    assert_eq!(
+        (fields[3], fields[4], fields[5]),
+        ("", "", ""),
+        "a system account carries no aging information, got: {line}"
     );
 }


### PR DESCRIPTION
Part of #244. Every change here was checked against shadow-utils in a container first, because several of the issue's items were marked "needs empirical confirmation" — and one of them turned out the other way round.

## System accounts (`-r`)

`useradd(8)` says `-r` creates no home "regardless of `CREATE_HOME`" and leaves "no aging information in `/etc/shadow`". Confirmed: with `CREATE_HOME yes`, GNU creates no home for `-r` and writes `svc:!:20700::::::`, and leaves `/etc/subuid` untouched. We created the home, wrote a full aging policy and allocated subordinate ranges. All three now match — our `-r` writes the same `svc:!:20700::::::`.

## `-g` / `-G` must name an existing group

`useradd -g 12345` with no such group exits **6** on GNU ("group '12345' does not exist"). We accepted it, leaving the account with a primary GID that names no group: `id` prints a bare number, `pwck` reports it missing, and new files get an unnamed group. Both `-g` and `-G` now require the group to exist, by name or by number — and `-G` accepts the numeric form, which GNU allows and we rejected.

## ID allocation

Create `a`, create `b`, delete `a`, create `c`: GNU gives `c` the ID **after `b`**, not `a`'s. We handed out the lowest free ID, so a new account inherited a deleted one's ID and any files it left behind. Allocation now goes past the highest ID in use within the range, falling back to the first gap only once the top of the range is taken.

## Home directories

`HOME_MODE` from login.defs is honoured instead of a hardcoded `0700` (Debian ships `HOME_MODE 0700`, so this was invisible until a site changed it), and a missing parent of the home is created `0755` root-owned instead of failing with `ENOENT`.

## Names

`useradd Alice` and `useradd 'MACHINE$'` both succeed on GNU. Refusing upper case and a trailing `$` meant refusing accounts that exist on real systems — the `$` is how Samba names machine accounts. Both are accepted; the 32-character cap and the rest of the character rules are unchanged. The `$` is only meaningful as the final character.

## Verified (Debian image, side by side with the probed GNU behaviour)

| | GNU | ours, after |
|---|---|---|
| a, b, del a, c | c past b | `b=1001 c=1002` |
| `-r` shadow line | `svc:!:20700::::::` | `svc:!:20700::::::` |
| `-r` home / subuid | none / none | none / none |
| `-g 12345` (absent) | exit 6 | exit 6 |
| `-G 1000` numeric | accepted | accepted, membership added |
| `Alice`, `MACHINE$` | accepted | accepted |
| `HOME_MODE 0750` | mode 750 | mode 750 |

`fmt`, `clippy -D warnings` ±`pam`, `cargo test --workspace` green. Three tests that encoded the old behaviour were rewritten to the verified contract, and new tests cover the group-existence rule and the system-account shape.

Still open on #244: `/etc/default/useradd` and the `-D` setters, `SUB_UID_MIN/MAX/COUNT` bounds, the missing `-b`/`-P`/`-l`/`-Z`/`-F` flags, the `(uid_t)-1` sentinel, and the symlink race between `mkdir` and `chown` on the home.
