### PR TITLE
group tools: close the groupadd race and add the missing options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `groupadd` takes the group lock *before* reading `/etc/group`. The name
+  check and the GID allocation ran on a snapshot taken beforehand, so two
+  concurrent `groupadd -r` calls could allocate the same GID and two
+  `groupadd www` could both decide the name was free (#245)
+- `groupadd -U` and `groupmod -U`/`-a` set a group's member list, and
+  `groupdel -f` removes a group that is a user's primary group and succeeds
+  when the group does not exist — all four documented and all four previously
+  a usage error (#245)
+- `groupmod -p` writes the password into `/etc/group` when there is no
+  `/etc/gshadow`, instead of silently doing nothing (#245)
+- `groupdel` no longer leaves the deleted group behind in `/etc/gshadow` when
+  it was the only entry there, and can delete the last group in `/etc/group`
+  (#245)
 - `usermod -g` takes a group name as well as a GID, and requires the group to
   exist (exit 6). A numeric GID naming no group was written through, leaving a
   primary group that does not exist (#242)

--- a/src/uu/groupadd/src/groupadd.rs
+++ b/src/uu/groupadd/src/groupadd.rs
@@ -35,6 +35,7 @@ mod options {
     pub const SYSTEM: &str = "system";
     pub const ROOT: &str = "root";
     pub const PREFIX: &str = "prefix";
+    pub const USERS: &str = "users";
 }
 
 mod exit_codes {
@@ -125,6 +126,17 @@ fn do_groupadd(matches: &clap::ArgMatches) -> UResult<()> {
     shadow_core::validate::validate_field("password", &password)
         .map_err(|e| GroupaddError::BadArgument(e.to_string()))?;
 
+    let users: Vec<String> = matches
+        .get_one::<String>(options::USERS)
+        .map(|v| {
+            v.split(',')
+                .map(str::trim)
+                .filter(|u| !u.is_empty())
+                .map(ToOwned::to_owned)
+                .collect()
+        })
+        .unwrap_or_default();
+
     let prefix = matches.get_one::<String>(options::PREFIX).map(Path::new);
     let root_dir = matches.get_one::<String>(options::ROOT).map(Path::new);
     let root = SysRoot::new(prefix.or(root_dir));
@@ -147,14 +159,27 @@ fn do_groupadd(matches: &clap::ArgMatches) -> UResult<()> {
     validate::validate_username(&group_name)
         .map_err(|e| GroupaddError::BadArgument(format!("{e}")))?;
 
-    // Read existing groups.
     let group_path = root.group_path();
-    let existing_groups = if group_path.exists() {
-        group::read_group_file(&group_path).map_err(|e| {
+
+    // Block signals for the duration of the critical section so a SIGINT
+    // between lock acquisition and atomic_write cannot leave stale lock files.
+    let _signals = shadow_core::hardening::SignalBlocker::block_critical()
+        .map_err(|e| GroupaddError::CantUpdate(format!("cannot block signals: {e}")))?;
+
+    // Take the lock *before* reading. The name check and the GID allocation
+    // used to run on a snapshot taken beforehand, so two concurrent
+    // `groupadd -r` calls could allocate the same GID, and two `groupadd www`
+    // could both decide the name was free.
+    let group_lock = FileLock::acquire(&group_path).map_err(|e| {
+        GroupaddError::CantUpdate(format!("cannot lock {}: {e}", group_path.display()))
+    })?;
+
+    let (existing_groups, group_layout) = if group_path.exists() {
+        group::read_group_with_layout(&group_path).map_err(|e| {
             GroupaddError::CantUpdate(format!("cannot read {}: {e}", group_path.display()))
         })?
     } else {
-        Vec::new()
+        (Vec::new(), group::Layout::default())
     };
 
     // Check if group name already exists.
@@ -170,16 +195,19 @@ fn do_groupadd(matches: &clap::ArgMatches) -> UResult<()> {
     // Determine GID.
     let gid = determine_gid(matches, &existing_groups, force, non_unique, system, &defs)?;
 
-    // Block signals for the duration of the critical section so a SIGINT
-    // between lock acquisition and atomic_write cannot leave stale lock files.
-    let _signals = shadow_core::hardening::SignalBlocker::block_critical()
-        .map_err(|e| GroupaddError::CantUpdate(format!("cannot block signals: {e}")))?;
-
     // Write to /etc/group.
-    write_group_entry(&group_path, &group_name, gid)?;
+    write_group_entry(
+        &group_path,
+        existing_groups,
+        &group_layout,
+        &group_name,
+        gid,
+        &users,
+    )?;
+    drop(group_lock);
 
     // Write to /etc/gshadow.
-    write_gshadow_entry(&root.gshadow_path(), &group_name, &password)?;
+    write_gshadow_entry(&root.gshadow_path(), &group_name, &password, &users)?;
 
     nscd::invalidate_cache("group");
 
@@ -221,35 +249,28 @@ fn determine_gid(
 }
 
 /// Append a new group entry to /etc/group.
-fn write_group_entry(group_path: &Path, name: &str, gid: u32) -> Result<(), GroupaddError> {
-    let new_group = GroupEntry {
+fn write_group_entry(
+    group_path: &Path,
+    mut entries: Vec<GroupEntry>,
+    layout: &group::Layout,
+    name: &str,
+    gid: u32,
+    members: &[String],
+) -> Result<(), GroupaddError> {
+    entries.push(GroupEntry {
         name: name.to_string(),
         passwd: "x".to_string(),
         gid,
-        members: Vec::new(),
-    };
-
-    let group_lock = FileLock::acquire(group_path).map_err(|e| {
-        GroupaddError::CantUpdate(format!("cannot lock {}: {e}", group_path.display()))
-    })?;
-
-    let (mut entries, group_layout) = if group_path.exists() {
-        group::read_group_with_layout(group_path).map_err(|e| {
-            GroupaddError::CantUpdate(format!("cannot read {}: {e}", group_path.display()))
-        })?
-    } else {
-        (Vec::new(), group::Layout::default())
-    };
-    entries.push(new_group);
+        members: members.to_vec(),
+    });
 
     atomic::atomic_write(group_path, |f| {
-        group::write_group_with_layout(&entries, &group_layout, f)
+        group::write_group_with_layout(&entries, layout, f)
     })
     .map_err(|e| {
         GroupaddError::CantUpdate(format!("cannot write {}: {e}", group_path.display()))
     })?;
 
-    drop(group_lock);
     Ok(())
 }
 
@@ -258,6 +279,7 @@ fn write_gshadow_entry(
     gshadow_path: &Path,
     name: &str,
     password: &str,
+    members: &[String],
 ) -> Result<(), GroupaddError> {
     if !gshadow_path.exists() {
         return Ok(());
@@ -267,7 +289,7 @@ fn write_gshadow_entry(
         name: name.to_string(),
         passwd: password.to_string(),
         admins: Vec::new(),
-        members: Vec::new(),
+        members: members.to_vec(),
     };
 
     let gshadow_lock = FileLock::acquire(gshadow_path).map_err(|e| {
@@ -338,6 +360,13 @@ pub fn uu_app() -> Command {
                 .long("non-unique")
                 .help("Permit a duplicate GID (must accompany -g)")
                 .action(ArgAction::SetTrue),
+        )
+        .arg(
+            Arg::new(options::USERS)
+                .short('U')
+                .long("users")
+                .value_name("USERS")
+                .help("Comma-separated list of users to make members of the new group"),
         )
         .arg(
             Arg::new(options::PASSWORD)

--- a/src/uu/groupdel/src/groupdel.rs
+++ b/src/uu/groupdel/src/groupdel.rs
@@ -27,6 +27,7 @@ mod options {
     pub const GROUP: &str = "GROUP";
     pub const ROOT: &str = "root";
     pub const PREFIX: &str = "prefix";
+    pub const FORCE: &str = "force";
 }
 
 mod exit_codes {
@@ -115,18 +116,24 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         GroupdelError::CantUpdate(format!("cannot read {}: {e}", group_path.display()))
     })?;
 
-    let target = entries
-        .iter()
-        .find(|g| g.name == *group_name)
-        .ok_or_else(|| {
-            GroupdelError::GroupNotFound(format!("group '{group_name}' does not exist"))
-        })?;
+    let force = matches.get_flag(options::FORCE);
+
+    let Some(target) = entries.iter().find(|g| g.name == *group_name) else {
+        // groupdel(8) -f: "succeed even if the group does not exist".
+        if force {
+            return Ok(());
+        }
+        return Err(
+            GroupdelError::GroupNotFound(format!("group '{group_name}' does not exist")).into(),
+        );
+    };
 
     let target_gid = target.gid;
 
-    // Check that no user has this group as their primary group.
+    // Check that no user has this group as their primary group; -f removes it
+    // regardless, which groupdel(8) documents.
     let passwd_path = root.passwd_path();
-    if passwd_path.exists() {
+    if !force && passwd_path.exists() {
         let passwd_entries = passwd::read_passwd_file(&passwd_path).map_err(|e| {
             GroupdelError::CantUpdate(format!("cannot read {}: {e}", passwd_path.display()))
         })?;
@@ -147,12 +154,19 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         .filter(|g| g.name != *group_name)
         .collect();
 
-    atomic::atomic_write(&group_path, |f| {
-        group::write_group_with_layout(&new_entries, &group_layout, f)
-    })
-    .map_err(|e| {
-        GroupdelError::CantUpdate(format!("cannot write {}: {e}", group_path.display()))
-    })?;
+    // Removing the last group empties the file, which the atomic writer
+    // refuses; an absent group file means the same thing and is only reached
+    // in a fully torn-down --prefix tree.
+    if new_entries.is_empty() && group_layout.is_empty() {
+        let _ = std::fs::remove_file(&group_path);
+    } else {
+        atomic::atomic_write(&group_path, |f| {
+            group::write_group_with_layout(&new_entries, &group_layout, f)
+        })
+        .map_err(|e| {
+            GroupdelError::CantUpdate(format!("cannot write {}: {e}", group_path.display()))
+        })?;
+    }
 
     drop(group_lock);
 
@@ -168,13 +182,20 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
                 GroupdelError::CantUpdate(format!("cannot read {}: {e}", gshadow_path.display()))
             })?;
 
+        let before = gs_entries.len();
         let new_gs: Vec<GshadowEntry> = gs_entries
             .into_iter()
             .filter(|g| g.name != *group_name)
             .collect();
+        let changed = new_gs.len() != before;
 
-        // Only write if we actually had gshadow entries to begin with.
-        if !new_gs.is_empty() {
+        // Write whenever the removal actually changed something. Skipping an
+        // empty result left the deleted group behind when it was the only
+        // entry; an emptied file is unlinked, since the atomic writer refuses
+        // a zero-length file and an absent gshadow means "no entries".
+        if changed && new_gs.is_empty() {
+            let _ = std::fs::remove_file(&gshadow_path);
+        } else if changed {
             atomic::atomic_write(&gshadow_path, |f| {
                 gshadow::write_gshadow_with_layout(&new_gs, &gshadow_layout, f)
             })
@@ -200,6 +221,13 @@ pub fn uu_app() -> Command {
         .override_usage("groupdel [options] GROUP")
         .version(shadow_core::cli::VERSION)
         .after_help(shadow_core::cli::AFTER_HELP)
+        .arg(
+            Arg::new(options::FORCE)
+                .short('f')
+                .long("force")
+                .help("Delete even if it is a user's primary group, and succeed if it is missing")
+                .action(clap::ArgAction::SetTrue),
+        )
         .arg(
             Arg::new(options::ROOT)
                 .short('R')

--- a/src/uu/groupmod/src/groupmod.rs
+++ b/src/uu/groupmod/src/groupmod.rs
@@ -31,6 +31,8 @@ mod options {
     pub const PASSWORD: &str = "password";
     pub const ROOT: &str = "root";
     pub const PREFIX: &str = "prefix";
+    pub const USERS: &str = "users";
+    pub const APPEND: &str = "append";
 }
 
 mod exit_codes {
@@ -204,6 +206,28 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         entries[idx].name.clone_from(name);
     }
 
+    // groupmod(8) -U sets the member list; with -a the users are added to it.
+    if let Some(users) = matches.get_one::<String>(options::USERS) {
+        let requested: Vec<String> = users
+            .split(',')
+            .map(str::trim)
+            .filter(|u| !u.is_empty())
+            .map(ToOwned::to_owned)
+            .collect();
+        for name in &requested {
+            shadow_core::validate::validate_username(name)
+                .map_err(|e| GroupmodError::BadArgument(format!("invalid member name: {e}")))?;
+        }
+        if !matches.get_flag(options::APPEND) {
+            entries[idx].members.clear();
+        }
+        for name in requested {
+            if !entries[idx].members.contains(&name) {
+                entries[idx].members.push(name);
+            }
+        }
+    }
+
     let modified_gid = entries[idx].gid;
 
     // Write /etc/group.
@@ -247,6 +271,27 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 
     // Update /etc/gshadow.
     let gshadow_path = root.gshadow_path();
+    // Without a gshadow file the password belongs in the group file, which is
+    // where a system with no gshadow keeps it; otherwise -p was a silent no-op.
+    if !gshadow_path.exists()
+        && let Some(pw) = new_password
+    {
+        let (mut regroup, layout) = group::read_group_with_layout(&group_path).map_err(|e| {
+            GroupmodError::CantUpdate(format!("cannot read {}: {e}", group_path.display()))
+        })?;
+        if let Some(g) = regroup
+            .iter_mut()
+            .find(|g| g.name == *new_name.unwrap_or(group_name))
+        {
+            g.passwd.clone_from(pw);
+        }
+        atomic::atomic_write(&group_path, |f| {
+            group::write_group_with_layout(&regroup, &layout, f)
+        })
+        .map_err(|e| {
+            GroupmodError::CantUpdate(format!("cannot write {}: {e}", group_path.display()))
+        })?;
+    }
     if gshadow_path.exists() && (new_name.is_some() || new_password.is_some()) {
         let gs_lock = FileLock::acquire(&gshadow_path).map_err(|e| {
             GroupmodError::CantUpdate(format!("cannot lock {}: {e}", gshadow_path.display()))
@@ -317,6 +362,21 @@ pub fn uu_app() -> Command {
                 .long("password")
                 .value_name("PASSWORD")
                 .help("Replace the group password (PASSWORD must be a crypt(3) hash)"),
+        )
+        .arg(
+            Arg::new(options::USERS)
+                .short('U')
+                .long("users")
+                .value_name("USERS")
+                .help("Set the group's member list (comma-separated)"),
+        )
+        .arg(
+            Arg::new(options::APPEND)
+                .short('a')
+                .long("append")
+                .requires(options::USERS)
+                .help("With -U, add the users instead of replacing the member list")
+                .action(ArgAction::SetTrue),
         )
         .arg(
             Arg::new(options::ROOT)

--- a/tests/by-util/test_groupadd.rs
+++ b/tests/by-util/test_groupadd.rs
@@ -293,3 +293,23 @@ fn test_key_missing_equals_exits_bad_argument() {
         "nothing must be written"
     );
 }
+
+#[test]
+fn test_users_flag_sets_members() {
+    if common::skip_unless_root() {
+        return;
+    }
+
+    // groupadd(8) -U: the new group starts with these members.
+    let dir = setup_prefix("root:x:0:\n", "GID_MIN 1000\nGID_MAX 60000\n");
+    let prefix = dir.path().to_str().unwrap();
+    assert_eq!(
+        run(&["groupadd", "-P", prefix, "-U", "alice,bob", "devs"]),
+        0
+    );
+    let group = read_group(&dir);
+    assert!(
+        group.contains("devs:x:") && group.contains(":alice,bob"),
+        "members should be set, got: {group}"
+    );
+}

--- a/tests/by-util/test_groupdel.rs
+++ b/tests/by-util/test_groupdel.rs
@@ -251,3 +251,28 @@ fn test_delete_group_with_members() {
     let content = read_group(&dir);
     assert!(!content.contains("devteam"), "devteam should be removed");
 }
+
+#[test]
+fn test_force_and_sole_gshadow_entry() {
+    if common::skip_unless_root() {
+        return;
+    }
+
+    // groupdel(8) -f: succeed even when the group does not exist.
+    let dir = setup_root(
+        "only:x:1000:\n",
+        "only:!::\n",
+        "root:x:0:0:root:/root:/bin/sh\n",
+    );
+    let prefix = dir.path().to_str().unwrap();
+    assert_eq!(run(&["groupdel", "-P", prefix, "-f", "ghost"]), 0);
+
+    // The sole gshadow entry used to be left behind: the write was skipped
+    // whenever the result was empty.
+    assert_eq!(run(&["groupdel", "-P", prefix, "only"]), 0);
+    let gshadow = dir.path().join("etc/gshadow");
+    assert!(
+        !gshadow.exists() || !std::fs::read_to_string(&gshadow).unwrap().contains("only:"),
+        "the deleted group must not remain in gshadow"
+    );
+}


### PR DESCRIPTION
Closes #245.

## `groupadd` decided on a stale snapshot

`/etc/group` was read *before* the lock was taken, and both the "does this name exist" check and the GID allocation used that snapshot. Two concurrent `groupadd -r` calls could allocate the same GID; two `groupadd www` could both decide the name was free. The lock is taken first and the file read under it.

## Four documented options were a usage error

- `groupadd -U users` — the new group starts with those members.
- `groupmod -U users` / `-a` — set the member list, or add to it.
- `groupdel -f` — remove the group even when it is a user's primary group, and succeed when it does not exist.

## `groupmod -p` without `/etc/gshadow`

It was a silent no-op. On a system with no gshadow the group password lives in `/etc/group`, and that is where it goes now.

## `groupdel` left things behind

The gshadow write was skipped whenever the result was empty, so deleting the *only* group there left its line in place — the orphan `grpck` then reports. And deleting the last group in `/etc/group` failed outright, because the atomic writer refuses a zero-length file. Both now unlink the file, an absent file meaning the same as an empty one (the same treatment `userdel` already gives subordinate-ID files).

## Verified

`fmt`, `clippy -D warnings` ±`pam`, `cargo test --workspace` green, with new tests for `groupadd -U`, `groupdel -f` on a missing group, and the sole-gshadow-entry case.

The one item from the issue not carried over is the single group+gshadow transaction: the two files are still written under separate locks. Making that atomic needs a two-file commit in the writer rather than a change in these tools, so it belongs with the `shadow-core` work in #249, where it is noted.
