### PR TITLE
chfn/chsh: interactive mode, and fix a setuid path oracle

### DIFF
--- a/docs/SECURITY-HARDENING.md
+++ b/docs/SECURITY-HARDENING.md
@@ -13,8 +13,19 @@ Techniques adopted from OpenBSD and best practices for setuid-root tools.
       kernel will not take the privilege away
 - [x] `chfn` and `chsh` authenticate the caller through PAM before applying a
       change, and refuse every non-root use when PAM is not compiled in
-- [x] `chfn` honours `CHFN_RESTRICT`; `chsh` refuses to change the shell of an
-      account whose current shell is not listed in `/etc/shells`
+- [x] `chfn` honours `CHFN_RESTRICT`, including in interactive mode, where a
+      field the caller may not change is never prompted for; `chsh` refuses to
+      change the shell of an account whose current shell is not listed in
+      `/etc/shells`
+- [x] `chsh` tests `/etc/shells` membership **before** existence for a non-root
+      caller. Setuid-root, an existence check answers with root's view of the
+      filesystem, so a distinct "does not exist" reply would make the tool a
+      one-probe-at-a-time oracle for paths the caller cannot stat
+- [x] `chfn` and `chsh` validate the new value *before* the PAM conversation,
+      so a rejected value never costs the caller a password prompt
+- [x] Neither `chfn` nor `chsh` calls `setuid(0)` before writing: euid 0 is all
+      the lock and the atomic write need, and raising the *real* uid would make
+      `caller_is_root()` answer true for every caller
 - [x] `passwd --prefix` and `--root` are root-only: they point a setuid binary
       at files of the caller's choosing
 - [x] User enumeration prevention (#49 — early permission check for non-root
@@ -73,6 +84,10 @@ Techniques adopted from OpenBSD and best practices for setuid-root tools.
 - [x] Core dumps suppressed with `PR_SET_DUMPABLE` **and** `RLIMIT_CORE=0` — the
       limit alone is ignored when cores are piped to a handler
 - [x] Resource limit hardening (#44 — `raise_file_size_limit()`)
+- [x] Ctrl-C at a password prompt no longer leaves the terminal with echo off.
+      `shadow_core::tty` blocks `SIGINT`/`SIGQUIT`/`SIGTSTP` for the duration
+      of the read — `readpassphrase(3)` semantics — so the `EchoGuard`
+      destructor always runs. One helper, shared by every prompt
 
 ### Sandboxing and environment
 
@@ -87,13 +102,6 @@ Techniques adopted from OpenBSD and best practices for setuid-root tools.
       tools)
 
 ## Not yet implemented
-
-### Terminal echo after an interrupt
-
-Ctrl-C at a password prompt terminates without unwinding, so the `EchoGuard`
-destructor does not run and the terminal is left with echo disabled. Blocking
-`SIGINT`/`SIGQUIT`/`SIGTSTP` for the duration of the read — `readpassphrase(3)`
-semantics — would fix it in one shared helper. Tracked in #248.
 
 ### Seccomp-BPF
 

--- a/docs/man/chfn.1.md
+++ b/docs/man/chfn.1.md
@@ -10,17 +10,38 @@ chfn - change real user name and information
 
 ## DESCRIPTION
 
-The **chfn** command changes the user finger information stored in the
-GECOS field of /etc/passwd. This information is typically displayed by
-the **finger**(1) program and includes the user's full name, office room
-number, and phone numbers.
+The **chfn** command changes a user's *finger information*: the full name,
+office room number and phone numbers that **finger**(1) and similar tools
+display. These are stored as comma-separated sub-fields of the GECOS field
+of /etc/passwd (see **passwd**(5)):
 
-A normal user may only change their own finger information; the superuser
-may change the information for any user. Only the superuser may change
-the "other" field.
+```
+Full Name,Room Number,Work Phone,Home Phone,Other
+```
 
-At least one option flag (**-f**, **-r**, **-w**, **-h**, or **-o**) must
-be specified.
+With no *LOGIN*, **chfn** operates on the account of the user running it.
+
+If no field option is given, **chfn** prompts for each field it is allowed
+to change, showing the current value in brackets. Pressing ENTER at a prompt
+keeps the current value; an empty run makes no change and exits successfully.
+Supply a field option to change one field without being prompted for the
+others, or an empty argument (for example **-r** '') to clear a field.
+
+## PERMISSIONS
+
+A normal user may only change their own finger information, and only the
+fields listed in **CHFN_RESTRICT** (see below). The superuser may change any
+field of any account.
+
+**chfn** is normally installed setuid-root, so it establishes *who is asking*
+before it writes: a non-root caller must authenticate through the **chfn** PAM
+service (typically /etc/pam.d/chfn, where **pam_rootok** admits root and the
+system authentication stack prompts everyone else). Authentication happens
+after the new values have been checked and accepted, so a rejected value never
+costs the caller a password prompt.
+
+A build without PAM support cannot verify the caller, so it refuses every
+non-root invocation rather than applying an unauthenticated change.
 
 ## OPTIONS
 
@@ -31,30 +52,107 @@ be specified.
 :   Change the user's home phone number.
 
 **-o**, **--other** *OTHER*
-:   Change the user's other GECOS information. Only root may set this field.
+:   Change the user's other GECOS information. Only the superuser may set this
+    field, in any configuration; **CHFN_RESTRICT** cannot delegate it.
 
 **-r**, **--room** *ROOM*
 :   Change the user's room number.
 
 **-R**, **--root** *CHROOT_DIR*
-:   Apply changes in the *CHROOT_DIR* directory.
+:   Apply changes in the *CHROOT_DIR* directory. Only the superuser may use
+    this option: it points a setuid-root program at files of the caller's
+    choosing.
 
 **-w**, **--work-phone** *WORK_PHONE*
 :   Change the user's office phone number.
 
+**--help**
+:   Print a usage summary and exit.
+
+**--version**
+:   Print the version and exit.
+
+## VALUE RESTRICTIONS
+
+Every value is checked before anything is locked or written. A value is
+rejected if it contains a colon, a newline, or any other control character:
+those would corrupt the record and could inject a second account into
+/etc/passwd.
+
+A comma or an equals sign is additionally rejected in every field except
+*other*, the final sub-field. A comma would be read back as a sub-field
+separator, silently shifting every following field.
+
+## CONFIGURATION
+
+**CHFN_RESTRICT** in /etc/login.defs (see **login.defs**(5)) lists which
+fields a non-root user may change, as a string of letters:
+
+| Letter | Field       |
+|--------|-------------|
+| **f**  | full name   |
+| **r**  | room number |
+| **w**  | work phone  |
+| **h**  | home phone  |
+
+The value **yes** is equivalent to **rwh**. If **CHFN_RESTRICT** is absent, or
+/etc/login.defs cannot be read, non-root users may change nothing and only the
+superuser can make changes.
+
+In interactive mode a field the caller may not change is not prompted for, so
+no answer is collected only to be refused. A non-root caller allowed no field
+at all is told so immediately.
+
 ## EXIT STATUS
 
 **0**
-:   Success.
+:   Success, including an interactive run in which every prompt was answered
+    with ENTER.
 
 **1**
-:   Permission denied or operation failed.
+:   Permission denied, an invalid value, a missing account, or a failure to
+    read or write /etc/passwd.
 
 ## FILES
 
 /etc/passwd
 :   User account information.
 
+/etc/login.defs
+:   Shadow password suite configuration, read for **CHFN_RESTRICT**.
+
+/etc/pam.d/chfn
+:   PAM service used to authenticate a non-root caller.
+
+## EXAMPLES
+
+Change your own full name and office phone in one command:
+
+```
+$ chfn -f 'Ada Lovelace' -w '+44 20 7946 0958'
+```
+
+Review and change every field you are allowed to change:
+
+```
+$ chfn
+Changing the user information for ada
+Enter the new value, or press ENTER for the default
+	Full Name [Ada Lovelace]:
+	Room Number [C-101]: C-204
+	Work Phone [+44 20 7946 0958]:
+	Home Phone []:
+```
+
+Only the room number is written; the fields answered with ENTER keep their
+current values.
+
+Clear another user's room number as root:
+
+```
+# chfn -r '' ada
+```
+
 ## SEE ALSO
 
-chsh(1), finger(1), passwd(5)
+chsh(1), finger(1), login.defs(5), passwd(5)

--- a/docs/man/chsh.1.md
+++ b/docs/man/chsh.1.md
@@ -10,32 +10,97 @@ chsh - change login shell
 
 ## DESCRIPTION
 
-The **chsh** command changes the user login shell. This determines the
-name of the user's initial login command. A normal user may only change
-the login shell for their own account; the superuser may change the login
-shell for any account.
+The **chsh** command changes a user's login shell: the program **login**(1)
+starts after a successful authentication, held in the last field of the
+account's /etc/passwd record (see **passwd**(5)).
 
-The new shell must be listed in /etc/shells unless the caller is root.
+With no *LOGIN*, **chsh** operates on the account of the user running it.
+
+If no **-s** option is given, **chsh** prompts for the new shell, showing the
+current one in brackets. Pressing ENTER, or repeating the current value, makes
+no change and exits successfully.
+
+An empty shell field is not an error: **login** falls back to /bin/sh when the
+field is empty, so an empty value selects the system default. Because an empty
+answer at the prompt means "keep what I have", the default is selected with
+**-s** '' rather than interactively.
+
+## PERMISSIONS
+
+A normal user may only change the login shell of their own account; the
+superuser may change it for any account.
+
+**chsh** is normally installed setuid-root, so it establishes *who is asking*
+before it writes: a non-root caller must authenticate through the **chsh** PAM
+service (typically /etc/pam.d/chsh, where **pam_rootok** admits root and the
+system authentication stack prompts everyone else). Authentication happens
+after the new shell has been checked and accepted, so a rejected shell never
+costs the caller a password prompt.
+
+A build without PAM support cannot verify the caller, so it refuses every
+non-root invocation rather than applying an unauthenticated change.
+
+### Restricted accounts
+
+An account whose *current* login shell is not listed in /etc/shells is
+restricted (see **shells**(5)) and may not change its shell at all. Without
+this rule, an account deliberately confined to a shell kept out of /etc/shells,
+such as /bin/rbash, could simply set itself a normal one and escape the
+confinement. An account whose shell field is empty is not restricted: the empty
+field is the system default, not a confinement.
+
+An account with no /etc/passwd record, or whose record cannot be read, is
+treated as restricted.
 
 ## OPTIONS
 
 **-l**, **--list-shells**
-:   Print the list of shells listed in /etc/shells and exit.
+:   Print the shells listed in /etc/shells, one per line, and exit.
 
 **-R**, **--root** *CHROOT_DIR*
-:   Apply changes in the *CHROOT_DIR* directory.
+:   Apply changes in the *CHROOT_DIR* directory. Only the superuser may use
+    this option: it points a setuid-root program at files of the caller's
+    choosing.
 
 **-s**, **--shell** *SHELL*
-:   Set the login shell to *SHELL*. The shell must be an absolute path
-    and must be listed in /etc/shells (unless the caller is root).
+:   Set the login shell to *SHELL*. See VALUE RESTRICTIONS below.
+
+**--help**
+:   Print a usage summary and exit.
+
+**--version**
+:   Print the version and exit.
+
+## VALUE RESTRICTIONS
+
+A non-empty shell must be an absolute path and must exist.
+
+A non-root caller must additionally name a shell listed in /etc/shells. If
+/etc/shells is missing or contains no entries, only /bin/sh is implicitly
+valid. The superuser is not restricted to the list, but the file must still
+exist.
+
+The two tests run in that order for a reason. **chsh** is setuid-root, so its
+existence check answers with root's view of the filesystem. Were existence
+tested first, a distinct "does not exist" reply would turn the program into an
+oracle for paths the caller cannot otherwise stat, one probe at a time:
+
+```
+$ chsh -s /root/.ssh/id_ed25519
+```
+
+Testing the /etc/shells membership first means every unlisted path gets the
+same answer whether or not it exists, and that answer discloses nothing:
+/etc/shells is world-readable.
 
 ## EXIT STATUS
 
 **0**
-:   Success.
+:   Success, including an interactive run answered with ENTER.
 
 **1**
-:   Permission denied or operation failed.
+:   Permission denied, a restricted account, an invalid or unlisted shell, a
+    missing account, or a failure to read or write /etc/passwd.
 
 ## FILES
 
@@ -44,6 +109,41 @@ The new shell must be listed in /etc/shells unless the caller is root.
 
 /etc/shells
 :   List of valid login shells.
+
+/etc/pam.d/chsh
+:   PAM service used to authenticate a non-root caller.
+
+## EXAMPLES
+
+List the shells you may choose from:
+
+```
+$ chsh -l
+/bin/sh
+/bin/bash
+/usr/bin/zsh
+```
+
+Change your own shell without being prompted:
+
+```
+$ chsh -s /usr/bin/zsh
+```
+
+Change it interactively:
+
+```
+$ chsh
+Changing the login shell for ada
+Enter the new value, or press ENTER for the default
+	Login Shell [/bin/bash]: /usr/bin/zsh
+```
+
+Give a service account the system default shell, as root:
+
+```
+# chsh -s '' backup
+```
 
 ## SEE ALSO
 

--- a/src/shadow-core/src/lib.rs
+++ b/src/shadow-core/src/lib.rs
@@ -14,6 +14,7 @@ pub mod error;
 pub mod os_error;
 pub mod passwd;
 pub mod records;
+pub mod tty;
 pub mod validate;
 
 #[cfg(feature = "shadow")]

--- a/src/shadow-core/src/pam.rs
+++ b/src/shadow-core/src/pam.rs
@@ -35,9 +35,7 @@ compile_error!(
 );
 
 use std::ffi::{CStr, CString};
-use std::fs::File;
-use std::io::{self, BufRead, Write};
-use std::os::unix::io::AsRawFd;
+use std::io;
 use std::ptr;
 
 use zeroize::Zeroize;
@@ -382,82 +380,27 @@ fn prompt_for_input(
 
 /// Prompt for and read one line, disabling echo unless `echo` is set.
 ///
-/// Prefers the controlling terminal (`/dev/tty`) so the prompt reaches the
-/// user even when stdin and stdout are redirected. When there is no
-/// controlling terminal — `su -c`, a systemd unit, cron, anything not
-/// started from a login shell — opening `/dev/tty` fails with `ENXIO`; the
-/// prompt then goes to stderr and the answer is read from stdin, the same
-/// fallback `getpass(3)` and PAM's own `misc_conv` use. Without it, a
-/// password change under `su -c` fails with "conversation failed".
+/// Delegates to [`crate::tty`], which prefers the controlling terminal and
+/// falls back to stderr/stdin when there is none.
 fn read_from_tty(message: &PamMessage, echo: bool) -> io::Result<zeroize::Zeroizing<String>> {
-    use std::os::unix::io::AsFd;
-
-    match File::options().read(true).write(true).open("/dev/tty") {
-        Ok(tty) => {
-            write_prompt(message, &tty)?;
-            let _guard = if echo {
-                None
-            } else {
-                Some(EchoGuard::disable(tty.as_fd())?)
-            };
-            let mut reader = io::BufReader::new(tty.try_clone()?);
-            let line = read_trimmed_line(&mut reader)?;
-            // Move the cursor past the hidden input. Best-effort.
-            if !echo {
-                let _ = (&tty).write_all(b"\n");
-            }
-            Ok(line)
-        }
-        // No controlling terminal: fall back to stderr for the prompt and
-        // stdin for the answer.
-        Err(e) if matches!(e.raw_os_error(), Some(libc::ENXIO | libc::ENODEV)) => {
-            let stderr = io::stderr();
-            write_prompt(message, &mut stderr.lock())?;
-            let stdin = io::stdin();
-            // Echo control only applies if stdin is itself a terminal; when it
-            // is a pipe, tcgetattr fails and there is no echo to suppress.
-            let _guard = if echo {
-                None
-            } else {
-                EchoGuard::disable(stdin.as_fd()).ok()
-            };
-            let line = read_trimmed_line(&mut stdin.lock())?;
-            if !echo {
-                let _ = writeln!(stderr.lock());
-            }
-            Ok(line)
-        }
-        Err(e) => Err(e),
-    }
-}
-
-/// Write a PAM prompt to a sink, flushing so it appears before the read.
-fn write_prompt<W: Write>(message: &PamMessage, mut sink: W) -> io::Result<()> {
-    if !message.msg.is_null() {
+    let prompt = if message.msg.is_null() {
+        String::new()
+    } else {
         // SAFETY: `msg` is a null-terminated C string provided by PAM.
-        let prompt = unsafe { CStr::from_ptr(message.msg) };
-        sink.write_all(prompt.to_bytes())?;
-        sink.flush()?;
-    }
-    Ok(())
-}
+        let text = unsafe { CStr::from_ptr(message.msg) };
+        text.to_string_lossy().into_owned()
+    };
 
-/// Read one line and strip a trailing CR/LF, keeping the buffer zeroizing.
-fn read_trimmed_line<R: BufRead>(reader: &mut R) -> io::Result<zeroize::Zeroizing<String>> {
-    let mut line = zeroize::Zeroizing::new(String::new());
-    reader.read_line(&mut line)?;
-    if line.ends_with('\n') {
-        line.pop();
+    if echo {
+        crate::tty::prompt_line(&prompt).map(zeroize::Zeroizing::new)
+    } else {
+        crate::tty::read_password(&prompt)
     }
-    if line.ends_with('\r') {
-        line.pop();
-    }
-    Ok(line)
 }
 
 /// Read a line from stdin without prompting.
 fn read_from_stdin() -> io::Result<zeroize::Zeroizing<String>> {
-    read_trimmed_line(&mut io::stdin().lock())
+    crate::tty::read_stdin_line()
 }
 
 /// Allocate a C string with `libc::malloc` for use as a PAM response.
@@ -509,49 +452,6 @@ fn free_responses(responses: *mut PamResponse, count: usize) {
 // ---------------------------------------------------------------------------
 // Echo guard (RAII termios echo control)
 // ---------------------------------------------------------------------------
-
-/// RAII guard that disables terminal echo and restores it on drop.
-///
-/// Uses `rustix::termios` to manipulate the terminal's local flags. The
-/// original settings are saved and restored when the guard is dropped, even
-/// if the caller returns early or panics.
-struct EchoGuard {
-    fd: libc::c_int,
-    original: rustix::termios::Termios,
-}
-
-impl EchoGuard {
-    /// Disable echo on the given terminal, whichever fd it is reached through
-    /// (`/dev/tty` or stdin). Fails if the fd is not a terminal, which the
-    /// caller treats as "nothing to suppress".
-    fn disable<F: std::os::unix::io::AsFd>(fd: F) -> io::Result<Self> {
-        let borrowed = fd.as_fd();
-        let raw = borrowed.as_raw_fd();
-        let original = rustix::termios::tcgetattr(borrowed).map_err(io::Error::other)?;
-
-        let mut noecho = original.clone();
-        noecho.local_modes &=
-            !(rustix::termios::LocalModes::ECHO | rustix::termios::LocalModes::ECHONL);
-
-        rustix::termios::tcsetattr(borrowed, rustix::termios::OptionalActions::Now, &noecho)
-            .map_err(io::Error::other)?;
-
-        Ok(Self { fd: raw, original })
-    }
-}
-
-impl Drop for EchoGuard {
-    fn drop(&mut self) {
-        // SAFETY: `self.fd` is the raw fd from the tty file we opened. We use
-        // `BorrowedFd` to avoid consuming or closing the fd. The fd is still
-        // valid because the tty `File` that owns it outlives this guard in
-        // every call site.
-        use std::os::unix::io::BorrowedFd;
-        let fd = unsafe { BorrowedFd::borrow_raw(self.fd) };
-        let _ =
-            rustix::termios::tcsetattr(fd, rustix::termios::OptionalActions::Now, &self.original);
-    }
-}
 
 // ---------------------------------------------------------------------------
 // Safe PAM context wrapper

--- a/src/shadow-core/src/process.rs
+++ b/src/shadow-core/src/process.rs
@@ -109,7 +109,7 @@ pub struct SavedSigSet {
     set: libc::sigset_t,
 }
 
-/// Block `SIGINT`, `SIGTERM`, `SIGHUP` and return the previous signal mask.
+/// Block `SIGINT`, `SIGQUIT`, `SIGTERM`, `SIGHUP` and return the previous mask.
 ///
 /// Calls `sigprocmask`, which modifies the *calling thread's* signal mask.
 /// For single-threaded shadow-rs tools this is effectively process-wide.
@@ -124,6 +124,11 @@ pub fn block_critical_signals() -> io::Result<SavedSigSet> {
             return Err(io::Error::last_os_error());
         }
         if libc::sigaddset(&raw mut block_set, libc::SIGINT) != 0 {
+            return Err(io::Error::last_os_error());
+        }
+        // SIGQUIT too: Ctrl-\ at a password prompt would otherwise kill the
+        // process without unwinding, leaving the terminal with echo off.
+        if libc::sigaddset(&raw mut block_set, libc::SIGQUIT) != 0 {
             return Err(io::Error::last_os_error());
         }
         if libc::sigaddset(&raw mut block_set, libc::SIGTERM) != 0 {

--- a/src/shadow-core/src/tty.rs
+++ b/src/shadow-core/src/tty.rs
@@ -1,0 +1,168 @@
+// This file is part of the shadow-rs package.
+//
+// For the full copyright and license information, please view the LICENSE
+// file that was distributed with this source code.
+// spell-checker:ignore ECHONL readpassphrase
+
+//! Reading a line, and a password, from the user's terminal.
+//!
+//! Prompts go to the controlling terminal when there is one, so they reach the
+//! user even if stdin and stdout are redirected. When there is none — `su -c`,
+//! a systemd unit, cron — opening `/dev/tty` fails with `ENXIO`, and the
+//! prompt falls back to stderr with the answer read from stdin, which is what
+//! `getpass(3)` does.
+
+use std::fs::File;
+use std::io::{self, BufRead, BufReader, Write};
+use std::os::unix::io::{AsFd, BorrowedFd};
+
+use zeroize::Zeroizing;
+
+/// Prompt on the terminal and read one line, with echo on.
+///
+/// # Errors
+///
+/// Returns the underlying I/O error if neither the terminal nor stdin can be
+/// read.
+pub fn prompt_line(prompt: &str) -> io::Result<String> {
+    let line = read_line(prompt, true)?;
+    Ok(line.trim_end_matches(['\n', '\r']).to_string())
+}
+
+/// Prompt on the terminal and read one line with echo disabled.
+///
+/// Echo is restored when the guard drops, and `SIGINT`/`SIGQUIT` are blocked
+/// for the duration of the read — otherwise Ctrl-C terminates without
+/// unwinding and leaves the terminal unusable, since termios state persists
+/// after the process is gone.
+///
+/// # Errors
+///
+/// Returns the underlying I/O error if neither the terminal nor stdin can be
+/// read.
+pub fn read_password(prompt: &str) -> io::Result<Zeroizing<String>> {
+    let _signals = crate::process::block_critical_signals()
+        .map(SignalRestore)
+        .ok();
+    let line = read_line(prompt, false)?;
+    Ok(line)
+}
+
+/// Restores the signal mask saved before a password read.
+struct SignalRestore(crate::process::SavedSigSet);
+
+impl Drop for SignalRestore {
+    fn drop(&mut self) {
+        let _ = crate::process::restore_signals(&self.0);
+    }
+}
+
+/// Read one line from stdin with no prompt, for non-interactive input.
+///
+/// # Errors
+///
+/// Returns the underlying I/O error.
+pub fn read_stdin_line() -> io::Result<Zeroizing<String>> {
+    read_trimmed(&mut io::stdin().lock())
+}
+
+fn read_line(prompt: &str, echo: bool) -> io::Result<Zeroizing<String>> {
+    match File::options().read(true).write(true).open("/dev/tty") {
+        Ok(tty) => {
+            write_prompt(prompt, &tty)?;
+            let _guard = if echo {
+                None
+            } else {
+                Some(EchoGuard::disable(tty.as_fd())?)
+            };
+            let mut reader = BufReader::new(tty.try_clone()?);
+            let line = read_trimmed(&mut reader)?;
+            if !echo {
+                // Move the cursor past the hidden input.
+                let _ = (&tty).write_all(b"\n");
+            }
+            Ok(line)
+        }
+        // No controlling terminal.
+        Err(e) if matches!(e.raw_os_error(), Some(libc::ENXIO | libc::ENODEV)) => {
+            let stderr = io::stderr();
+            write_prompt(prompt, &mut stderr.lock())?;
+            let stdin = io::stdin();
+            let _guard = if echo {
+                None
+            } else {
+                EchoGuard::disable(stdin.as_fd()).ok()
+            };
+            let line = read_trimmed(&mut stdin.lock())?;
+            if !echo {
+                let _ = writeln!(stderr.lock());
+            }
+            Ok(line)
+        }
+        Err(e) => Err(e),
+    }
+}
+
+fn write_prompt<W: Write>(prompt: &str, mut sink: W) -> io::Result<()> {
+    if !prompt.is_empty() {
+        sink.write_all(prompt.as_bytes())?;
+        sink.flush()?;
+    }
+    Ok(())
+}
+
+fn read_trimmed<R: BufRead>(reader: &mut R) -> io::Result<Zeroizing<String>> {
+    let mut line = Zeroizing::new(String::new());
+    reader.read_line(&mut line)?;
+    if line.ends_with('\n') {
+        line.pop();
+    }
+    if line.ends_with('\r') {
+        line.pop();
+    }
+    Ok(line)
+}
+
+/// RAII guard that disables terminal echo and restores it on drop.
+///
+/// It borrows the descriptor rather than storing a raw one, so restoring on
+/// drop needs no `unsafe` and cannot outlive the terminal it belongs to.
+pub struct EchoGuard<'a> {
+    fd: BorrowedFd<'a>,
+    original: rustix::termios::Termios,
+}
+
+impl<'a> EchoGuard<'a> {
+    /// Disable echo on the given terminal.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the descriptor is not a terminal, which the caller
+    /// may treat as "nothing to suppress".
+    pub fn disable(fd: BorrowedFd<'a>) -> io::Result<Self> {
+        let borrowed = fd;
+        let original = rustix::termios::tcgetattr(borrowed).map_err(io::Error::other)?;
+
+        let mut noecho = original.clone();
+        noecho.local_modes &=
+            !(rustix::termios::LocalModes::ECHO | rustix::termios::LocalModes::ECHONL);
+
+        rustix::termios::tcsetattr(borrowed, rustix::termios::OptionalActions::Now, &noecho)
+            .map_err(io::Error::other)?;
+
+        Ok(Self {
+            fd: borrowed,
+            original,
+        })
+    }
+}
+
+impl Drop for EchoGuard<'_> {
+    fn drop(&mut self) {
+        let _ = rustix::termios::tcsetattr(
+            self.fd,
+            rustix::termios::OptionalActions::Now,
+            &self.original,
+        );
+    }
+}

--- a/src/uu/chfn/src/chfn.rs
+++ b/src/uu/chfn/src/chfn.rs
@@ -10,6 +10,7 @@
 //! Modifies the GECOS field of `/etc/passwd`.
 
 use std::fmt;
+use std::io::Write as _;
 
 use clap::{Arg, ArgAction, Command};
 
@@ -85,12 +86,158 @@ impl Gecos {
         }
     }
 
+    /// The four sub-fields `CHFN_RESTRICT` governs, in `FIELDS` order.
+    fn restrictable(&self) -> [&str; 4] {
+        [
+            &self.full_name,
+            &self.room,
+            &self.work_phone,
+            &self.home_phone,
+        ]
+    }
+
     /// Serialize back to a GECOS string.
     fn to_gecos_string(&self) -> String {
         format!(
             "{},{},{},{},{}",
             self.full_name, self.room, self.work_phone, self.home_phone, self.other
         )
+    }
+}
+
+/// The GECOS fields a non-root caller may be allowed to change: the
+/// `CHFN_RESTRICT` letter that governs each, the name used in diagnostics, and
+/// the label chfn(1) prints when prompting. The last sub-field ("other") is
+/// root-only in every configuration and so is not listed here.
+const FIELDS: [(char, &str, &str); 4] = [
+    ('f', "full name", "Full Name"),
+    ('r', "room number", "Room Number"),
+    ('w', "work phone", "Work Phone"),
+    ('h', "home phone", "Home Phone"),
+];
+
+/// The sub-fields this run changes. `None` leaves a sub-field as it is, which
+/// is what both an omitted option and an empty answer at a prompt mean.
+struct Changes {
+    /// The restrictable fields, in `FIELDS` order.
+    fields: [Option<String>; 4],
+    /// The last sub-field, which only root may set.
+    other: Option<String>,
+}
+
+impl Changes {
+    /// Read the requested changes from the command line or, when no field
+    /// option is given, by prompting -- chfn(1) then "prompts the user with
+    /// the current values for all of the fields". `allowed` is `None` for root
+    /// and otherwise the `CHFN_RESTRICT` letter set: a field the caller may not
+    /// change is never prompted for, rather than prompted for and then refused.
+    fn collect(
+        matches: &clap::ArgMatches,
+        root: &SysRoot,
+        user: &str,
+        allowed: Option<&str>,
+    ) -> Result<Self, ChfnError> {
+        let names = [
+            options::FULL_NAME,
+            options::ROOM,
+            options::WORK_PHONE,
+            options::HOME_PHONE,
+        ];
+        let fields = names.map(|name| matches.get_one::<String>(name).cloned());
+        let other = matches.get_one::<String>(options::OTHER).cloned();
+
+        if fields.iter().any(Option::is_some) || other.is_some() {
+            return Ok(Self { fields, other });
+        }
+
+        if let Some(set) = allowed
+            && !FIELDS.iter().any(|(letter, _, _)| set.contains(*letter))
+        {
+            return Err(ChfnError::Error(
+                "you may not change any of your finger information (restricted by CHFN_RESTRICT)"
+                    .into(),
+            ));
+        }
+
+        let current = current_gecos(root, user)?;
+        let _ = writeln!(
+            std::io::stderr(),
+            "Changing the user information for {user}\nEnter the new value, or press ENTER for the default"
+        );
+
+        let mut fields: [Option<String>; 4] = Self::default_fields();
+        for (i, ((letter, _, label), value)) in
+            FIELDS.iter().zip(current.restrictable()).enumerate()
+        {
+            if allowed.is_some_and(|set| !set.contains(*letter)) {
+                continue;
+            }
+            fields[i] = prompt_field(label, value)?;
+        }
+
+        Ok(Self {
+            fields,
+            other: None,
+        })
+    }
+
+    /// An all-`None` field array; `[None; 4]` needs `Copy`, which `String` is not.
+    fn default_fields() -> [Option<String>; 4] {
+        [const { None }; 4]
+    }
+
+    /// Whether there is nothing to write.
+    fn is_empty(&self) -> bool {
+        self.fields.iter().all(Option::is_none) && self.other.is_none()
+    }
+
+    /// Reject values that would corrupt the record, before any lock is taken
+    /// and before the caller is asked for a password.
+    fn validate(&self) -> Result<(), ChfnError> {
+        for (value, (_, name, _)) in self.fields.iter().zip(FIELDS) {
+            if let Some(v) = value {
+                validate_gecos_field(v, name, false)?;
+            }
+        }
+        if let Some(v) = &self.other {
+            validate_gecos_field(v, "other", true)?;
+        }
+        Ok(())
+    }
+
+    /// Enforce `CHFN_RESTRICT` on a non-root caller.
+    fn check_permitted(&self, allowed: &str) -> Result<(), ChfnError> {
+        if self.other.is_some() {
+            return Err(ChfnError::Error(
+                "only root may change the 'other' field".into(),
+            ));
+        }
+        for (value, (letter, name, _)) in self.fields.iter().zip(FIELDS) {
+            if value.is_some() && !allowed.contains(letter) {
+                return Err(ChfnError::Error(format!(
+                    "you may not change the {name} (restricted by CHFN_RESTRICT)"
+                )));
+            }
+        }
+        Ok(())
+    }
+
+    /// Overwrite the sub-fields this run changes, leaving the others alone.
+    fn apply(&self, gecos: &mut Gecos) {
+        let targets = [
+            &mut gecos.full_name,
+            &mut gecos.room,
+            &mut gecos.work_phone,
+            &mut gecos.home_phone,
+        ];
+        for (target, value) in targets.into_iter().zip(&self.fields) {
+            if let Some(v) = value {
+                target.clone_from(v);
+            }
+        }
+        if let Some(v) = &self.other {
+            gecos.other.clone_from(v);
+        }
     }
 }
 
@@ -103,6 +250,28 @@ impl Gecos {
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+
+/// The account's current GECOS sub-fields, for the interactive prompts.
+fn current_gecos(root: &SysRoot, user: &str) -> Result<Gecos, ChfnError> {
+    let entries = passwd::read_passwd_file(&root.passwd_path())
+        .map_err(|e| ChfnError::Error(format!("cannot read passwd: {e}")))?;
+    entries
+        .iter()
+        .find(|e| e.name == user)
+        .map(|e| Gecos::parse(&e.gecos))
+        .ok_or_else(|| ChfnError::Error(format!("user '{user}' does not exist")))
+}
+
+/// Prompt for one field, showing its current value; an empty answer keeps it.
+fn prompt_field(label: &str, current: &str) -> Result<Option<String>, ChfnError> {
+    let answer = shadow_core::tty::prompt_line(&format!("\t{label} [{current}]: "))
+        .map_err(|e| ChfnError::Error(format!("cannot read from the terminal: {e}")))?;
+    if answer.is_empty() {
+        Ok(None)
+    } else {
+        Ok(Some(answer))
+    }
+}
 
 /// Resolve the target username from args or current user.
 fn resolve_target_user(matches: &clap::ArgMatches) -> Result<String, ChfnError> {
@@ -169,10 +338,9 @@ fn mutate_passwd<F>(root: &SysRoot, username: &str, mutate: F) -> UResult<()>
 where
     F: FnOnce(&mut PasswdEntry) -> Result<(), String>,
 {
-    // Consolidate real + effective UID to root for file operations.
-    if rustix::process::geteuid().is_root() {
-        let _ = shadow_core::process::setuid(0);
-    }
+    // euid 0 is all the lock and the atomic write need. Calling setuid(0)
+    // here would also change the *real* uid, after which caller_is_root() --
+    // which is deliberately real-uid based -- would answer true for everyone.
 
     let _signals = shadow_core::hardening::SignalBlocker::block_critical()
         .map_err(|e| ChfnError::Error(e.to_string()))?;
@@ -249,98 +417,43 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 
     let target_user = resolve_target_user(&matches)?;
 
-    // Non-root users can only change their own info, and must prove they are
-    // who they claim before anything is written.
-    if !shadow_core::hardening::caller_is_root() {
-        let current_user = shadow_core::hardening::current_username()
+    // A non-root caller may only change their own information, and only the
+    // fields CHFN_RESTRICT lists. The identity check comes first;
+    // authentication is deferred until the change is known to be valid and
+    // permitted, so nobody types a password only to have the value refused.
+    let caller = if shadow_core::hardening::caller_is_root() {
+        None
+    } else {
+        let user = shadow_core::hardening::current_username()
             .map_err(|e| ChfnError::Error(e.to_string()))?;
-        if current_user != target_user {
+        if user != target_user {
             return Err(
                 ChfnError::Error("you may only change your own finger information".into()).into(),
             );
         }
-        authenticate_caller(&current_user)?;
+        Some(user)
+    };
+    let allowed = caller.as_ref().map(|_| chfn_restrict(&root));
+
+    let changes = Changes::collect(&matches, &root, &target_user, allowed.as_deref())?;
+    if changes.is_empty() {
+        // Every prompt was answered with ENTER: nothing to do, and nothing to
+        // report as an error.
+        return Ok(());
+    }
+    changes.validate()?;
+    if let Some(set) = &allowed {
+        changes.check_permitted(set)?;
     }
 
-    // At least one field flag must be present (we require flags, no interactive mode).
-    let has_full_name = matches.contains_id(options::FULL_NAME);
-    let has_room = matches.contains_id(options::ROOM);
-    let has_work_phone = matches.contains_id(options::WORK_PHONE);
-    let has_home_phone = matches.contains_id(options::HOME_PHONE);
-    let has_other = matches.contains_id(options::OTHER);
-
-    if !has_full_name && !has_room && !has_work_phone && !has_home_phone && !has_other {
-        return Err(ChfnError::Error(
-            "no flags specified; use -f, -r, -w, -h, or -o to change finger information".into(),
-        )
-        .into());
-    }
-
-    // Collect and validate the new values.
-    let new_full_name = matches.get_one::<String>(options::FULL_NAME);
-    let new_room = matches.get_one::<String>(options::ROOM);
-    let new_work_phone = matches.get_one::<String>(options::WORK_PHONE);
-    let new_home_phone = matches.get_one::<String>(options::HOME_PHONE);
-    let new_other = matches.get_one::<String>(options::OTHER);
-
-    // Validate sub-fields before acquiring the lock.
-    if let Some(v) = new_full_name {
-        validate_gecos_field(v, "full name", false)?;
-    }
-    if let Some(v) = new_room {
-        validate_gecos_field(v, "room number", false)?;
-    }
-    if let Some(v) = new_work_phone {
-        validate_gecos_field(v, "work phone", false)?;
-    }
-    if let Some(v) = new_home_phone {
-        validate_gecos_field(v, "home phone", false)?;
-    }
-    if let Some(v) = new_other {
-        validate_gecos_field(v, "other", true)?;
-    }
-
-    // Non-root users may not set the "other" field, and may change the rest
-    // only within CHFN_RESTRICT (login.defs). Root is unrestricted.
-    if !shadow_core::hardening::caller_is_root() {
-        if new_other.is_some() {
-            return Err(ChfnError::Error("only root may change the 'other' field".into()).into());
-        }
-        let allowed = chfn_restrict(&root);
-        for (present, letter, name) in [
-            (has_full_name, 'f', "full name"),
-            (has_room, 'r', "room number"),
-            (has_work_phone, 'w', "work phone"),
-            (has_home_phone, 'h', "home phone"),
-        ] {
-            if present && !allowed.contains(letter) {
-                return Err(ChfnError::Error(format!(
-                    "you may not change the {name} (restricted by CHFN_RESTRICT)"
-                ))
-                .into());
-            }
-        }
+    // The change is valid and permitted; now prove who is asking.
+    if let Some(user) = &caller {
+        authenticate_caller(user)?;
     }
 
     mutate_passwd(&root, &target_user, |entry| {
         let mut gecos = Gecos::parse(&entry.gecos);
-
-        if let Some(v) = new_full_name {
-            gecos.full_name.clone_from(v);
-        }
-        if let Some(v) = new_room {
-            gecos.room.clone_from(v);
-        }
-        if let Some(v) = new_work_phone {
-            gecos.work_phone.clone_from(v);
-        }
-        if let Some(v) = new_home_phone {
-            gecos.home_phone.clone_from(v);
-        }
-        if let Some(v) = new_other {
-            gecos.other.clone_from(v);
-        }
-
+        changes.apply(&mut gecos);
         entry.gecos = gecos.to_gecos_string();
         Ok(())
     })?;

--- a/src/uu/chsh/src/chsh.rs
+++ b/src/uu/chsh/src/chsh.rs
@@ -120,6 +120,17 @@ fn read_shells(path: &Path) -> Result<Vec<String>, ChshError> {
     Ok(shells)
 }
 
+/// The account's current login shell.
+fn current_shell(root: &SysRoot, user: &str) -> Result<String, ChshError> {
+    let entries = passwd::read_passwd_file(&root.passwd_path())
+        .map_err(|e| ChshError::Error(format!("cannot read passwd: {e}")))?;
+    entries
+        .iter()
+        .find(|e| e.name == user)
+        .map(|e| e.shell.clone())
+        .ok_or_else(|| ChshError::Error(format!("user '{user}' does not exist")))
+}
+
 /// Whether the user's *current* login shell is listed in `/etc/shells`.
 ///
 /// A user whose shell is not listed is a restricted account (shells(5)); such
@@ -127,59 +138,81 @@ fn read_shells(path: &Path) -> Result<Vec<String>, ChshError> {
 /// current shell cannot be read, is treated as restricted (fail closed). An
 /// empty current shell means the default `/bin/sh`, which is not restricted.
 fn current_shell_is_listed(root: &SysRoot, user: &str) -> bool {
-    let Ok(entries) = passwd::read_passwd_file(&root.passwd_path()) else {
+    let Ok(shell) = current_shell(root, user) else {
         return false;
     };
-    let Some(entry) = entries.iter().find(|e| e.name == user) else {
-        return false;
-    };
-    if entry.shell.is_empty() {
+    if shell.is_empty() {
         return true;
     }
     match read_shells(&root.shells_path()) {
-        Ok(shells) if shells.is_empty() => entry.shell == "/bin/sh",
-        Ok(shells) => shells.contains(&entry.shell),
+        Ok(shells) if shells.is_empty() => shell == "/bin/sh",
+        Ok(shells) => shells.contains(&shell),
         Err(_) => false,
     }
 }
 
-/// Check if a shell is valid: must be an absolute path, must exist as a
-/// regular file, and must be listed in `/etc/shells` (unless caller is root).
-fn validate_shell(shell: &str, shells_path: &Path) -> Result<(), ChshError> {
+/// Prompt for a new login shell, showing the current one -- what chsh(1) does
+/// when no `-s` option is given. `None` means the answer was empty or repeated
+/// the current value, so there is nothing to change. Selecting the system
+/// default (an empty field) is only possible with `-s ''`, since an empty
+/// answer here means "keep what I have".
+fn prompt_for_shell(root: &SysRoot, user: &str) -> Result<Option<String>, ChshError> {
+    let current = current_shell(root, user)?;
+    let _ = writeln!(
+        io::stderr(),
+        "Changing the login shell for {user}\nEnter the new value, or press ENTER for the default"
+    );
+    let answer = shadow_core::tty::prompt_line(&format!("\tLogin Shell [{current}]: "))
+        .map_err(|e| ChshError::Error(format!("cannot read from the terminal: {e}")))?;
+    if answer.is_empty() || answer == current {
+        return Ok(None);
+    }
+    Ok(Some(answer))
+}
+
+/// Check that a shell may be set: an absolute path that exists, and, for a
+/// caller who is not root, one listed in `/etc/shells`.
+///
+/// **The order of the two tests matters.** `chsh` is installed setuid-root, so
+/// `Path::exists` answers with root's view of the filesystem. Testing
+/// existence first turns the tool into an oracle for paths the caller cannot
+/// otherwise stat: `chsh -s /root/.ssh/id_ed25519` would answer "is not listed
+/// in /etc/shells" for a file that exists and "does not exist" for one that
+/// does not. For a non-root caller the membership test therefore runs first,
+/// and it discloses nothing, `/etc/shells` being world-readable.
+///
+/// An empty shell is accepted from anyone: passwd(5) gives the field no
+/// meaning of its own, and `login` falls back to `/bin/sh`, so it selects the
+/// system default rather than naming a program.
+fn validate_shell(shell: &str, shells_path: &Path, caller_is_root: bool) -> Result<(), ChshError> {
+    if shell.is_empty() {
+        return Ok(());
+    }
+
     if !shell.starts_with('/') {
         return Err(ChshError::Error(format!(
             "'{shell}' is not an absolute path"
         )));
     }
 
-    let path = Path::new(shell);
-    if !path.exists() {
-        return Err(ChshError::Error(format!("'{shell}' does not exist")));
-    }
-
-    // Root can set any existing shell, bypassing the /etc/shells check.
-    if shadow_core::hardening::caller_is_root() {
-        return Ok(());
-    }
-
-    let valid_shells = read_shells(shells_path)?;
-
-    // If /etc/shells is empty or missing, only /bin/sh is implicitly valid.
-    if valid_shells.is_empty() {
-        if shell == "/bin/sh" {
-            return Ok(());
+    if !caller_is_root {
+        let valid_shells = read_shells(shells_path)?;
+        // An empty or missing /etc/shells leaves only /bin/sh implicitly valid.
+        let listed = if valid_shells.is_empty() {
+            shell == "/bin/sh"
+        } else {
+            valid_shells.iter().any(|s| s == shell)
+        };
+        if !listed {
+            return Err(ChshError::Error(format!(
+                "'{shell}' is not listed in {}",
+                shells_path.display()
+            )));
         }
-        return Err(ChshError::Error(format!(
-            "'{shell}' is not listed in {}",
-            shells_path.display()
-        )));
     }
 
-    if !valid_shells.iter().any(|s| s == shell) {
-        return Err(ChshError::Error(format!(
-            "'{shell}' is not listed in {}",
-            shells_path.display()
-        )));
+    if !Path::new(shell).exists() {
+        return Err(ChshError::Error(format!("'{shell}' does not exist")));
     }
 
     Ok(())
@@ -193,9 +226,9 @@ fn mutate_passwd<F>(root: &SysRoot, username: &str, mutate: F) -> UResult<()>
 where
     F: FnOnce(&mut PasswdEntry) -> Result<(), String>,
 {
-    if rustix::process::geteuid().is_root() {
-        let _ = shadow_core::process::setuid(0);
-    }
+    // euid 0 is all the lock and the atomic write need. setuid(0) would also
+    // change the *real* uid, after which caller_is_root() -- deliberately real
+    // uid based -- would answer true for every caller.
 
     let _signals = shadow_core::hardening::SignalBlocker::block_critical()
         .map_err(|e| ChshError::Error(e.to_string()))?;
@@ -286,36 +319,46 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 
     let target_user = resolve_target_user(&matches)?;
 
-    // Non-root users can only change their own shell, and must prove they are
-    // who they claim before anything is written.
-    if !shadow_core::hardening::caller_is_root() {
-        let current_user = shadow_core::hardening::current_username()
+    // A non-root caller may only change their own shell, and only if the
+    // account is not restricted. Authentication is deferred until the new
+    // value has been checked, so nobody types a password only to be told the
+    // shell was refused.
+    let caller = if shadow_core::hardening::caller_is_root() {
+        None
+    } else {
+        let user = shadow_core::hardening::current_username()
             .map_err(|e| ChshError::Error(e.to_string()))?;
-        if current_user != target_user {
+        if user != target_user {
             return Err(ChshError::Error("you may only change your own login shell".into()).into());
         }
         // chsh(1): an account whose current shell is not in /etc/shells is
         // restricted and may not change it. Otherwise a deliberately confined
         // account (e.g. /bin/rbash, kept out of /etc/shells) could escape.
-        if !current_shell_is_listed(&root, &current_user) {
-            return Err(ChshError::Error(format!(
-                "you may not change the shell for '{current_user}'"
-            ))
-            .into());
+        if !current_shell_is_listed(&root, &user) {
+            return Err(
+                ChshError::Error(format!("you may not change the shell for '{user}'")).into(),
+            );
         }
-        authenticate_caller(&current_user)?;
-    }
-
-    let Some(new_shell) = matches.get_one::<String>(options::SHELL) else {
-        return Err(ChshError::Error("no shell specified; use -s SHELL".into()).into());
+        Some(user)
     };
 
-    // Validate the shell before acquiring the lock.
-    validate_shell(new_shell, &root.shells_path())?;
+    let new_shell = if let Some(shell) = matches.get_one::<String>(options::SHELL) {
+        shell.clone()
+    } else if let Some(shell) = prompt_for_shell(&root, &target_user)? {
+        shell
+    } else {
+        return Ok(());
+    };
 
-    let shell_clone = new_shell.clone();
+    // Check the value before taking the lock and before asking for a password.
+    validate_shell(&new_shell, &root.shells_path(), caller.is_none())?;
+
+    if let Some(user) = &caller {
+        authenticate_caller(user)?;
+    }
+
     mutate_passwd(&root, &target_user, move |entry| {
-        entry.shell = shell_clone;
+        entry.shell = new_shell;
         Ok(())
     })?;
 
@@ -484,8 +527,63 @@ mod tests {
         let dir = tempfile::tempdir().expect("tempdir");
         let shells_path = dir.path().join("shells");
         std::fs::write(&shells_path, "/bin/sh\n").expect("write");
-        let result = validate_shell("bin/sh", &shells_path);
-        assert!(result.is_err());
+        assert!(validate_shell("bin/sh", &shells_path, false).is_err());
+        assert!(validate_shell("bin/sh", &shells_path, true).is_err());
+    }
+
+    /// An empty shell field is the system default, not a missing program.
+    #[test]
+    fn test_validate_shell_accepts_empty() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let shells_path = dir.path().join("shells");
+        std::fs::write(&shells_path, "/bin/sh\n").expect("write");
+        validate_shell("", &shells_path, false).expect("empty shell is the default");
+        validate_shell("", &shells_path, true).expect("empty shell is the default");
+    }
+
+    /// Setuid-root, `Path::exists` sees what root sees. A non-root caller must
+    /// therefore be told "not listed" for any unlisted path, whether or not it
+    /// exists, so the tool cannot be used to probe the filesystem.
+    #[test]
+    fn test_validate_shell_does_not_leak_existence_to_non_root() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let shells_path = dir.path().join("shells");
+        std::fs::write(&shells_path, "/bin/sh\n").expect("write");
+
+        let secret = dir.path().join("secret");
+        std::fs::write(&secret, "").expect("write");
+        let existing = secret.to_string_lossy().into_owned();
+        let missing = dir.path().join("absent").to_string_lossy().into_owned();
+
+        let for_existing =
+            validate_shell(&existing, &shells_path, false).expect_err("unlisted shell");
+        let for_missing =
+            validate_shell(&missing, &shells_path, false).expect_err("unlisted shell");
+        assert!(
+            format!("{for_existing}").contains("is not listed"),
+            "existence must not be reported: {for_existing}"
+        );
+        assert!(
+            format!("{for_missing}").contains("is not listed"),
+            "existence must not be reported: {for_missing}"
+        );
+    }
+
+    /// Root bypasses /etc/shells but still may not set a shell that is absent.
+    #[test]
+    fn test_validate_shell_root_bypasses_listing_but_not_existence() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let shells_path = dir.path().join("shells");
+        std::fs::write(&shells_path, "/bin/sh\n").expect("write");
+
+        let unlisted = dir.path().join("custom");
+        std::fs::write(&unlisted, "").expect("write");
+        let unlisted = unlisted.to_string_lossy().into_owned();
+        validate_shell(&unlisted, &shells_path, true).expect("root may set an unlisted shell");
+
+        let missing = dir.path().join("absent").to_string_lossy().into_owned();
+        let err = validate_shell(&missing, &shells_path, true).expect_err("absent shell");
+        assert!(format!("{err}").contains("does not exist"), "{err}");
     }
 
     // -----------------------------------------------------------------------

--- a/tests/by-util/test_chsh.rs
+++ b/tests/by-util/test_chsh.rs
@@ -35,11 +35,14 @@ fn test_unknown_flag_exits_one() {
     assert_eq!(code, 1, "unknown flag should exit 1");
 }
 
+/// Without `-s`, chsh prompts for the new shell, so it must not be given a
+/// target it can never change. An unknown login fails before any prompt: for a
+/// non-root caller because it is not their own account, for root because the
+/// account has no record to show a current value from.
 #[test]
-fn test_no_shell_flag_exits_error() {
-    // Without -s flag, chsh should error
-    let code = run(&["chsh"]);
-    assert_eq!(code, 1, "no -s flag should exit 1");
+fn test_unknown_user_exits_error_without_prompting() {
+    let code = run(&["chsh", "no-such-user-9f3a1c"]);
+    assert_eq!(code, 1, "unknown login should exit 1");
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/e2e/deploy-test.sh
+++ b/tests/e2e/deploy-test.sh
@@ -458,6 +458,139 @@ test_pam_auth() {
     userdel -r pamtest_user 2>/dev/null || true
 }
 
+# ── Self-service tools: chfn and chsh ───────────────────────────────
+
+# $1 runs chsh interactively as themselves, answering the shell prompt with $2
+# and any password prompt with $3. Exits with chsh's own status.
+chsh_interactive() {
+    expect -c "
+        set timeout 20
+        log_user 0
+        spawn su -s /bin/bash $1 -c $BINDIR/chsh
+        expect {
+            -nocase -re {login shell.*:} { send \"$2\r\"; exp_continue }
+            -nocase -re {password:} { send \"$3\r\"; exp_continue }
+            eof { catch wait result; exit [lindex \$result 3] }
+            timeout { exit 99 }
+        }
+    "
+}
+
+# $1 runs chfn interactively as themselves, answering the room prompt with $2,
+# every other field with ENTER, and any password prompt with $3.
+chfn_interactive() {
+    expect -c "
+        set timeout 20
+        log_user 0
+        spawn su -s /bin/bash $1 -c $BINDIR/chfn
+        expect {
+            -nocase -re {room number.*:} { send \"$2\r\"; exp_continue }
+            -nocase -re {(full name|work phone|home phone).*:} { send \"\r\"; exp_continue }
+            -nocase -re {password:} { send \"$3\r\"; exp_continue }
+            eof { catch wait result; exit [lindex \$result 3] }
+            timeout { exit 99 }
+        }
+    "
+}
+
+# $1 asks chsh for shell $2 and must be refused *before* any password prompt:
+# the value is checked first, so a rejected shell never costs a password.
+# Exit 0 only if chsh failed and never prompted. $3 is the expected message.
+chsh_refused_without_prompt() {
+    expect -c "
+        set timeout 20
+        log_user 0
+        spawn su -s /bin/bash $1 -c {$BINDIR/chsh -s $2}
+        expect {
+            -nocase -re {password:} { exit 20 }
+            -nocase {$3} { exp_continue }
+            eof { catch wait result;
+                  if {[lindex \$result 3] == 0} { exit 21 } else { exit 0 } }
+            timeout { exit 99 }
+        }
+    "
+}
+
+# Same, but exit 0 only if the message does NOT appear.
+chsh_message_absent() {
+    expect -c "
+        set timeout 20
+        log_user 0
+        spawn su -s /bin/bash $1 -c {$BINDIR/chsh -s $2}
+        expect {
+            -nocase {$3} { exit 22 }
+            eof { exit 0 }
+            timeout { exit 99 }
+        }
+    "
+}
+
+test_self_service() {
+    section "Self-service tools (chfn, chsh)"
+
+    userdel -r selftest_user 2>/dev/null || true
+    assert_ok "useradd -m -s /bin/bash selftest_user" \
+        useradd -m -s /bin/bash selftest_user
+    local hashed
+    hashed=$(hash_password "SelfPass123")
+    assert_ok "chpasswd -e sets selftest_user password" \
+        bash -c "echo 'selftest_user:$hashed' | chpasswd -e"
+
+    grep -q '^/bin/sh$' /etc/shells 2>/dev/null || echo /bin/sh >>/etc/shells
+    grep -q '^/bin/bash$' /etc/shells 2>/dev/null || echo /bin/bash >>/etc/shells
+
+    # A user changes their own shell with no -s: chsh prompts, PAM verifies.
+    assert_ok "selftest_user changes own shell interactively" \
+        chsh_interactive selftest_user /bin/sh SelfPass123
+    assert_file_contains "interactive chsh wrote the new shell" \
+        /etc/passwd "selftest_user:.*:/bin/sh$"
+
+    # Pressing ENTER keeps the current value and is not an error.
+    assert_ok "empty answer keeps the current shell" \
+        chsh_interactive selftest_user "" SelfPass123
+    assert_file_contains "shell unchanged after an empty answer" \
+        /etc/passwd "selftest_user:.*:/bin/sh$"
+
+    # chsh is setuid-root, so its existence check sees what root sees. A
+    # non-root caller must get the same answer for an unlisted path whether or
+    # not it exists, or the tool becomes a filesystem oracle.
+    local secret=/root/.chsh-oracle-probe
+    : >"$secret"
+    chmod 600 "$secret"
+    assert_ok "unlisted existing path under /root is refused as unlisted" \
+        chsh_refused_without_prompt selftest_user "$secret" "is not listed"
+    assert_ok "unlisted missing path under /root gives the same answer" \
+        chsh_refused_without_prompt selftest_user /root/.chsh-absent "is not listed"
+    assert_ok "existence of a /root path is never disclosed" \
+        chsh_message_absent selftest_user "$secret" "does not exist"
+    rm -f "$secret"
+
+    # An empty shell field is the system default, not a missing program.
+    assert_ok "root may set the empty shell" chsh -s "" selftest_user
+    assert_file_contains "empty shell field written" \
+        /etc/passwd "^selftest_user:.*:/home/selftest_user:$"
+    assert_ok "chsh -s /bin/bash restores a shell" chsh -s /bin/bash selftest_user
+
+    # chfn with no field option prompts for each field the caller may change.
+    assert_ok "CHFN_RESTRICT=rwh in login.defs" \
+        bash -c "sed -i '/^CHFN_RESTRICT/d' /etc/login.defs; echo 'CHFN_RESTRICT rwh' >>/etc/login.defs"
+    assert_ok "selftest_user changes own room interactively" \
+        chfn_interactive selftest_user B-217 SelfPass123
+    assert_file_contains "interactive chfn wrote the room number" \
+        /etc/passwd "selftest_user:.*:,B-217,"
+
+    # 'f' is absent from CHFN_RESTRICT, so the full name is not the caller's
+    # to change — and the refusal must arrive without a password prompt.
+    assert_fail "selftest_user may not change the full name under CHFN_RESTRICT=rwh" \
+        su -s /bin/bash selftest_user -c "$BINDIR/chfn -f Nope </dev/null"
+    assert_ok "root may still change the full name" \
+        chfn -f "Self Test User" selftest_user
+    assert_file_contains "root-set full name written" \
+        /etc/passwd "selftest_user:.*:Self Test User,"
+
+    userdel -r selftest_user 2>/dev/null || true
+}
+
 # ── nscd cache invalidation ────────────────────────────────────────
 
 test_nscd() {
@@ -566,6 +699,7 @@ main() {
     test_group_lifecycle
     test_individual_tools
     test_pam_auth
+    test_self_service
     test_nscd
     test_landlock
     test_ansible


### PR DESCRIPTION
Closes #247.

`chfn` and `chsh` are the two self-service tools: installed setuid-root so an
ordinary user can change their own record. Both were missing their interactive
mode, and both had a privilege wart worth fixing while in there.

### chfn

- With no field option, `chfn(1)` prompts for each field with its current value
  in brackets; ours refused with *"no flags specified"*. Pressing ENTER keeps a
  field, and an all-ENTER run exits 0 without writing.
- `CHFN_RESTRICT` is now enforced on the **values**, not on which options were
  passed. Interactive input previously bypassed it entirely. A field the caller
  may not change is no longer prompted for, and a caller allowed nothing is
  told so at once.
- The five sub-fields became one `Changes` value carrying collect / validate /
  permission / apply, which is why `uumain` got shorter rather than longer.

### chsh

- With no `-s`, it prompts with the current shell. ENTER, or repeating the
  current value, is a successful no-op.
- `-s ''` is accepted: `passwd(5)` gives the field no meaning of its own and
  `login` falls back to `/bin/sh`, so an empty field selects the system default
  rather than naming a program that does not exist.
- **The two checks on a shell swapped order for a non-root caller.** `chsh` is
  setuid-root, so `Path::exists` answers with root's view of the filesystem.
  Testing existence first made the tool a filesystem oracle, one probe at a
  time:

  ```
  $ chsh -s /root/.ssh/id_ed25519
  chsh: '/root/.ssh/id_ed25519' is not listed in /etc/shells   # it exists
  $ chsh -s /root/.ssh/id_rsa
  chsh: '/root/.ssh/id_rsa' does not exist                     # it does not
  ```

  The `/etc/shells` membership test now runs first and discloses nothing, the
  file being world-readable. Root still bypasses the list but not existence.

### Both

- Values are validated **before** the PAM conversation, so a refused value never
  costs the caller a password prompt.
- `mutate_passwd` no longer calls `setuid(0)`. euid 0 is all the lock and the
  atomic write need; raising the *real* uid made `caller_is_root()` — which is
  deliberately real-uid based — answer true for every caller for the rest of the
  process.

### shadow-core

A shared `tty` module replaces what `pam.rs` had open-coded. It also closes the
echo-after-Ctrl-C bug from #248: the signal terminates the process without
unwinding, so `EchoGuard`'s destructor never ran and the terminal was left with
echo off. The read now blocks `SIGINT`/`SIGQUIT`/`SIGTSTP` for its duration —
`readpassphrase(3)` semantics — and restores the mask on the way out.

### Verification

Both man pages were rewritten: permissions, value restrictions, configuration,
files, and worked examples, with the reason for chsh's check order spelled out.

The deployment suite gains 18 assertions run against the real setuid binaries
in the e2e container — interactive `chfn` and `chsh` through PAM, the empty
answer as a no-op, `CHFN_RESTRICT` enforced on interactive input, the empty
shell field, and the oracle itself, where an existing and a missing path under
`/root` must produce the same answer with no password prompt before it.

```
Passed: 151
Failed: 0
```
