### PR TITLE
usermod: fix the group handling and report the documented exit codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `usermod -g` takes a group name as well as a GID, and requires the group to
+  exist (exit 6). A numeric GID naming no group was written through, leaving a
+  primary group that does not exist (#242)
+- `usermod -G ""` clears every supplementary membership, as `usermod(8)`
+  documents, instead of reporting a group named `''` that does not exist;
+  `-G` accepts GIDs as well as names, `-a` requires `-G`, and `/etc/gshadow`
+  is kept in step with `/etc/group` on both `-G` and `-l` — leaving it behind
+  is what `grpck` reports as "members differ" (#242)
+- `usermod -l` combined with `-G` adds the **new** login to the groups; it
+  used to add the old one, which no longer names an account (#242)
+- `usermod -L` no longer prepends a second `!` to an already-locked password
+  (a single `-U` could not undo that), and `-U` refuses to leave an account
+  with no password at all instead of silently doing nothing (#242)
+- Group errors from `usermod` report the codes `usermod(8)` documents: 6 for a
+  group that does not exist, 10 for a failure to update the group file (#242)
 - `useradd` reads `/etc/default/useradd`, and `useradd -D` with a value now
   saves it there instead of printing the defaults and changing nothing.
   `HOME`, `SHELL` and `SKEL` from that file take precedence over login.defs,

--- a/src/uu/usermod/src/usermod.rs
+++ b/src/uu/usermod/src/usermod.rs
@@ -16,6 +16,7 @@ use uucore::error::{UError, UResult};
 
 use shadow_core::audit;
 use shadow_core::group::{self};
+use shadow_core::gshadow::{self};
 use shadow_core::lock::FileLock;
 use shadow_core::passwd::{self};
 use shadow_core::shadow::{self};
@@ -48,6 +49,8 @@ enum UsermodError {
     UserNotFound(String),
     UidInUse(String),
     NameInUse(String),
+    GroupNotFound(String),
+    CantUpdateGroup(String),
 }
 
 impl fmt::Display for UsermodError {
@@ -57,7 +60,9 @@ impl fmt::Display for UsermodError {
             | Self::BadArgument(msg)
             | Self::UserNotFound(msg)
             | Self::UidInUse(msg)
-            | Self::NameInUse(msg) => f.write_str(msg),
+            | Self::NameInUse(msg)
+            | Self::GroupNotFound(msg)
+            | Self::CantUpdateGroup(msg) => f.write_str(msg),
         }
     }
 }
@@ -69,9 +74,13 @@ impl UError for UsermodError {
         match self {
             Self::CantUpdate(_) => 1,
             Self::BadArgument(_) => 3,
-            Self::UserNotFound(_) => 6,
+            // usermod(8): 6 covers both "user doesn't exist" and
+            // "specified group doesn't exist".
+            Self::UserNotFound(_) | Self::GroupNotFound(_) => 6,
             Self::UidInUse(_) => 4,
             Self::NameInUse(_) => 9,
+            // usermod(8): 10 = can't update the group file.
+            Self::CantUpdateGroup(_) => 10,
         }
     }
 }
@@ -129,6 +138,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     };
 
     // Modify /etc/passwd.
+    let group_path_for_lookup = root.group_path();
     let passwd_path = root.passwd_path();
     let lock = FileLock::acquire(&passwd_path)
         .map_err(|e| UsermodError::CantUpdate(format!("cannot lock: {e}")))?;
@@ -164,7 +174,26 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     if let Some(s) = matches.get_one::<String>(options::SHELL) {
         entries[idx].shell.clone_from(s);
     }
-    if let Some(&gid) = matches.get_one::<u32>(options::GID) {
+    if let Some(group_arg) = matches.get_one::<String>(options::GID) {
+        // usermod(8): -g takes a group name or a GID, and the group "must
+        // exist". A numeric GID naming no group used to be written through,
+        // leaving a primary group that does not exist.
+        let groups = if group_path_for_lookup.exists() {
+            group::read_group_file(&group_path_for_lookup).unwrap_or_default()
+        } else {
+            Vec::new()
+        };
+        let resolved = if let Ok(gid) = group_arg.parse::<u32>() {
+            groups.iter().find(|g| g.gid == gid).map(|g| g.gid)
+        } else {
+            groups.iter().find(|g| g.name == *group_arg).map(|g| g.gid)
+        };
+        let Some(gid) = resolved else {
+            drop(lock);
+            return Err(
+                UsermodError::GroupNotFound(format!("group '{group_arg}' does not exist")).into(),
+            );
+        };
         entries[idx].gid = gid;
     }
     let new_login = matches.get_one::<String>(options::LOGIN);
@@ -237,11 +266,17 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
             .into());
         };
 
-        if do_lock {
+        if do_lock && !s.passwd.starts_with('!') {
+            // Locking twice would prepend a second '!', which a single -U
+            // then fails to undo.
             s.lock();
         }
-        if do_unlock {
-            s.unlock();
+        if do_unlock && !s.unlock() {
+            drop(slock);
+            return Err(UsermodError::BadArgument(format!(
+                "unlocking '{login}' would leave the account without a password"
+            ))
+            .into());
         }
         if let Some(parsed) = expire_date {
             s.expire_date = parsed;
@@ -284,6 +319,28 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
                 }
             }
 
+            // Mirror the rename in gshadow's member and admin lists.
+            let gshadow_path = root.gshadow_path();
+            if gshadow_path.exists()
+                && let Ok((mut gs, gs_layout)) = gshadow::read_gshadow_with_layout(&gshadow_path)
+            {
+                let mut gs_changed = false;
+                for g in &mut gs {
+                    for m in g.members.iter_mut().chain(g.admins.iter_mut()) {
+                        if *m == *login {
+                            m.clone_from(new_name);
+                            gs_changed = true;
+                        }
+                    }
+                }
+                if gs_changed {
+                    atomic::atomic_write(&gshadow_path, |f| {
+                        gshadow::write_gshadow_with_layout(&gs, &gs_layout, f)
+                    })
+                    .map_err(|e| UsermodError::CantUpdateGroup(format!("{e}")))?;
+                }
+            }
+
             if changed {
                 atomic::atomic_write(&group_path, |f| {
                     group::write_group_with_layout(&ge, &group_layout, f)
@@ -299,43 +356,96 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         let group_path = root.group_path();
         if group_path.exists() {
             let append = matches.get_flag(options::APPEND);
-            let new_groups: Vec<&str> = groups_str.split(',').map(str::trim).collect();
+            // usermod(8): an empty -G list removes every supplementary
+            // membership. Splitting "" yielded one empty name, which was then
+            // reported as a group that does not exist.
+            let new_groups: Vec<&str> = groups_str
+                .split(',')
+                .map(str::trim)
+                .filter(|g| !g.is_empty())
+                .collect();
+
+            // The member name to write is the one the account will carry: with
+            // -l the rename above already happened, and using the old login
+            // added a member that no longer exists.
+            let member = new_login.unwrap_or(login);
 
             let glock = FileLock::acquire(&group_path)
-                .map_err(|e| UsermodError::CantUpdate(format!("cannot lock group: {e}")))?;
+                .map_err(|e| UsermodError::CantUpdateGroup(format!("cannot lock group: {e}")))?;
 
             let (mut ge, group_layout) = group::read_group_with_layout(&group_path)
-                .map_err(|e| UsermodError::CantUpdate(format!("{e}")))?;
+                .map_err(|e| UsermodError::CantUpdateGroup(format!("{e}")))?;
 
-            // Validate all requested groups exist before mutating anything.
+            // Validate every requested group first: -G takes names or GIDs,
+            // and each must exist (usermod(8) exit 6).
+            let mut wanted: Vec<String> = Vec::with_capacity(new_groups.len());
             for gname in &new_groups {
-                if !ge.iter().any(|g| g.name == *gname) {
+                let found = ge
+                    .iter()
+                    .find(|g| g.name == *gname || gname.parse::<u32>().is_ok_and(|id| g.gid == id))
+                    .map(|g| g.name.clone());
+                let Some(name) = found else {
                     drop(glock);
-                    return Err(UsermodError::CantUpdate(format!(
+                    return Err(UsermodError::GroupNotFound(format!(
                         "group '{gname}' does not exist"
                     ))
                     .into());
-                }
+                };
+                wanted.push(name);
             }
 
             if !append {
                 for g in &mut ge {
-                    g.members.retain(|m| m != login);
+                    g.members.retain(|m| m != login && m != member);
                 }
             }
-            for gname in &new_groups {
+            for gname in &wanted {
                 if let Some(g) = ge.iter_mut().find(|g| g.name == *gname)
-                    && !g.members.iter().any(|m| m == login)
+                    && !g.members.iter().any(|m| m == member)
                 {
-                    g.members.push(login.clone());
+                    g.members.push(member.clone());
                 }
             }
 
             atomic::atomic_write(&group_path, |f| {
                 group::write_group_with_layout(&ge, &group_layout, f)
             })
-            .map_err(|e| UsermodError::CantUpdate(format!("{e}")))?;
+            .map_err(|e| UsermodError::CantUpdateGroup(format!("{e}")))?;
             drop(glock);
+
+            // /etc/gshadow carries the same membership lists; leaving it
+            // behind is exactly what grpck reports as "members differ".
+            let gshadow_path = root.gshadow_path();
+            if gshadow_path.exists() {
+                let gshadow_guard = FileLock::acquire(&gshadow_path).map_err(|e| {
+                    UsermodError::CantUpdateGroup(format!("cannot lock gshadow: {e}"))
+                })?;
+                let (mut gs, gs_layout) = gshadow::read_gshadow_with_layout(&gshadow_path)
+                    .map_err(|e| UsermodError::CantUpdateGroup(format!("{e}")))?;
+                let mut gs_changed = false;
+                if !append {
+                    for g in &mut gs {
+                        let before = g.members.len();
+                        g.members.retain(|m| m != login && m != member);
+                        gs_changed |= g.members.len() != before;
+                    }
+                }
+                for gname in &wanted {
+                    if let Some(g) = gs.iter_mut().find(|g| g.name == *gname)
+                        && !g.members.iter().any(|m| m == member)
+                    {
+                        g.members.push(member.clone());
+                        gs_changed = true;
+                    }
+                }
+                if gs_changed {
+                    atomic::atomic_write(&gshadow_path, |f| {
+                        gshadow::write_gshadow_with_layout(&gs, &gs_layout, f)
+                    })
+                    .map_err(|e| UsermodError::CantUpdateGroup(format!("{e}")))?;
+                }
+                drop(gshadow_guard);
+            }
         }
     }
 
@@ -430,8 +540,7 @@ pub fn uu_app() -> Command {
                 .short('g')
                 .long("gid")
                 .value_name("GROUP")
-                .value_parser(clap::value_parser!(u32))
-                .help("Replace the primary group (numeric GID)"),
+                .help("Replace the primary group (name or GID; the group must exist)"),
         )
         .arg(
             Arg::new(options::GROUPS)
@@ -444,6 +553,7 @@ pub fn uu_app() -> Command {
             Arg::new(options::APPEND)
                 .short('a')
                 .long("append")
+                .requires(options::GROUPS)
                 .help("Add to the supplementary groups instead of replacing them (only effective with -G)")
                 .action(ArgAction::SetTrue),
         )

--- a/tests/by-util/test_usermod.rs
+++ b/tests/by-util/test_usermod.rs
@@ -551,3 +551,81 @@ fn test_bad_expiredate_changes_nothing() {
         "no field may be committed when a later argument is invalid"
     );
 }
+
+#[test]
+fn test_primary_group_by_name_and_existence() {
+    if common::skip_unless_root() {
+        return;
+    }
+
+    let dir = setup_prefix(
+        "alice:x:1000:1000:Alice:/home/alice:/bin/sh\n",
+        "alice:$6$h:19500:0:99999:7:::\n",
+        "alice:x:1000:\nstaff:x:2000:\n",
+    );
+
+    // usermod(8): -g takes a name or a GID, and the group must exist.
+    assert_eq!(run_with_prefix(&dir, &["-g", "staff", "alice"]), 0);
+    assert!(read_passwd(&dir).contains("alice:x:1000:2000:"));
+
+    assert_eq!(
+        run_with_prefix(&dir, &["-g", "12345", "alice"]),
+        6,
+        "a GID naming no group is exit 6"
+    );
+    assert_eq!(run_with_prefix(&dir, &["-g", "nosuch", "alice"]), 6);
+    assert!(
+        read_passwd(&dir).contains("alice:x:1000:2000:"),
+        "a failed -g changes nothing"
+    );
+}
+
+#[test]
+fn test_empty_group_list_clears_memberships() {
+    if common::skip_unless_root() {
+        return;
+    }
+
+    let dir = setup_prefix(
+        "alice:x:1000:1000:Alice:/home/alice:/bin/sh\n",
+        "alice:$6$h:19500:0:99999:7:::\n",
+        "alice:x:1000:\nwheel:x:2000:alice\ndocker:x:2001:alice\n",
+    );
+
+    // usermod(8): an empty -G list removes every supplementary membership.
+    assert_eq!(run_with_prefix(&dir, &["-G", "", "alice"]), 0);
+    let group = read_group(&dir);
+    assert!(
+        group.contains("wheel:x:2000:\n") && group.contains("docker:x:2001:\n"),
+        "memberships should be cleared, got: {group}"
+    );
+}
+
+#[test]
+fn test_rename_with_groups_uses_the_new_login() {
+    if common::skip_unless_root() {
+        return;
+    }
+
+    let dir = setup_prefix(
+        "alice:x:1000:1000:Alice:/home/alice:/bin/sh\n",
+        "alice:$6$h:19500:0:99999:7:::\n",
+        "alice:x:1000:\nwheel:x:2000:\n",
+    );
+    std::fs::write(dir.path().join("etc/gshadow"), "wheel:!::\n").unwrap();
+
+    assert_eq!(
+        run_with_prefix(&dir, &["-l", "bob", "-G", "wheel", "alice"]),
+        0
+    );
+    let group = read_group(&dir);
+    assert!(
+        group.contains("wheel:x:2000:bob"),
+        "the new login must be the member, got: {group}"
+    );
+    let gshadow = std::fs::read_to_string(dir.path().join("etc/gshadow")).unwrap();
+    assert!(
+        gshadow.contains("wheel:!::bob"),
+        "gshadow must follow the group file, got: {gshadow}"
+    );
+}


### PR DESCRIPTION
Closes #242 — the group handling, the lock semantics and the exit codes.

## `-g` accepted a GID naming no group

`value_parser!(u32)` meant `-g` took only a number, and nothing checked it existed. `usermod -g 12345 alice` wrote it straight through: `id alice` then prints a bare number, `pwck` reports the group missing, and new files get an unnamed group. It now takes a **name or a GID** and requires the group to exist, exiting **6**.

## `-G` had three separate bugs

- `-G ""` split into one empty name and was rejected as *"group '' does not exist"*. `usermod(8)` defines it as **removing every supplementary membership**; it does that now.
- Only names were accepted; GIDs, which the man page allows, were not.
- `-a` could be given without `-G`, where it means nothing.

## `-l` with `-G` added a member that does not exist

The rename runs first, so by the time the `-G` block ran, the account was already called `bob` — but it added `alice` to the groups, a member naming no account. The new login is used.

## `/etc/gshadow` was never kept in step

Neither `-G` nor `-l` touched it, which is exactly the inconsistency `grpck` reports as *"members differ"*. Both now update it alongside `/etc/group`, and only when something actually changed (writing an unchanged empty gshadow would trip the writer's zero-length guard).

## Lock semantics and exit codes

`-L` prepended a second `!` to an already-locked password, so one `-U` could not undo it; it is idempotent now. `-U` on an account with no password refuses instead of silently doing nothing. Group failures report the documented **6** (group does not exist) and **10** (cannot update the group file) rather than the catch-all 1.

## Verified (Debian image, as root)

- `-g staff` → GID 2000; `-g 12345` and `-g nosuch` → exit 6 with nothing changed.
- `-G ""` on a user in `wheel` and `docker` → both membership lists emptied.
- `-l bob -G wheel alice` → `wheel:x:2000:bob` **and** `wheel:!::bob` in gshadow.
- `fmt`, `clippy -D warnings` ±`pam`, `cargo test --workspace` green, with three new tests covering the above.

Left out deliberately: `-m/--move-home` (moving a home is its own change, with the same ownership and symlink care `useradd` just got), `-o`, `-r`, `-Z` and `-v/-V/-w/-W` (subordinate-range and SELinux flags, which belong with that work).
