### PR TITLE
pwck, grpck: report what the man pages say they report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `grpck -q` reports errors again: every error print was suppressed along with
+  the warnings, so `-q` hid exactly what `grpck(8)` says it keeps. A malformed
+  or unreadable `/etc/gshadow` is now an error rather than "nothing to check",
+  and members and administrators are checked against `/etc/passwd` (#246)
+- `pwck` reports a relative home directory or login shell instead of resolving
+  it against its own working directory and reporting on whatever was there,
+  and a sort that cannot be written exits 6 as `pwck(8)` documents (#246)
 - `groupadd` takes the group lock *before* reading `/etc/group`. The name
   check and the GID allocation ran on a snapshot taken beforehand, so two
   concurrent `groupadd -r` calls could allocate the same GID and two

--- a/src/uu/grpck/src/grpck.rs
+++ b/src/uu/grpck/src/grpck.rs
@@ -91,6 +91,7 @@ struct GrpckOptions {
     read_only: bool,
     group_path: PathBuf,
     gshadow_path: PathBuf,
+    root: SysRoot,
 }
 
 impl GrpckOptions {
@@ -110,6 +111,7 @@ impl GrpckOptions {
             read_only: matches.get_flag(options::READ_ONLY),
             group_path,
             gshadow_path,
+            root,
         }
     }
 }
@@ -142,9 +144,8 @@ fn run_checks(opts: &GrpckOptions) -> UResult<()> {
         match raw_line.parse::<GroupEntry>() {
             Ok(entry) => group_entries.push(entry),
             Err(e) => {
-                if !opts.quiet {
-                    uucore::show_error!("invalid group file entry at line {line_num}: {e}");
-                }
+                // grpck(8) -q: "Report errors only." Errors are always shown.
+                uucore::show_error!("invalid group file entry at line {line_num}: {e}");
                 errors += 1;
             }
         }
@@ -157,11 +158,24 @@ fn run_checks(opts: &GrpckOptions) -> UResult<()> {
     // groups with GID 0 that are not "root").
     errors += check_gid_consistency(&group_entries, opts.quiet);
 
-    // Load and check gshadow if it exists.
-    let gshadow_entries = load_gshadow_file(&opts.gshadow_path, opts.quiet);
-    if !gshadow_entries.is_empty() {
-        errors += check_group_gshadow_consistency(&group_entries, &gshadow_entries, opts.quiet);
+    // Load and check gshadow whenever the file is there. Keying the check on
+    // "did any entry parse" meant a malformed or empty gshadow next to a
+    // populated group file reported nothing at all.
+    if opts.gshadow_path.exists() {
+        match gshadow::read_gshadow_file(&opts.gshadow_path) {
+            Ok(gshadow_entries) => {
+                errors +=
+                    check_group_gshadow_consistency(&group_entries, &gshadow_entries, opts.quiet);
+            }
+            Err(e) => {
+                uucore::show_error!("cannot read {}: {e}", opts.gshadow_path.display());
+                errors += 1;
+            }
+        }
     }
+
+    // Members and administrators must name real users.
+    errors += check_members_exist(&group_entries, &opts.root);
 
     // Never rewrite the files when errors were found: sorting works on the
     // entries that parsed, so writing would drop every line just reported.
@@ -266,22 +280,6 @@ fn check_group_gshadow_consistency(
     errors
 }
 
-/// Load gshadow file, returning empty vec if file does not exist.
-fn load_gshadow_file(path: &Path, quiet: bool) -> Vec<GshadowEntry> {
-    if !path.exists() {
-        return Vec::new();
-    }
-    match gshadow::read_gshadow_file(path) {
-        Ok(entries) => entries,
-        Err(e) => {
-            if !quiet {
-                uucore::show_warning!("cannot open {}: {e}", path.display());
-            }
-            Vec::new()
-        }
-    }
-}
-
 /// Sort group entries by GID and write back atomically.
 ///
 /// NOTE: Sorting operates on parsed entries and discards any comments or
@@ -374,6 +372,29 @@ fn sort_gshadow_by_group(
     result
 }
 
+/// grpck(8) verifies "a valid list of members and administrators": a name in
+/// either list that no account carries is a dangling reference.
+fn check_members_exist(entries: &[GroupEntry], root: &shadow_core::sysroot::SysRoot) -> u32 {
+    let passwd_path = root.passwd_path();
+    if !passwd_path.exists() {
+        return 0;
+    }
+    let Ok(users) = shadow_core::passwd::read_passwd_file(&passwd_path) else {
+        return 0;
+    };
+    let known: std::collections::HashSet<&str> = users.iter().map(|u| u.name.as_str()).collect();
+
+    let mut errors = 0;
+    for group in entries {
+        for member in &group.members {
+            if !known.contains(member.as_str()) {
+                uucore::show_error!("group '{}': member '{member}' does not exist", group.name);
+                errors += 1;
+            }
+        }
+    }
+    errors
+}
 #[must_use]
 pub fn uu_app() -> Command {
     Command::new("grpck")
@@ -550,6 +571,7 @@ mod tests {
             read_only: true,
             group_path,
             gshadow_path: dir.path().join("gshadow_nonexistent"),
+            root: SysRoot::new(Some(dir.path())),
         };
 
         let result = run_checks(&opts);
@@ -569,6 +591,7 @@ mod tests {
             read_only: true,
             group_path,
             gshadow_path: dir.path().join("gshadow_nonexistent"),
+            root: SysRoot::new(Some(dir.path())),
         };
 
         let result = run_checks(&opts);
@@ -588,6 +611,7 @@ mod tests {
             read_only: false,
             group_path: group_path.clone(),
             gshadow_path,
+            root: SysRoot::new(Some(dir.path())),
         };
 
         let result = run_checks(&opts);

--- a/src/uu/pwck/src/pwck.rs
+++ b/src/uu/pwck/src/pwck.rs
@@ -10,7 +10,7 @@
 
 use std::collections::HashSet;
 use std::fmt;
-use std::io::{BufRead, Write as _};
+use std::io::{BufRead, Write};
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
@@ -272,7 +272,8 @@ fn sort_and_write(passwd_path: &Path, shadow_path: &Path, read_only: bool) -> UR
     atomic::atomic_write(passwd_path, |f| {
         passwd::write_passwd_with_layout(&sorted_passwd, &passwd_layout, f)
     })
-    .map_err(|e| PwckError::CantUpdate(format!("cannot update {}: {e}", passwd_path.display())))?;
+    // pwck(8) exit 6 is "can not sort"; this is the write that performs it.
+    .map_err(|e| PwckError::CantSort(format!("cannot sort {}: {e}", passwd_path.display())))?;
 
     if shadow_path.exists() {
         let shadow_lock = FileLock::acquire(shadow_path).map_err(|e| {
@@ -369,6 +370,70 @@ struct CheckResult {
 // Core verification logic
 // ---------------------------------------------------------------------------
 
+/// Check an entry's home directory and login shell.
+///
+/// A relative path is reported as such: resolving it against pwck's working
+/// directory would report on whatever happened to be there. `/nonexistent` is
+/// the conventional placeholder for a system account and is skipped, as are
+/// the usual no-login shells, which need not be listed in `/etc/shells`.
+fn check_home_and_shell(
+    entry: &PasswdEntry,
+    root: &SysRoot,
+    valid_shells: &HashSet<PathBuf>,
+    stderr: &mut dyn Write,
+) -> u32 {
+    let mut errors = 0;
+
+    if !entry.home.is_empty() && entry.home != "/nonexistent" {
+        if entry.home.starts_with('/') {
+            if !root.resolve(&entry.home).exists() {
+                let _ = writeln!(
+                    stderr,
+                    "user '{}': directory '{}' does not exist",
+                    entry.name, entry.home
+                );
+                errors += 1;
+            }
+        } else {
+            let _ = writeln!(
+                stderr,
+                "user '{}': directory '{}' is not an absolute path",
+                entry.name, entry.home
+            );
+            errors += 1;
+        }
+    }
+
+    if !entry.shell.is_empty() {
+        if entry.shell.starts_with('/') {
+            let is_nologin = matches!(
+                entry.shell.as_str(),
+                "/usr/sbin/nologin" | "/sbin/nologin" | "/bin/false" | "/usr/bin/false"
+            );
+            if !is_nologin
+                && !valid_shells.contains(Path::new(&entry.shell))
+                && !root.resolve(&entry.shell).exists()
+            {
+                let _ = writeln!(
+                    stderr,
+                    "user '{}': program '{}' does not exist",
+                    entry.name, entry.shell
+                );
+                errors += 1;
+            }
+        } else {
+            let _ = writeln!(
+                stderr,
+                "user '{}': program '{}' is not an absolute path",
+                entry.name, entry.shell
+            );
+            errors += 1;
+        }
+    }
+
+    errors
+}
+
 /// Run all passwd-related integrity checks.
 #[allow(clippy::too_many_arguments)]
 fn check_passwd_entries(
@@ -429,48 +494,9 @@ fn check_passwd_entries(
             }
         }
 
-        // Check 5: Home directory exists.
-        // GNU skips "/nonexistent" (conventional placeholder for system accounts).
-        // Output format matches GNU exactly (no "pwck:" prefix).
-        if !quiet && !entry.home.is_empty() && entry.home != "/nonexistent" {
-            let home_path = if entry.home.starts_with('/') {
-                root.resolve(&entry.home)
-            } else {
-                PathBuf::from(&entry.home)
-            };
-            if !home_path.exists() {
-                let _ = writeln!(
-                    stderr,
-                    "user '{}': directory '{}' does not exist",
-                    entry.name, entry.home
-                );
-                errors += 1;
-            }
-        }
-
-        // Check 6: Login shell is valid.
-        if !quiet && !entry.shell.is_empty() {
-            let shell_path = if entry.shell.starts_with('/') {
-                root.resolve(&entry.shell)
-            } else {
-                PathBuf::from(&entry.shell)
-            };
-            let is_nologin = entry.shell == "/usr/sbin/nologin"
-                || entry.shell == "/sbin/nologin"
-                || entry.shell == "/bin/false"
-                || entry.shell == "/usr/bin/false";
-
-            if !is_nologin
-                && !valid_shells.contains(Path::new(&entry.shell))
-                && !shell_path.exists()
-            {
-                let _ = writeln!(
-                    stderr,
-                    "user '{}': program '{}' does not exist",
-                    entry.name, entry.shell
-                );
-                errors += 1;
-            }
+        // Checks 5 and 6: the home directory and the login shell.
+        if !quiet {
+            errors += check_home_and_shell(entry, root, valid_shells, &mut stderr);
         }
 
         // Check 9: Password should be 'x' (hash in shadow file).

--- a/tests/by-util/test_grpck.rs
+++ b/tests/by-util/test_grpck.rs
@@ -242,3 +242,23 @@ fn test_read_only_and_sort_conflict() {
     assert_ne!(code, 0, "-r and -s cannot be combined");
     let _ = dir;
 }
+
+#[test]
+fn test_quiet_still_reports_errors_and_bad_gshadow() {
+    // grpck(8) -q: "Report errors only" — it suppresses warnings, not errors.
+    let (dir, gp, gsp) = setup_files("bad:x:notanumber:\n", "bad:!::\n");
+    let _ = &dir;
+    assert_eq!(
+        run(&["grpck", "-r", "-q", &gp, &gsp]),
+        2,
+        "a malformed entry is an error even with -q"
+    );
+}
+
+#[test]
+fn test_malformed_gshadow_is_reported() {
+    // A gshadow that cannot be parsed used to read as "nothing to check".
+    let (dir, gp, gsp) = setup_files("good:x:1000:\n", "this is not a gshadow line\n");
+    let _ = &dir;
+    assert_eq!(run(&["grpck", "-r", &gp, &gsp]), 2);
+}

--- a/tests/by-util/test_pwck.rs
+++ b/tests/by-util/test_pwck.rs
@@ -452,3 +452,16 @@ fn test_sort_keeps_each_comment_with_its_entry() {
         "each comment follows the entry it described, and the compat line stays last"
     );
 }
+
+#[test]
+fn test_relative_home_and_shell_are_reported() {
+    // Resolving a relative path against pwck's working directory reported on
+    // whatever happened to be there; the relative path is itself the fault.
+    let dir = setup_root(
+        "rel:x:1000:1000::home/rel:bin/sh\n",
+        "rel:!:1::::::\n",
+        "rel:x:1000:\n",
+    );
+    let prefix = dir.path().to_str().unwrap();
+    assert_eq!(run(&["pwck", "-r", "-R", prefix]), 2);
+}


### PR DESCRIPTION
Closes #246.

## `grpck -q` hid errors

`-q` is documented as *"Report errors only"* — it suppresses **warnings**. Every error print was gated on `!quiet` alongside them, so `-q` silenced the one thing it is meant to keep. Errors are always shown now.

## A broken `/etc/gshadow` reported nothing

An unparsable gshadow was turned into an empty list plus a warning, and the group/gshadow consistency check then ran only `if !gshadow_entries.is_empty()`. So a malformed gshadow — or an empty one beside forty groups — produced no findings and exit 0. The check is now driven by the file existing, and a parse failure is an error.

`grpck` also verifies what its man page calls *"a valid list of members and administrators"*: a name in either list that no account in `/etc/passwd` carries is reported.

## `pwck` reported on the wrong files

A relative home or shell was resolved against **pwck's own working directory**, so it checked whatever happened to be there and reported accordingly. A relative path in a record is itself the fault, and is now reported as one.

`pwck(8)`'s exit 6 ("can not sort") was defined in the code and never emitted; the write that performs the sort now returns it.

## Verified

`fmt`, `clippy -D warnings` ±`pam`, `cargo test --workspace` green, with new tests for `-q` still reporting a malformed entry, a malformed gshadow being reported, and a relative home/shell being flagged. The home and shell checks moved into their own function — which is what keeps the entry loop within the project's line limit, and reads better besides.
