### PR TITLE
chage/passwd/chpasswd/newgrp: aging bounds, input rules and newgrp -

### DIFF
--- a/docs/SECURITY-HARDENING.md
+++ b/docs/SECURITY-HARDENING.md
@@ -23,7 +23,7 @@ Techniques adopted from OpenBSD and best practices for setuid-root tools.
       one-probe-at-a-time oracle for paths the caller cannot stat
 - [x] `chfn` and `chsh` validate the new value *before* the PAM conversation,
       so a rejected value never costs the caller a password prompt
-- [x] Neither `chfn` nor `chsh` calls `setuid(0)` before writing: euid 0 is all
+- [x] Neither `chfn`, `chsh` nor `chpasswd` calls `setuid(0)` before writing: euid 0 is all
       the lock and the atomic write need, and raising the *real* uid would make
       `caller_is_root()` answer true for every caller
 - [x] `passwd --prefix` and `--root` are root-only: they point a setuid binary
@@ -58,6 +58,13 @@ Techniques adopted from OpenBSD and best practices for setuid-root tools.
       shares, unless `-f`
 - [x] Path resolution is total: no `unreachable!()` reachable from a `--prefix`
       argument or a home directory read out of `/etc/passwd`
+- [x] The aging arithmetic is checked. `lastchg + max + inactive` sums three
+      values read from a file anyone with write access to `/etc/shadow` can
+      choose; the sum is bounded rather than wrapped, and an unrepresentable
+      date displays as `never` instead of an arithmetic artefact
+- [x] `chpasswd` resolves every account in a batch before writing any of them,
+      so an unknown login mid-list leaves the file untouched rather than half
+      applied
 
 ### Locking
 
@@ -84,6 +91,13 @@ Techniques adopted from OpenBSD and best practices for setuid-root tools.
 - [x] Core dumps suppressed with `PR_SET_DUMPABLE` **and** `RLIMIT_CORE=0` — the
       limit alone is ignored when cores are piped to a handler
 - [x] Resource limit hardening (#44 — `raise_file_size_limit()`)
+- [x] The copy of the password `crypt(3)` requires as a C string is owned in a
+      zeroizing buffer with its capacity reserved up front, so neither the copy
+      nor a reallocation of it is left in freed heap
+- [x] Each `user:password` line `chpasswd` reads is owned in a zeroizing buffer
+- [x] The PAM response scrub uses volatile writes and a compiler fence: a plain
+      `write_bytes` into a buffer freed on the next line is a dead store the
+      optimiser may delete
 - [x] Ctrl-C at a password prompt no longer leaves the terminal with echo off.
       `shadow_core::tty` blocks `SIGINT`/`SIGQUIT`/`SIGTSTP` for the duration
       of the read — `readpassphrase(3)` semantics — so the `EchoGuard`
@@ -95,6 +109,12 @@ Techniques adopted from OpenBSD and best practices for setuid-root tools.
       shadow file directly. Deliberately **not** applied around a PAM
       conversation: `restrict_self` sets `no_new_privs`, which strips the setgid
       bit from `unix_chkpwd` and blocks `dlopen` of the PAM modules
+- [x] `PAM_TTY` and `PAM_RUSER` are set on every PAM handle, so `pam_unix` and
+      `pam_faillock` can record which terminal and which caller a failed
+      authentication came from instead of logging `tty=?`
+- [x] `newgrp` without `-` keeps the caller's environment and execs a
+      non-login shell; only `newgrp -` builds a login environment, and it
+      builds it explicitly rather than passing the caller's through
 - [x] Absolute paths for subprocess execution (`/usr/sbin/nscd`)
 - [x] Environment sanitization for spawned children (#40 — `sanitized_env()`)
 - [x] Targeted hardening in `newgrp` (no `RLIMIT_FSIZE` leak to the exec'd shell)

--- a/docs/man/chage.1.md
+++ b/docs/man/chage.1.md
@@ -10,44 +10,96 @@ chage - change user password expiry information
 
 ## DESCRIPTION
 
-The **chage** command changes the number of days between password changes
-and the date of the last password change. This information is used by
-the system to determine when a user must change their password.
+The **chage** command changes the password aging fields of a user account:
+when the password was last changed, how long it may be kept, when the account
+itself expires. The fields live in /etc/shadow (see **shadow**(5)) and are
+counted in **days since 1970-01-01**, not in dates.
+
+**chage -l** prints those fields in a readable form and is the only mode a
+normal user may run, and only for their own account. Every other mode requires
+the superuser.
 
 ## OPTIONS
 
 **-d**, **--lastday** *LAST_DAY*
-:   Set the date of the last password change. The date may be expressed
-    as a date (YYYY-MM-DD) or as the number of days since January 1, 1970.
-    A value of -1 removes the last-change date requirement.
+:   Record *LAST_DAY* as the date of the last password change. Accepts
+    **YYYY-MM-DD** or a number of days since the epoch. **-1** clears the
+    field. A last day of **0** forces a password change at the next login.
 
 **-E**, **--expiredate** *EXPIRE_DATE*
-:   Set the account expiration date. The date may be expressed as a date
-    (YYYY-MM-DD) or as the number of days since January 1, 1970.
-    A value of -1 removes the expiration date.
+:   Expire the account on *EXPIRE_DATE*, in the same two forms. **-1** removes
+    the expiry. An expired account is refused a login even with a valid
+    password.
 
 **-I**, **--inactive** *INACTIVE*
-:   Set the number of days of inactivity after a password has expired
-    before the account is locked. A value of -1 removes the inactivity
-    requirement.
+:   Disable the account *INACTIVE* days after its password expires. **-1**
+    removes the inactivity period.
 
 **-l**, **--list**
-:   Show account aging information.
+:   Print the aging information. Cannot be combined with any field option.
 
 **-m**, **--mindays** *MIN_DAYS*
-:   Set the minimum number of days between password changes. A value
-    of -1 removes the minimum days requirement.
+:   Require at least *MIN_DAYS* between password changes. **0** allows a change
+    at any time; **-1** clears the field.
 
 **-M**, **--maxdays** *MAX_DAYS*
-:   Set the maximum number of days during which a password is valid.
-    A value of -1 removes the maximum days requirement.
+:   Require a password change at least every *MAX_DAYS*. **-1** clears the
+    field. See the note on 10000 below.
+
+**-P**, **--prefix** *PREFIX_DIR*
+:   Read and write the account files under *PREFIX_DIR* instead of /etc.
+    Only the superuser may use this option.
 
 **-R**, **--root** *CHROOT_DIR*
-:   Apply changes in the *CHROOT_DIR* directory.
+:   Apply changes in the *CHROOT_DIR* directory. Only the superuser may use
+    this option.
 
 **-W**, **--warndays** *WARN_DAYS*
-:   Set the number of days of warning before a password change is
-    required. A value of -1 removes the warning.
+:   Warn the user *WARN_DAYS* before the password expires. **-1** clears the
+    field.
+
+**--help**
+:   Print a usage summary and exit.
+
+**--version**
+:   Print the version and exit.
+
+## VALUE RESTRICTIONS
+
+Every day count is either a non-negative number or **-1**, which clears the
+field. A value such as **-5** is rejected rather than written: a negative
+aging field is not a policy any reader can act on, and it would silently change
+how the account behaves.
+
+A date that does not exist is rejected rather than rolled over: **2025-02-29**
+and **2025-04-31** are errors, not 1 March and 1 May.
+
+## THE -l OUTPUT
+
+```
+Last password change                                    : Jan 01, 2026
+Password expires                                        : Apr 01, 2026
+Password inactive                                       : May 01, 2026
+Account expires                                         : never
+Minimum number of days between password change          : 0
+Maximum number of days between password change          : 90
+Number of days of warning before password expires       : 7
+```
+
+Two rules govern what appears in place of a date:
+
+**A last change of 0** is the "must change at next login" marker that
+**passwd -e** writes. It is not a date, and it makes the two dates derived from
+it meaningless as well, so the first three lines all read *password must be
+changed*. The account expiry is a separate field and keeps its own value.
+
+**A maximum age of 10000 days or more** disables password expiry: the password
+and inactive lines read *never*. A maximum of 9999 still produces a date.
+
+An unset field prints *never* on a date line and **-1** on a day-count line.
+A field holding a value too large to be a date -- anything with write access to
+/etc/shadow can put one there -- also prints *never* rather than an arithmetic
+artefact.
 
 ## EXIT STATUS
 
@@ -55,16 +107,55 @@ the system to determine when a user must change their password.
 :   Success.
 
 **1**
-:   Permission denied.
+:   Permission denied, or the login does not exist.
 
 **2**
-:   Invalid command syntax.
+:   Invalid command syntax, or an out-of-range value.
+
+**3**
+:   An unexpected failure.
+
+**5**
+:   /etc/shadow is locked by another process.
+
+**15**
+:   /etc/shadow could not be read. This code is for the *file*; a missing
+    *account* is exit 1.
 
 ## FILES
 
+/etc/passwd
+:   User account information.
+
 /etc/shadow
-:   Secure user account information.
+:   Password aging fields.
+
+## EXAMPLES
+
+Show what a password policy currently is:
+
+```
+$ chage -l ada
+```
+
+Require a change every 90 days, with a week of warning, and force one now:
+
+```
+# chage -M 90 -W 7 -d 0 ada
+```
+
+Retire an account on a date without deleting it:
+
+```
+# chage -E 2026-12-31 contractor
+```
+
+Remove every aging restriction:
+
+```
+# chage -m -1 -M -1 -W -1 -I -1 -E -1 ada
+```
 
 ## SEE ALSO
 
-passwd(1), passwd(5), shadow(5)
+passwd(1), passwd(5), shadow(5), usermod(8)

--- a/docs/man/chpasswd.8.md
+++ b/docs/man/chpasswd.8.md
@@ -10,33 +10,88 @@ chpasswd - update passwords in batch mode
 
 ## DESCRIPTION
 
-The **chpasswd** command reads a list of username:password pairs from
-standard input and uses this information to update a group of existing
-users. Each line is of the format:
+The **chpasswd** command reads a list of *user*:*password* pairs from standard
+input and applies them to /etc/shadow. It is the tool for provisioning: one
+invocation sets any number of passwords, and either all of them are written or
+none are.
 
-    username:password
+Only the superuser may run it.
 
-By default the password is expected to be in cleartext (not yet
-supported in shadow-rs; use **-e**). With the **-e** flag, the password
-is expected to be already encrypted (pre-hashed).
+By default the passwords are plaintext and are hashed before being stored. With
+**-e** they are already-hashed fields and are stored verbatim.
+
+## INPUT FORMAT
+
+One pair per line:
+
+```
+alice:a long passphrase
+bob:another one
+```
+
+The username is everything before the **first** colon; the password is
+everything after it, **verbatim**. Trailing whitespace is part of the password.
+A password containing a colon needs no quoting or escaping, because only the
+first colon separates. Blank lines are skipped. A line with no colon, or with
+an empty username, is an error.
+
+An empty plaintext password is refused. Hashing an empty string produces a
+perfectly valid hash, and the account would then accept a bare ENTER as its
+password. Locking an account is what **passwd -l** is for. With **-e** an empty
+field is allowed, since that is how `!` and `*` style locks are written.
 
 ## OPTIONS
 
 **-c**, **--crypt-method** *METHOD*
-:   Use the specified crypt method. Supported values: SHA256, SHA512,
-    YESCRYPT, DES, MD5.
+:   Hash with *METHOD*: **SHA256**, **SHA512** or **YESCRYPT**. Overrides the
+    system default. **MD5** and **DES** are refused rather than silently
+    downgraded.
 
 **-e**, **--encrypted**
-:   Supplied passwords are already encrypted (pre-hashed).
+:   The supplied passwords are already hashed and are stored as given. Mutually
+    exclusive with **-c** and **-m**.
 
 **-m**, **--md5**
-:   Use MD5 encryption for cleartext passwords (deprecated).
+:   Refused. MD5 is not a usable password hash; use **-c SHA512**.
+
+**-P**, **--prefix** *PREFIX_DIR*
+:   Read and write the account files under *PREFIX_DIR* instead of /etc.
 
 **-R**, **--root** *CHROOT_DIR*
 :   Apply changes in the *CHROOT_DIR* directory.
 
 **-s**, **--sha-rounds** *ROUNDS*
-:   Use the specified number of rounds for SHA256/SHA512 encryption.
+:   Iteration count for the SHA-2 schemes. Requires **-c**: a rounds count
+    without a scheme names nothing, and ignoring it would write a password the
+    caller did not ask for. Not accepted with YESCRYPT, which takes no rounds
+    parameter.
+
+**--help**
+:   Print a usage summary and exit.
+
+**--version**
+:   Print the version and exit.
+
+## CONFIGURATION
+
+The default hashing scheme is **ENCRYPT_METHOD** from /etc/login.defs, which is
+how a distribution chooses one for the whole system. Debian and its derivatives
+set YESCRYPT. **-c** overrides it for one run.
+
+If /etc/login.defs is unreadable, names no method, or names one this build will
+not write, SHA-512 is used. A misconfigured file does not stop a password
+change.
+
+## HOW A BATCH IS APPLIED
+
+The passwords are hashed **before** the /etc/shadow lock is taken. A modern
+hash is deliberately slow, and hashing under the lock would hold it, with
+signals blocked, for as long as the whole batch took.
+
+Every account named in the input is then resolved before any of them is
+written. An unknown login anywhere in the batch aborts the run with the file
+untouched, rather than applying the first half of a list. The file is replaced
+atomically, so a reader either sees all the changes or none.
 
 ## EXIT STATUS
 
@@ -44,13 +99,43 @@ is expected to be already encrypted (pre-hashed).
 :   Success.
 
 **1**
-:   Permission denied, invalid input, file busy, or unexpected failure.
+:   Permission denied, malformed input, an unknown login, or a failure to read
+    or write /etc/shadow.
+
+**2**
+:   Invalid command syntax.
 
 ## FILES
 
 /etc/shadow
-:   Secure user account information.
+:   Hashed passwords.
+
+/etc/login.defs
+:   Read for **ENCRYPT_METHOD**.
+
+## EXAMPLES
+
+Set several passwords at once:
+
+```
+# chpasswd <<'EOF'
+alice:correct horse battery staple
+bob:a different passphrase
+EOF
+```
+
+Restore hashes taken from a backup, unchanged:
+
+```
+# chpasswd -e < hashes.txt
+```
+
+Choose the scheme and cost explicitly:
+
+```
+# echo 'alice:a long passphrase' | chpasswd -c SHA512 -s 100000
+```
 
 ## SEE ALSO
 
-passwd(1), passwd(5), shadow(5)
+passwd(1), login.defs(5), shadow(5), useradd(8)

--- a/docs/man/newgrp.1.md
+++ b/docs/man/newgrp.1.md
@@ -6,45 +6,110 @@ newgrp - log in to a new group
 
 ## SYNOPSIS
 
-**newgrp** [*group*]
+**newgrp** [**-**] [*group*]
 
 ## DESCRIPTION
 
-The **newgrp** command is used to change the current group ID during a
-login session. If the optional *group* argument is given, the effective
-group ID is changed to that group; otherwise the effective group ID is
-changed to the user's primary group from /etc/passwd.
+The **newgrp** command starts a new shell with *group* as the primary group.
+Files the user creates in that shell belong to *group* without any need to
+change permissions afterwards, which is the usual reason to run it.
 
-If the user is not a member of the specified group, and the group has a
-password set in /etc/gshadow, the user will be prompted for the group
-password. Root always has access to any group without a password prompt.
+With no *group*, the shell is started with the user's own primary group from
+/etc/passwd, undoing an earlier **newgrp**.
 
-A new shell is started with the changed group ID. The shell is
-determined by the **SHELL** environment variable, falling back to
-/bin/sh.
+The shell comes from the user's /etc/passwd record, never from **$SHELL**:
+**newgrp** is installed setuid-root, and an environment variable is the
+caller's to choose. Privileges are dropped to the caller's own user before the
+shell is started, and the supplementary group list is rebuilt from scratch so
+no membership leaks across the change.
 
-## OPTIONS
+**newgrp** replaces the current shell rather than nesting one inside it. Leave
+the new group by exiting that shell.
 
-None. Only an optional positional group name argument is accepted.
+## THE - OPERAND
+
+A bare **-** as the first operand reinitializes the environment as though the
+user had just logged in: the shell is a login shell, the working directory
+becomes the home directory, and the environment is rebuilt with **HOME**,
+**SHELL**, **USER**, **LOGNAME** and **PATH**. Terminal and locale settings
+(**TERM**, **LANG**, **LC_**\*) are carried over, as they are at a real login.
+
+Without **-**, the environment and the working directory are kept exactly as
+they are, and the shell is **not** a login shell. This matters: a login shell
+re-reads the profile files, so making every **newgrp** a login shell would run
+them again, in an environment they had already been applied to, on each
+invocation.
+
+The **-** may only appear first, and only once. Anything else is a usage error
+rather than a group named `-`.
+
+## PERMISSIONS
+
+A user may enter a group without a password if it is their primary group in
+/etc/passwd, or if they are listed as a member of it in /etc/group.
+
+Otherwise the group's password from /etc/gshadow is required, and the user is
+prompted for it. A group whose password field is empty, `!`, `!!` or `*` has no
+usable password, so a non-member is refused outright: those values mean "no
+password access", not "no password needed".
+
+Membership is read from /etc/group and the password from /etc/gshadow. The
+member list in /etc/gshadow does not by itself grant access, matching the
+behaviour of the shadow suite this replaces.
+
+The superuser may enter any group without a password.
+
+## OPERANDS
+
+**-**
+:   Reinitialize the environment as at login. Must come first.
+
+*group*
+:   The group to switch to. Defaults to the user's primary group.
 
 ## EXIT STATUS
 
 **0**
-:   Success (though note that **newgrp** replaces the current process
-    with a new shell via **execv**(2), so exit status 0 is not normally
-    returned to the caller).
+:   Never returned on success: the process is replaced by the shell.
 
 **1**
-:   Permission denied, group not found, or unable to execute shell.
+:   Usage error, unknown group, permission denied, wrong password, or the shell
+    could not be started.
 
 ## FILES
 
+/etc/passwd
+:   User account information, including the shell and primary group.
+
 /etc/group
-:   Group account information.
+:   Group membership.
 
 /etc/gshadow
-:   Secure group account information (for group passwords).
+:   Group passwords.
+
+## EXAMPLES
+
+Work in the `docker` group for a while:
+
+```
+$ newgrp docker
+$ id -gn
+docker
+$ exit
+```
+
+Start clean, as at login:
+
+```
+$ newgrp - docker
+```
+
+Go back to your own primary group:
+
+```
+$ newgrp
+```
 
 ## SEE ALSO
 
-groups(1), id(1), login(1), sg(1), group(5), gshadow(5)
+group(5), gshadow(5), login(1), sg(1)

--- a/src/shadow-core/src/crypt.rs
+++ b/src/shadow-core/src/crypt.rs
@@ -24,12 +24,41 @@
 use std::ffi::CString;
 
 use subtle::ConstantTimeEq;
+use zeroize::Zeroizing;
 
 use crate::error::ShadowError;
 
 #[cfg_attr(not(target_env = "musl"), link(name = "crypt"))]
 unsafe extern "C" {
     fn crypt(key: *const libc::c_char, salt: *const libc::c_char) -> *mut libc::c_char;
+}
+
+/// A NUL-terminated copy of a secret that is scrubbed when it drops.
+///
+/// crypt(3) takes C strings, so a copy of the password has to exist. Making it
+/// with `CString::new` leaves that copy in freed heap when it drops: the
+/// caller's `Zeroizing<String>` scrubs its own buffer and never learns about
+/// this one. Owning the bytes here is what closes that gap.
+struct SecretCString(Zeroizing<Vec<u8>>);
+
+impl SecretCString {
+    /// Copy `secret` into a scrubbing buffer, appending the NUL crypt(3) needs.
+    fn new(secret: &str) -> Result<Self, ShadowError> {
+        if secret.as_bytes().contains(&0) {
+            return Err(ShadowError::Auth("password contains null byte".into()));
+        }
+        // Reserve the exact length up front: a reallocation would leave the
+        // first copy of the password behind, unzeroed, in freed memory.
+        let mut buf = Zeroizing::new(Vec::with_capacity(secret.len() + 1));
+        buf.extend_from_slice(secret.as_bytes());
+        buf.push(0);
+        Ok(Self(buf))
+    }
+
+    /// A pointer to the NUL-terminated bytes, valid while `self` is alive.
+    fn as_ptr(&self) -> *const libc::c_char {
+        self.0.as_ptr().cast()
+    }
 }
 
 /// crypt(3) salt alphabet (POSIX: [a-zA-Z0-9./]).
@@ -105,8 +134,7 @@ pub fn hash_password(
     rounds: Option<u32>,
 ) -> Result<String, ShadowError> {
     let salt = generate_salt(method, rounds)?;
-    let c_password = CString::new(password)
-        .map_err(|_| ShadowError::Auth("password contains null byte".into()))?;
+    let c_password = SecretCString::new(password)?;
     let c_salt = CString::new(salt.as_str())
         .map_err(|_| ShadowError::Auth("salt contains null byte".into()))?;
 
@@ -151,8 +179,7 @@ pub fn hash_password(
 /// static buffer on glibc. Concurrent calls from multiple threads will
 /// corrupt each other's results. All shadow-rs tools are single-threaded.
 pub fn verify_password(password: &str, hash: &str) -> Result<bool, ShadowError> {
-    let c_password = CString::new(password)
-        .map_err(|_| ShadowError::Auth("password contains null byte".into()))?;
+    let c_password = SecretCString::new(password)?;
     let c_hash =
         CString::new(hash).map_err(|_| ShadowError::Auth("hash contains null byte".into()))?;
 

--- a/src/shadow-core/src/date.rs
+++ b/src/shadow-core/src/date.rs
@@ -100,6 +100,71 @@ pub fn parse_expire_date(s: &str) -> Result<Option<i64>, ShadowError> {
     Ok(Some(days_from_civil(year, month, day)))
 }
 
+/// The range of day counts this module will turn back into a calendar date.
+///
+/// The aging fields are read from a file anyone with write access to
+/// `/etc/shadow` can put anything in, and they are summed (`lastchg + max +
+/// inactive`) before being displayed. Bounding the input keeps every such sum
+/// inside `i64` and keeps the output a date a human can read: the limits are
+/// 0001-01-01 and 9999-12-31.
+const MIN_DAYS: i64 = -719_162;
+const MAX_DAYS: i64 = 2_932_896;
+
+/// The civil date `(year, month, day)` for `days` since the Unix epoch.
+///
+/// `None` for a value outside the representable range, which is how a corrupt
+/// or absurd field arrives here. The inverse of [`days_from_civil`].
+#[must_use]
+pub fn civil_from_days(days: i64) -> Option<(i64, i64, i64)> {
+    if !(MIN_DAYS..=MAX_DAYS).contains(&days) {
+        return None;
+    }
+
+    // Shift the epoch to 0000-03-01 so leap days fall at the end of the era.
+    let z = days + 719_468;
+    let era = z.div_euclid(146_097);
+    let doe = z.rem_euclid(146_097);
+    let yoe = (doe - doe / 1460 + doe / 36_524 - doe / 146_096) / 365;
+    let y = yoe + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = doy - (153 * mp + 2) / 5 + 1;
+    let m = if mp < 10 { mp + 3 } else { mp - 9 };
+
+    Some((if m <= 2 { y + 1 } else { y }, m, d))
+}
+
+/// Format `days` since the epoch the way `chage -l` prints a date, for example
+/// `Jan 01, 2026`.
+///
+/// `None` for a value that is not a representable date; every caller displays
+/// `never` in that case, which is also what GNU `chage` shows for a field it
+/// cannot make sense of.
+#[must_use]
+pub fn format_human(days: i64) -> Option<String> {
+    const MONTHS: [&str; 12] = [
+        "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
+    ];
+    let (year, month, day) = civil_from_days(days)?;
+    let name = MONTHS.get(usize::try_from(month - 1).ok()?)?;
+    Some(format!("{name} {day:02}, {year}"))
+}
+
+/// Format the sum of `days` as a date, or `None` if any term overflows or the
+/// total is not a representable date.
+///
+/// `chage -l` adds `lastchg + max` and `lastchg + max + inactive`, each read
+/// from the file. Plain `+` would wrap in release builds and panic in debug
+/// ones, so the addition is checked here once for every caller.
+#[must_use]
+pub fn format_human_sum(days: &[i64]) -> Option<String> {
+    let mut total: i64 = 0;
+    for d in days {
+        total = total.checked_add(*d)?;
+    }
+    format_human(total)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -129,6 +194,60 @@ mod tests {
         assert_eq!(parse_expire_date("2024-02-29").unwrap(), Some(19782));
         // A bare integer is already days since the epoch.
         assert_eq!(parse_expire_date("19782").unwrap(), Some(19782));
+    }
+
+    #[test]
+    fn test_civil_from_days_round_trips() {
+        for (y, m, d) in [
+            (1970, 1, 1),
+            (1970, 1, 2),
+            (2000, 2, 29),
+            (2024, 2, 29),
+            (2026, 1, 1),
+            (2053, 5, 18),
+            (1, 1, 1),
+            (9999, 12, 31),
+        ] {
+            let days = days_from_civil(y, m, d);
+            assert_eq!(
+                civil_from_days(days),
+                Some((y, m, d)),
+                "round trip failed for {y}-{m}-{d}"
+            );
+        }
+    }
+
+    /// The aging fields come from a file, so the arithmetic must survive
+    /// anything that can be written into one rather than wrapping or panicking.
+    #[test]
+    fn test_out_of_range_days_have_no_date() {
+        assert_eq!(civil_from_days(i64::MAX), None);
+        assert_eq!(civil_from_days(i64::MIN), None);
+        assert_eq!(civil_from_days(MAX_DAYS + 1), None);
+        assert_eq!(civil_from_days(MIN_DAYS - 1), None);
+        assert_eq!(format_human(i64::MAX), None);
+    }
+
+    #[test]
+    fn test_format_human_matches_the_chage_form() {
+        assert_eq!(
+            format_human(days_from_civil(2026, 1, 1)).as_deref(),
+            Some("Jan 01, 2026")
+        );
+        assert_eq!(format_human(0).as_deref(), Some("Jan 01, 1970"));
+    }
+
+    /// `lastchg + max + inactive` is three file-supplied values added together.
+    #[test]
+    fn test_format_human_sum_is_checked() {
+        let base = days_from_civil(2026, 1, 1);
+        assert_eq!(
+            format_human_sum(&[base, 9999]).as_deref(),
+            Some("May 18, 2053")
+        );
+        assert_eq!(format_human_sum(&[i64::MAX, 1]), None);
+        assert_eq!(format_human_sum(&[i64::MAX, i64::MAX]), None);
+        assert_eq!(format_human_sum(&[i64::MIN, -1]), None);
     }
 
     #[test]

--- a/src/shadow-core/src/pam.rs
+++ b/src/shadow-core/src/pam.rs
@@ -426,6 +426,25 @@ fn alloc_c_response(s: &str) -> Result<*mut libc::c_char, ()> {
     Ok(buf)
 }
 
+/// The name of the controlling terminal, as PAM records it in `PAM_TTY`.
+///
+/// stdin, stdout and stderr are tried in turn: a tool invoked with its input
+/// redirected can still be attached to a terminal on one of the other two.
+/// `None` when none of them is a terminal.
+fn controlling_tty() -> Option<String> {
+    use std::os::fd::AsFd;
+
+    let stdin = std::io::stdin();
+    let stdout = std::io::stdout();
+    let stderr = std::io::stderr();
+    for fd in [stdin.as_fd(), stdout.as_fd(), stderr.as_fd()] {
+        if let Ok(name) = rustix::termios::ttyname(fd, Vec::new()) {
+            return name.into_string().ok();
+        }
+    }
+    None
+}
+
 /// Free partially-filled PAM responses on error.
 ///
 /// Frees the `resp` strings for responses `0..count`, then frees the array.
@@ -436,9 +455,16 @@ fn free_responses(responses: *mut PamResponse, count: usize) {
         unsafe {
             let r = &mut *responses.add(i);
             if !r.resp.is_null() {
-                // Zero out the response before freeing (may contain a password).
+                // The response may be a password. `ptr::write_bytes` into a
+                // buffer that is freed on the next line is a dead store the
+                // optimiser is free to delete, which would leave the password
+                // in the heap; volatile writes cannot be elided.
                 let len = libc::strlen(r.resp.cast::<libc::c_char>());
-                ptr::write_bytes(r.resp, 0, len);
+                let bytes = r.resp.cast::<u8>();
+                for off in 0..len {
+                    ptr::write_volatile(bytes.add(off), 0);
+                }
+                std::sync::atomic::compiler_fence(std::sync::atomic::Ordering::SeqCst);
                 libc::free(r.resp.cast::<libc::c_void>());
             }
         }
@@ -535,12 +561,31 @@ impl PamContext {
             ));
         }
 
-        Ok(Self {
+        let mut ctx = Self {
             handle,
             last_status: rc,
             _conv_data: conv_data,
             _conv: conv,
-        })
+        };
+        ctx.set_default_items();
+        Ok(ctx)
+    }
+
+    /// Tell the stack who is asking and from which terminal.
+    ///
+    /// Without these, `pam_unix` and `pam_faillock` log `tty=?` and no
+    /// requesting user, which makes their records useless for tracing a failed
+    /// authentication back to a session -- and `pam_faillock`'s per-tty
+    /// behaviour cannot work at all. Best effort: a tool with no controlling
+    /// terminal (a cron job, a `su -c`) still has to be able to authenticate,
+    /// so a failure here is not a failure to start.
+    fn set_default_items(&mut self) {
+        if let Some(tty) = controlling_tty() {
+            let _ = self.set_item_str(item_type::PAM_TTY, &tty);
+        }
+        if let Ok(user) = crate::hardening::current_username() {
+            let _ = self.set_item_str(item_type::PAM_RUSER, &user);
+        }
     }
 
     /// Authenticate the user.

--- a/src/shadow-core/src/process.rs
+++ b/src/shadow-core/src/process.rs
@@ -97,6 +97,31 @@ pub fn execv(path: &CStr, argv: &[&CStr]) -> io::Error {
     io::Error::last_os_error()
 }
 
+/// `execve(path, argv, envp)` — replace the process image with a chosen
+/// environment.
+///
+/// `execv` passes the caller's environment through, which is right for
+/// `newgrp` without `-`, where the man page says the current environment is
+/// kept. `newgrp -` must instead hand the shell a login environment, and
+/// `std::env::set_var` is `unsafe` (and process-global) in edition 2024, so
+/// the environment is built as data and passed here.
+///
+/// On success this never returns. On failure it returns the error.
+pub fn execve(path: &CStr, argv: &[&CStr], envp: &[&CStr]) -> io::Error {
+    let mut argv_ptrs: Vec<*const libc::c_char> = argv.iter().map(|s| s.as_ptr()).collect();
+    argv_ptrs.push(std::ptr::null());
+    let mut env_ptrs: Vec<*const libc::c_char> = envp.iter().map(|s| s.as_ptr()).collect();
+    env_ptrs.push(std::ptr::null());
+
+    // SAFETY: execve is a standard POSIX function. Both arrays are
+    // null-terminated and every pointer comes from a live CStr borrowed for
+    // the duration of the call.
+    unsafe {
+        libc::execve(path.as_ptr(), argv_ptrs.as_ptr(), env_ptrs.as_ptr());
+    }
+    io::Error::last_os_error()
+}
+
 // ---------------------------------------------------------------------------
 // Signal blocking (per-thread via libc sigprocmask)
 // ---------------------------------------------------------------------------

--- a/src/uu/chage/src/chage.rs
+++ b/src/uu/chage/src/chage.rs
@@ -9,11 +9,12 @@
 //! Drop-in replacement for GNU shadow-utils `chage(1)`.
 
 use std::fmt;
-use std::io::Write as _;
+use std::io::Write;
 use std::path::Path;
 
 use clap::{Arg, ArgAction, Command};
 
+use shadow_core::date;
 use shadow_core::lock::FileLock;
 use shadow_core::shadow::{self, ShadowEntry};
 use shadow_core::sysroot::SysRoot;
@@ -31,6 +32,7 @@ mod options {
     pub const MAXDAYS: &str = "maxdays";
     pub const ROOT: &str = "root";
     pub const WARNDAYS: &str = "warndays";
+    pub const PREFIX: &str = "prefix";
 }
 
 /// Exit code constants for `chage(1)`.
@@ -43,6 +45,7 @@ mod exit_codes {
     pub const PERMISSION_DENIED: i32 = 1;
     pub const INVALID_SYNTAX: i32 = 2;
     pub const SHADOW_NOT_FOUND: i32 = 15;
+    pub const USER_NOT_FOUND: i32 = 1;
 }
 
 // ---------------------------------------------------------------------------
@@ -62,8 +65,13 @@ enum ChageError {
     UnexpectedFailure(String),
     /// Exit 5 — could not acquire the shadow lock file.
     FileBusy(String),
-    /// Exit 15 — shadow entry not found for user.
+    /// Exit 15 — the shadow file itself could not be read.
     ShadowNotFound(String),
+    /// Exit 1 — the account does not exist.
+    ///
+    /// chage(1) reserves 15 for "can't find the shadow password file"; a
+    /// missing *account* is an ordinary failure, and GNU exits 1 for it.
+    UserNotFound(String),
     /// Exit 2 — a numeric option was given a value outside its range.
     InvalidArgument(String),
 }
@@ -75,6 +83,7 @@ impl fmt::Display for ChageError {
             | Self::UnexpectedFailure(msg)
             | Self::FileBusy(msg)
             | Self::ShadowNotFound(msg)
+            | Self::UserNotFound(msg)
             | Self::InvalidArgument(msg) => f.write_str(msg),
         }
     }
@@ -85,7 +94,10 @@ impl std::error::Error for ChageError {}
 impl UError for ChageError {
     fn code(&self) -> i32 {
         match self {
-            Self::PermissionDenied(_) => 1,
+            // A missing account is an ordinary failure, and shares the general
+            // failure code with a refused one; chage(1) reserves 15 for the
+            // shadow *file*.
+            Self::PermissionDenied(_) | Self::UserNotFound(_) => 1,
             Self::UnexpectedFailure(_) => 3,
             Self::FileBusy(_) => 5,
             Self::ShadowNotFound(_) => 15,
@@ -98,125 +110,21 @@ impl UError for ChageError {
 // Date parsing
 // ---------------------------------------------------------------------------
 
-/// Parse a date argument that can be either days since epoch or YYYY-MM-DD.
+/// Parse a date argument: `YYYY-MM-DD`, days since the epoch, or `-1`.
 ///
-/// Returns days since epoch. The value `-1` means "remove the field".
+/// `-1` reaches the caller as `-1` rather than `None`, because chage(1) uses
+/// it to clear the field and the caller has to tell "clear it" from "leave it
+/// alone" -- an absent option.
 fn parse_date_arg(input: &str) -> Result<i64, String> {
-    // Try plain integer (days since epoch) first.
-    if let Ok(days) = input.parse::<i64>() {
-        return Ok(days);
+    if input == "-1" {
+        return Ok(-1);
     }
-
-    // Try YYYY-MM-DD format.
-    parse_yyyy_mm_dd(input)
-}
-
-/// Parse `YYYY-MM-DD` into days since epoch using pure calendar math.
-///
-/// Uses the Howard Hinnant algorithm to avoid timezone-dependent `mktime`.
-fn parse_yyyy_mm_dd(input: &str) -> Result<i64, String> {
-    let parts: Vec<&str> = input.split('-').collect();
-    if parts.len() != 3 {
-        return Err(format!(
-            "invalid date '{input}' (expected YYYY-MM-DD or days since epoch)"
-        ));
+    match date::parse_expire_date(input) {
+        Ok(Some(days)) => Ok(days),
+        // An empty argument is not a date; only `-1` clears a field.
+        Ok(None) => Err(format!("invalid date '{input}'")),
+        Err(e) => Err(e.to_string()),
     }
-
-    let year: i64 = parts[0]
-        .parse()
-        .map_err(|_| format!("invalid year in '{input}'"))?;
-    let month: i64 = parts[1]
-        .parse()
-        .map_err(|_| format!("invalid month in '{input}'"))?;
-    let day: i64 = parts[2]
-        .parse()
-        .map_err(|_| format!("invalid day in '{input}'"))?;
-
-    if !(1..=12).contains(&month) {
-        return Err(format!("invalid month {month} in '{input}'"));
-    }
-
-    let max_day = days_in_month(year, month);
-    if day < 1 || day > max_day {
-        return Err(format!(
-            "invalid day {day} for {year}-{month:02} in '{input}'"
-        ));
-    }
-
-    Ok(days_since_epoch(year, month, day))
-}
-
-/// Calculate days since Unix epoch (1970-01-01) for a given date.
-///
-/// Uses the algorithm from <https://howardhinnant.github.io/date_algorithms.html>.
-/// Pure arithmetic, no timezone dependency.
-fn days_since_epoch(year: i64, month: i64, day: i64) -> i64 {
-    let y = if month <= 2 { year - 1 } else { year };
-    let m = if month <= 2 { month + 9 } else { month - 3 };
-
-    let era = y / 400;
-    let yoe = y - era * 400;
-    let doy = (153 * m + 2) / 5 + day - 1;
-    let doe = yoe * 365 + yoe / 4 - yoe / 100 + doy;
-    era * 146_097 + doe - 719_468
-}
-
-/// Whether `year` is a leap year in the Gregorian calendar.
-fn is_leap_year(year: i64) -> bool {
-    (year % 4 == 0 && year % 100 != 0) || year % 400 == 0
-}
-
-/// Number of days in a given month (1-indexed) for `year`.
-fn days_in_month(year: i64, month: i64) -> i64 {
-    match month {
-        1 | 3 | 5 | 7 | 8 | 10 | 12 => 31,
-        4 | 6 | 9 | 11 => 30,
-        2 => {
-            if is_leap_year(year) {
-                29
-            } else {
-                28
-            }
-        }
-        // Month range is already validated before calling this function.
-        _ => 0,
-    }
-}
-
-/// Convert days since epoch back to (year, month, day).
-///
-/// Inverse of `days_since_epoch`, also from the Hinnant algorithms.
-fn civil_from_days(days: i64) -> (i64, i64, i64) {
-    let z = days + 719_468;
-    let era = (if z >= 0 { z } else { z - 146_096 }) / 146_097;
-    let doe = z - era * 146_097;
-    let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146_096) / 365;
-    let y = yoe + era * 400;
-    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
-    let mp = (5 * doy + 2) / 153;
-    let d = doy - (153 * mp + 2) / 5 + 1;
-    let m = if mp < 10 { mp + 3 } else { mp - 9 };
-    let y = if m <= 2 { y + 1 } else { y };
-    (y, m, d)
-}
-
-/// Convert days since epoch to a human-readable date string (e.g., "Mar 23, 2026").
-///
-/// Uses pure calendar math instead of `localtime_r` to avoid timezone issues.
-fn format_date_human(days: i64) -> String {
-    let (year, month, day) = civil_from_days(days);
-
-    let month_names = [
-        "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
-    ];
-
-    let month_name = usize::try_from(month - 1)
-        .ok()
-        .and_then(|idx| month_names.get(idx))
-        .copied()
-        .unwrap_or("???");
-
-    format!("{month_name} {day:02}, {year:04}")
 }
 
 // ---------------------------------------------------------------------------
@@ -237,7 +145,13 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         do_chroot(chroot_dir)?;
     }
 
-    let root = SysRoot::default();
+    // --prefix points a setuid binary at files of the caller's choosing, so
+    // like --root it is root-only.
+    let prefix = matches.get_one::<String>(options::PREFIX).map(Path::new);
+    if prefix.is_some() && !shadow_core::hardening::caller_is_root() {
+        return Err(ChageError::PermissionDenied("only root may use --prefix".into()).into());
+    }
+    let root = SysRoot::new(prefix);
 
     // The LOGIN argument is required by clap.
     let login = matches
@@ -417,6 +331,13 @@ pub fn uu_app() -> Command {
                 .value_name("CHROOT_DIR"),
         )
         .arg(
+            Arg::new(options::PREFIX)
+                .short('P')
+                .long("prefix")
+                .help("directory prefix")
+                .value_name("PREFIX_DIR"),
+        )
+        .arg(
             Arg::new(options::WARNDAYS)
                 .short('W')
                 .long("warndays")
@@ -447,39 +368,62 @@ fn cmd_list(root: &SysRoot, login: &str) -> UResult<()> {
     let entry = entries
         .iter()
         .find(|e| e.name == login)
-        .ok_or_else(|| ChageError::ShadowNotFound(format!("user '{login}' does not exist")))?;
+        .ok_or_else(|| ChageError::UserNotFound(format!("user '{login}' does not exist")))?;
 
     print_aging_info(entry);
     Ok(())
 }
 
-/// Print the aging information in the GNU `chage -l` format.
+/// A `max_age` at or above this many days disables expiry.
+///
+/// chage(1) prints `never` for the two password lines at this value and a real
+/// date one day below it, verified against GNU shadow 4.17: `-M 9999` shows a
+/// date, `-M 10000` shows `never`.
+const MAX_AGE_NEVER: i64 = 10_000;
+
+/// Print the aging information to stdout in the GNU `chage -l` format.
 fn print_aging_info(entry: &ShadowEntry) {
-    let last_change = match entry.last_change {
-        Some(0) => "password must be changed".to_string(),
-        Some(days) => format_date_human(days),
-        None => "never".to_string(),
-    };
-
-    let password_expires = compute_expiry_display(entry.last_change, entry.max_age);
-    let password_inactive =
-        compute_inactive_display(entry.last_change, entry.max_age, entry.inactive_days);
-    let account_expires = match entry.expire_date {
-        Some(days) if days >= 0 => format_date_human(days),
-        _ => "never".to_string(),
-    };
-
-    let min_days = entry
-        .min_age
-        .map_or_else(|| "-1".to_string(), |v| v.to_string());
-    let max_days = entry
-        .max_age
-        .map_or_else(|| "-1".to_string(), |v| v.to_string());
-    let warn_days = entry
-        .warn_days
-        .map_or_else(|| "-1".to_string(), |v| v.to_string());
-
     let mut out = std::io::stdout().lock();
+    write_aging_info(entry, &mut out);
+}
+
+/// Render the aging information, so the exact output can be asserted on.
+fn write_aging_info<W: Write>(entry: &ShadowEntry, out: &mut W) {
+    // A last-change day of 0 is the "expired, must change at next login" marker
+    // that `passwd -e` writes. It is not a date, and it makes the two derived
+    // dates meaningless too, so all three lines say so.
+    let must_change = entry.last_change == Some(0);
+
+    let never = || "never".to_string();
+    let last_change = if must_change {
+        MUST_CHANGE.to_string()
+    } else {
+        entry
+            .last_change
+            .and_then(date::format_human)
+            .unwrap_or_else(never)
+    };
+    let password_expires = if must_change {
+        MUST_CHANGE.to_string()
+    } else {
+        expiry_display(entry.last_change, entry.max_age)
+    };
+    let password_inactive = if must_change {
+        MUST_CHANGE.to_string()
+    } else {
+        inactive_display(entry.last_change, entry.max_age, entry.inactive_days)
+    };
+    let account_expires = entry
+        .expire_date
+        .filter(|d| *d >= 0)
+        .and_then(date::format_human)
+        .unwrap_or_else(never);
+
+    let field = |v: Option<i64>| v.map_or_else(|| "-1".to_string(), |v| v.to_string());
+    let min_days = field(entry.min_age);
+    let max_days = field(entry.max_age);
+    let warn_days = field(entry.warn_days);
+
     let _ = writeln!(out, "Last password change\t\t\t\t\t: {last_change}");
     let _ = writeln!(out, "Password expires\t\t\t\t\t: {password_expires}");
     let _ = writeln!(out, "Password inactive\t\t\t\t\t: {password_inactive}");
@@ -498,26 +442,35 @@ fn print_aging_info(entry: &ShadowEntry) {
     );
 }
 
-/// Compute the password expiry display string.
-fn compute_expiry_display(last_change: Option<i64>, max_age: Option<i64>) -> String {
+/// What `chage -l` prints in place of a date for an expired password.
+const MUST_CHANGE: &str = "password must be changed";
+
+/// The date the password expires, or `never`.
+fn expiry_display(last_change: Option<i64>, max_age: Option<i64>) -> String {
     match (last_change, max_age) {
-        (Some(lc), Some(max)) if (0..99999).contains(&max) => format_date_human(lc + max),
-        _ => "never".to_string(),
+        (Some(lc), Some(max)) if (0..MAX_AGE_NEVER).contains(&max) => {
+            date::format_human_sum(&[lc, max])
+        }
+        _ => None,
     }
+    .unwrap_or_else(|| "never".to_string())
 }
 
-/// Compute the password inactive display string.
-fn compute_inactive_display(
+/// The date the account goes inactive, or `never`.
+fn inactive_display(
     last_change: Option<i64>,
     max_age: Option<i64>,
     inactive_days: Option<i64>,
 ) -> String {
     match (last_change, max_age, inactive_days) {
-        (Some(lc), Some(max), Some(inactive)) if (0..99999).contains(&max) && inactive >= 0 => {
-            format_date_human(lc + max + inactive)
+        (Some(lc), Some(max), Some(inactive))
+            if (0..MAX_AGE_NEVER).contains(&max) && inactive >= 0 =>
+        {
+            date::format_human_sum(&[lc, max, inactive])
         }
-        _ => "never".to_string(),
+        _ => None,
     }
+    .unwrap_or_else(|| "never".to_string())
 }
 
 // ---------------------------------------------------------------------------
@@ -588,7 +541,7 @@ where
     // Find the target user.
     let Some(entry) = entries.iter_mut().find(|e| e.name == username) else {
         drop(lock);
-        return Err(ChageError::ShadowNotFound(format!(
+        return Err(ChageError::UserNotFound(format!(
             "user '{username}' does not exist in {}",
             shadow_path.display()
         ))
@@ -799,138 +752,103 @@ mod tests {
         assert!(parse_date_arg("2026-06-00").is_err());
     }
 
-    #[test]
-    fn test_parse_yyyy_mm_dd_epoch() {
-        let days = parse_yyyy_mm_dd("1970-01-01").expect("should parse epoch date");
-        assert_eq!(days, 0);
-    }
-
-    #[test]
-    fn test_parse_yyyy_mm_dd_known_date() {
-        // 2000-01-01 should be exactly 10957 days since epoch.
-        let days = parse_yyyy_mm_dd("2000-01-01").expect("should parse 2000-01-01");
-        assert!(
-            (10956..=10958).contains(&days),
-            "expected ~10957, got {days}"
-        );
-    }
-
     // -----------------------------------------------------------------------
-    // Display formatting tests
+    // `chage -l` output
+    //
+    // The expected text is GNU shadow 4.17's, captured from the Debian image:
+    // the label columns, the "password must be changed" wording and the
+    // `never` threshold all have to match for scripts that parse this.
     // -----------------------------------------------------------------------
 
-    #[test]
-    fn test_format_date_human_epoch() {
-        let result = format_date_human(0);
-        assert!(
-            result.contains("1970"),
-            "epoch should show 1970, got: {result}"
-        );
-        assert!(
-            result.contains("Jan"),
-            "epoch should show Jan, got: {result}"
-        );
+    fn aging_lines(entry: &ShadowEntry) -> Vec<String> {
+        let mut out = Vec::new();
+        write_aging_info(entry, &mut out);
+        String::from_utf8(out)
+            .expect("utf-8")
+            .lines()
+            .map(|l| {
+                let (label, value) = l.rsplit_once(": ").unwrap_or((l, ""));
+                format!("{}|{value}", label.trim_end_matches(['\t', ' ']))
+            })
+            .collect()
     }
 
-    #[test]
-    fn test_format_date_human_known_date() {
-        // Day 10957 = 2000-01-01
-        let result = format_date_human(10957);
-        assert!(
-            result.contains("2000"),
-            "day 10957 should show 2000, got: {result}"
-        );
-    }
-
-    #[test]
-    fn test_compute_expiry_display_never_no_fields() {
-        assert_eq!(compute_expiry_display(None, None), "never");
-    }
-
-    #[test]
-    fn test_compute_expiry_display_never_no_max() {
-        assert_eq!(compute_expiry_display(Some(19500), None), "never");
-    }
-
-    #[test]
-    fn test_compute_expiry_display_never_large_max() {
-        assert_eq!(compute_expiry_display(Some(19500), Some(99999)), "never");
-    }
-
-    #[test]
-    fn test_compute_expiry_display_date() {
-        let result = compute_expiry_display(Some(0), Some(90));
-        // 0 + 90 = day 90 since epoch.
-        assert!(
-            result.contains("1970"),
-            "should show 1970 date, got: {result}"
-        );
-    }
-
-    #[test]
-    fn test_compute_inactive_display_never() {
-        assert_eq!(compute_inactive_display(None, None, None), "never");
-        assert_eq!(
-            compute_inactive_display(Some(19500), Some(90), None),
-            "never"
-        );
-        assert_eq!(
-            compute_inactive_display(Some(19500), None, Some(30)),
-            "never"
-        );
-    }
-
-    #[test]
-    fn test_compute_inactive_display_date() {
-        let result = compute_inactive_display(Some(0), Some(90), Some(30));
-        // 0 + 90 + 30 = day 120 since epoch.
-        assert!(
-            result.contains("1970"),
-            "should show 1970 date, got: {result}"
-        );
-    }
-
-    // -----------------------------------------------------------------------
-    // print_aging_info smoke test
-    // -----------------------------------------------------------------------
-
-    #[test]
-    fn test_print_aging_info_no_panic() {
-        let entry = ShadowEntry {
-            name: "testuser".into(),
+    fn entry_with(last_change: Option<i64>, max_age: Option<i64>) -> ShadowEntry {
+        ShadowEntry {
+            name: "u".into(),
             passwd: "$6$hash".into(),
-            last_change: Some(19500),
+            last_change,
             min_age: Some(0),
-            max_age: Some(99999),
+            max_age,
             warn_days: Some(7),
             inactive_days: None,
             expire_date: None,
             reserved: String::new(),
-        };
-        // Verify it doesn't panic.
-        print_aging_info(&entry);
+        }
     }
 
     #[test]
-    fn test_print_aging_info_expired_password() {
-        let entry = ShadowEntry {
-            name: "expired".into(),
-            passwd: "$6$hash".into(),
-            last_change: Some(0),
-            min_age: Some(0),
-            max_age: Some(90),
-            warn_days: Some(7),
-            inactive_days: Some(30),
-            expire_date: Some(20000),
-            reserved: String::new(),
-        };
-        print_aging_info(&entry);
+    fn test_aging_output_has_the_gnu_labels_and_order() {
+        let lines = aging_lines(&entry_with(Some(20454), Some(99999)));
+        let labels: Vec<&str> = lines
+            .iter()
+            .map(|l| l.split('|').next().unwrap_or(""))
+            .collect();
+        assert_eq!(
+            labels,
+            [
+                "Last password change",
+                "Password expires",
+                "Password inactive",
+                "Account expires",
+                "Minimum number of days between password change",
+                "Maximum number of days between password change",
+                "Number of days of warning before password expires",
+            ]
+        );
+    }
+
+    /// A last-change day of 0 is `passwd -e`'s "must change at next login"
+    /// marker, not a date, and it makes both derived dates meaningless too.
+    #[test]
+    fn test_last_change_zero_reports_must_be_changed_on_three_lines() {
+        let mut entry = entry_with(Some(0), Some(90));
+        entry.inactive_days = Some(30);
+        entry.expire_date = Some(0);
+        let lines = aging_lines(&entry);
+        assert_eq!(lines[0], "Last password change|password must be changed");
+        assert_eq!(lines[1], "Password expires|password must be changed");
+        assert_eq!(lines[2], "Password inactive|password must be changed");
+        // The account expiry is a separate field and keeps its own date.
+        assert_eq!(lines[3], "Account expires|Jan 01, 1970");
+    }
+
+    /// GNU shows a date at `-M 9999` and `never` at `-M 10000`.
+    #[test]
+    fn test_max_age_never_threshold_is_10000() {
+        let base = shadow_core::date::days_from_civil(2026, 1, 1);
+        let lines = aging_lines(&entry_with(Some(base), Some(9999)));
+        assert_eq!(lines[1], "Password expires|May 18, 2053");
+        let lines = aging_lines(&entry_with(Some(base), Some(10000)));
+        assert_eq!(lines[1], "Password expires|never");
+        let lines = aging_lines(&entry_with(Some(base), Some(99999)));
+        assert_eq!(lines[1], "Password expires|never");
     }
 
     #[test]
-    fn test_print_aging_info_all_none() {
-        let entry = ShadowEntry {
-            name: "minimal".into(),
+    fn test_inactive_date_is_the_sum_of_three_fields() {
+        let base = shadow_core::date::days_from_civil(2026, 1, 1);
+        let mut entry = entry_with(Some(base), Some(90));
+        entry.inactive_days = Some(30);
+        let lines = aging_lines(&entry);
+        assert_eq!(lines[1], "Password expires|Apr 01, 2026");
+        assert_eq!(lines[2], "Password inactive|May 01, 2026");
+    }
+
+    #[test]
+    fn test_unset_fields_report_never_and_minus_one() {
+        let lines = aging_lines(&ShadowEntry {
+            name: "u".into(),
             passwd: "*".into(),
             last_change: None,
             min_age: None,
@@ -939,8 +857,36 @@ mod tests {
             inactive_days: None,
             expire_date: None,
             reserved: String::new(),
-        };
-        print_aging_info(&entry);
+        });
+        assert_eq!(lines[0], "Last password change|never");
+        assert_eq!(lines[1], "Password expires|never");
+        assert_eq!(lines[2], "Password inactive|never");
+        assert_eq!(lines[3], "Account expires|never");
+        assert_eq!(
+            lines[4],
+            "Minimum number of days between password change|-1"
+        );
+        assert_eq!(
+            lines[5],
+            "Maximum number of days between password change|-1"
+        );
+        assert_eq!(
+            lines[6],
+            "Number of days of warning before password expires|-1"
+        );
+    }
+
+    /// Anyone who can write /etc/shadow can put a value in it that overflows
+    /// the `lastchg + max + inactive` sums. That must show as `never`, not
+    /// wrap into a plausible-looking date or panic in a debug build.
+    #[test]
+    fn test_absurd_field_values_report_never() {
+        let mut entry = entry_with(Some(i64::MAX), Some(90));
+        entry.inactive_days = Some(i64::MAX);
+        let lines = aging_lines(&entry);
+        assert_eq!(lines[0], "Last password change|never");
+        assert_eq!(lines[1], "Password expires|never");
+        assert_eq!(lines[2], "Password inactive|never");
     }
 
     // -----------------------------------------------------------------------
@@ -960,6 +906,12 @@ mod tests {
         assert_eq!(
             ChageError::ShadowNotFound("test".into()).code(),
             exit_codes::SHADOW_NOT_FOUND
+        );
+        // A missing account is not a missing shadow file: chage(1) reserves 15
+        // for the file, and GNU exits 1 for an unknown login.
+        assert_eq!(
+            ChageError::UserNotFound("test".into()).code(),
+            exit_codes::USER_NOT_FOUND
         );
         assert_eq!(
             shadow_core::cli::AlreadyPrinted(exit_codes::INVALID_SYNTAX).code(),
@@ -992,7 +944,7 @@ mod tests {
     #[test]
     fn test_reject_feb_29_non_leap_year() {
         assert!(
-            parse_yyyy_mm_dd("2025-02-29").is_err(),
+            parse_date_arg("2025-02-29").is_err(),
             "2025 is not a leap year, Feb 29 should be rejected"
         );
     }
@@ -1000,7 +952,7 @@ mod tests {
     #[test]
     fn test_reject_feb_31() {
         assert!(
-            parse_yyyy_mm_dd("2025-02-31").is_err(),
+            parse_date_arg("2025-02-31").is_err(),
             "February never has 31 days"
         );
     }
@@ -1008,7 +960,7 @@ mod tests {
     #[test]
     fn test_accept_feb_29_leap_year() {
         assert!(
-            parse_yyyy_mm_dd("2024-02-29").is_ok(),
+            parse_date_arg("2024-02-29").is_ok(),
             "2024 is a leap year, Feb 29 should be accepted"
         );
     }
@@ -1016,7 +968,7 @@ mod tests {
     #[test]
     fn test_reject_apr_31() {
         assert!(
-            parse_yyyy_mm_dd("2025-04-31").is_err(),
+            parse_date_arg("2025-04-31").is_err(),
             "April has 30 days, day 31 should be rejected"
         );
     }
@@ -1024,7 +976,7 @@ mod tests {
     #[test]
     fn test_accept_jan_31() {
         assert!(
-            parse_yyyy_mm_dd("2025-01-31").is_ok(),
+            parse_date_arg("2025-01-31").is_ok(),
             "January has 31 days, should be accepted"
         );
     }

--- a/src/uu/chpasswd/Cargo.toml
+++ b/src/uu/chpasswd/Cargo.toml
@@ -20,7 +20,7 @@ path = "src/main.rs"
 [dependencies]
 clap = { workspace = true }
 rustix = { workspace = true }
-shadow-core = { workspace = true, features = ["shadow", "crypt"] }
+shadow-core = { workspace = true, features = ["shadow", "crypt", "login-defs"] }
 uucore = { workspace = true }
 zeroize = { workspace = true }
 

--- a/src/uu/chpasswd/src/chpasswd.rs
+++ b/src/uu/chpasswd/src/chpasswd.rs
@@ -28,6 +28,7 @@ mod options {
     pub const MD5: &str = "md5";
     pub const ROOT: &str = "root";
     pub const SHA_ROUNDS: &str = "sha-rounds";
+    pub const PREFIX: &str = "prefix";
 }
 
 // ---------------------------------------------------------------------------
@@ -148,8 +149,13 @@ fn read_pairs_from_stdin() -> Result<Vec<PasswordPair>, ChpasswdError> {
     let mut pairs = Vec::new();
 
     for (idx, line) in reader.lines().enumerate() {
-        let line = line
-            .map_err(|e| ChpasswdError::UnexpectedFailure(format!("error reading stdin: {e}")))?;
+        // Every input line carries a password. Own it in a Zeroizing so the
+        // buffer is scrubbed when it drops, rather than left in freed heap for
+        // a core dump or the next allocation to expose.
+        let line =
+            zeroize::Zeroizing::new(line.map_err(|e| {
+                ChpasswdError::UnexpectedFailure(format!("error reading stdin: {e}"))
+            })?);
 
         // Skip empty lines.
         if line.trim().is_empty() {
@@ -184,7 +190,8 @@ fn days_since_epoch() -> Result<i64, ChpasswdError> {
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let _clean_env = shadow_core::hardening::harden_process();
 
-    let Some(matches) = shadow_core::cli::parse_args(uu_app(), args, |_| 1)? else {
+    // chpasswd(8) exits 2 for invalid command syntax; every other failure is 1.
+    let Some(matches) = shadow_core::cli::parse_args(uu_app(), args, |_| 2)? else {
         return Ok(());
     };
 
@@ -193,7 +200,8 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         do_chroot(chroot_dir)?;
     }
 
-    let root = SysRoot::default();
+    let prefix = matches.get_one::<String>(options::PREFIX).map(Path::new);
+    let root = SysRoot::new(prefix);
 
     // chpasswd always requires root.
     if !shadow_core::hardening::caller_is_root() {
@@ -240,7 +248,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let hash_config = if is_encrypted {
         None
     } else {
-        let method = resolve_crypt_method(crypt_method.map(String::as_str))?;
+        let method = resolve_crypt_method(crypt_method.map(String::as_str), &root)?;
         if sha_rounds.is_some() && method == shadow_core::crypt::CryptMethod::Yescrypt {
             return Err(ChpasswdError::UnexpectedFailure(
                 "--sha-rounds is not supported with YESCRYPT".into(),
@@ -276,10 +284,12 @@ pub fn uu_app() -> Command {
                 .value_parser(["SHA256", "SHA512", "YESCRYPT", "DES", "MD5"]),
         )
         .arg(
+            // chpasswd(8): "the -c, -e, and -m flags are exclusive".
             Arg::new(options::ENCRYPTED)
                 .short('e')
                 .long("encrypted")
                 .help("treat input passwords as already hashed")
+                .conflicts_with_all([options::CRYPT_METHOD, options::MD5])
                 .action(ArgAction::SetTrue),
         )
         .arg(
@@ -297,12 +307,23 @@ pub fn uu_app() -> Command {
                 .value_name("CHROOT_DIR"),
         )
         .arg(
+            // chpasswd(8): "the -s flag is only allowed with the -c flag". A
+            // rounds count is meaningless without a scheme that takes one, and
+            // silently ignoring it wrote a password the caller did not ask for.
             Arg::new(options::SHA_ROUNDS)
                 .short('s')
                 .long("sha-rounds")
-                .help("iteration count when hashing with SHA-2")
+                .help("iteration count when hashing with SHA-2 (requires -c)")
                 .value_name("ROUNDS")
+                .requires(options::CRYPT_METHOD)
                 .value_parser(clap::value_parser!(i64)),
+        )
+        .arg(
+            Arg::new(options::PREFIX)
+                .short('P')
+                .long("prefix")
+                .help("directory prefix")
+                .value_name("PREFIX_DIR"),
         )
 }
 
@@ -337,11 +358,6 @@ fn apply_password_changes(
         hashed.push((pair.username.as_str(), hash));
     }
 
-    // Consolidate real + effective UID to root for file operations.
-    if rustix::process::geteuid().is_root() {
-        let _ = shadow_core::process::setuid(0);
-    }
-
     // Block signals for the entire critical section.
     let _signals = shadow_core::hardening::SignalBlocker::block_critical()
         .map_err(|e| ChpasswdError::UnexpectedFailure(e.to_string()))?;
@@ -371,9 +387,19 @@ fn apply_password_changes(
 
     let today = days_since_epoch()?;
 
-    // Apply each pair.
+    // Index by name once. A linear scan per pair made the critical section --
+    // held with signals blocked -- quadratic in a batch the size of the file.
+    let index: std::collections::HashMap<&str, usize> = entries
+        .iter()
+        .enumerate()
+        .map(|(i, e)| (e.name.as_str(), i))
+        .collect();
+
+    // Resolve every pair before writing any, so an unknown account in the
+    // middle of a batch leaves the file untouched rather than half-applied.
+    let mut targets = Vec::with_capacity(hashed.len());
     for (username, hash) in hashed {
-        let Some(entry) = entries.iter_mut().find(|e| e.name == username) else {
+        let Some(&i) = index.get(username) else {
             drop(lock);
             return Err(ChpasswdError::InvalidInput(format!(
                 "user '{username}' does not exist in {}",
@@ -381,7 +407,17 @@ fn apply_password_changes(
             ))
             .into());
         };
+        targets.push((i, hash));
+    }
 
+    for (i, hash) in targets {
+        let Some(entry) = entries.get_mut(i) else {
+            drop(lock);
+            return Err(ChpasswdError::UnexpectedFailure(
+                "shadow entry vanished between indexing and writing".into(),
+            )
+            .into());
+        };
         entry.passwd = hash;
         entry.last_change = Some(today);
     }
@@ -412,23 +448,54 @@ fn apply_password_changes(
 // Helpers
 // ---------------------------------------------------------------------------
 
-/// Map `-c` flag to a `CryptMethod`.
+/// The hashing scheme to use, from `-c` or, absent that, from login.defs.
+///
+/// chpasswd(8) takes its default from `ENCRYPT_METHOD` in login.defs, which is
+/// how a distribution chooses the scheme for the whole system -- Debian sets
+/// YESCRYPT, and hard-coding SHA512 quietly wrote weaker hashes than the rest
+/// of the system was configured to produce. SHA512 remains the fallback when
+/// the file names nothing usable.
 fn resolve_crypt_method(
     method: Option<&str>,
+    root: &SysRoot,
 ) -> Result<shadow_core::crypt::CryptMethod, ChpasswdError> {
+    match method {
+        Some(name) => parse_crypt_method(name).ok_or_else(|| {
+            ChpasswdError::UnexpectedFailure(match name {
+                "MD5" | "DES" => {
+                    "MD5 and DES are insecure and not supported for plaintext hashing".into()
+                }
+                other => format!("unknown crypt method: {other}"),
+            })
+        }),
+        None => Ok(default_crypt_method(root)),
+    }
+}
+
+/// Map a login.defs / `-c` method name to a `CryptMethod`.
+///
+/// `None` for a name that is not supported, including the insecure ones.
+fn parse_crypt_method(name: &str) -> Option<shadow_core::crypt::CryptMethod> {
     use shadow_core::crypt::CryptMethod;
 
-    match method {
-        Some("SHA256") => Ok(CryptMethod::Sha256),
-        Some("SHA512") | None => Ok(CryptMethod::Sha512),
-        Some("YESCRYPT") => Ok(CryptMethod::Yescrypt),
-        Some("MD5" | "DES") => Err(ChpasswdError::UnexpectedFailure(
-            "MD5 and DES are insecure and not supported for plaintext hashing".into(),
-        )),
-        Some(other) => Err(ChpasswdError::UnexpectedFailure(format!(
-            "unknown crypt method: {other}"
-        ))),
+    match name {
+        "SHA256" => Some(CryptMethod::Sha256),
+        "SHA512" => Some(CryptMethod::Sha512),
+        "YESCRYPT" => Some(CryptMethod::Yescrypt),
+        _ => None,
     }
+}
+
+/// The system's configured hashing scheme, or SHA-512 if there is none.
+///
+/// An unreadable login.defs, a missing `ENCRYPT_METHOD`, or one naming a scheme
+/// this build will not write (MD5, DES) all fall back rather than fail: the
+/// caller asked to set a password, not to audit the configuration.
+fn default_crypt_method(root: &SysRoot) -> shadow_core::crypt::CryptMethod {
+    shadow_core::login_defs::LoginDefs::load(&root.login_defs_path())
+        .ok()
+        .and_then(|d| d.get("ENCRYPT_METHOD").and_then(parse_crypt_method))
+        .unwrap_or(shadow_core::crypt::CryptMethod::Sha512)
 }
 
 /// Perform `chroot(2)` into the specified directory.
@@ -501,11 +568,12 @@ mod tests {
         assert!(result.is_err(), "invalid crypt method should fail");
     }
 
+    /// `-s` needs `-c`, so the value is read from the pair of them.
     #[test]
     fn test_sha_rounds_flag() {
         let m = uu_app()
-            .try_get_matches_from(["chpasswd", "-s", "5000"])
-            .expect("should parse -s 5000");
+            .try_get_matches_from(["chpasswd", "-c", "SHA512", "-s", "5000"])
+            .expect("should parse -c SHA512 -s 5000");
         assert_eq!(m.get_one::<i64>(options::SHA_ROUNDS).copied(), Some(5000));
     }
 
@@ -683,5 +751,110 @@ mod tests {
             days < 47500,
             "days since epoch should be < 47500, got {days}"
         );
+    }
+
+    // -----------------------------------------------------------------------
+    // Crypt method selection
+    // -----------------------------------------------------------------------
+
+    fn defs_root(contents: &str) -> (tempfile::TempDir, SysRoot) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let etc = dir.path().join("etc");
+        std::fs::create_dir_all(&etc).expect("etc");
+        std::fs::write(etc.join("login.defs"), contents).expect("write");
+        let root = SysRoot::new(Some(dir.path()));
+        (dir, root)
+    }
+
+    /// The default scheme is the system's, not a hard-coded one: Debian sets
+    /// YESCRYPT, and writing SHA-512 there produced weaker hashes than every
+    /// other tool on the host.
+    #[test]
+    fn test_default_method_comes_from_login_defs() {
+        use shadow_core::crypt::CryptMethod;
+
+        let (_d, root) = defs_root("ENCRYPT_METHOD YESCRYPT\n");
+        assert_eq!(default_crypt_method(&root), CryptMethod::Yescrypt);
+
+        let (_d, root) = defs_root("ENCRYPT_METHOD SHA256\n");
+        assert_eq!(default_crypt_method(&root), CryptMethod::Sha256);
+    }
+
+    /// A configuration this build will not honour must not stop a password
+    /// change; SHA-512 is the fallback.
+    #[test]
+    fn test_default_method_falls_back_to_sha512() {
+        use shadow_core::crypt::CryptMethod;
+
+        for defs in [
+            "",
+            "ENCRYPT_METHOD MD5\n",
+            "ENCRYPT_METHOD DES\n",
+            "# nothing\n",
+        ] {
+            let (_d, root) = defs_root(defs);
+            assert_eq!(
+                default_crypt_method(&root),
+                CryptMethod::Sha512,
+                "unexpected fallback for {defs:?}"
+            );
+        }
+
+        // An absent login.defs is not an error either.
+        let dir = tempfile::tempdir().expect("tempdir");
+        assert_eq!(
+            default_crypt_method(&SysRoot::new(Some(dir.path()))),
+            CryptMethod::Sha512
+        );
+    }
+
+    /// `-c` wins over the configured default, and names the tool refuses stay
+    /// refused rather than silently falling back.
+    #[test]
+    fn test_explicit_method_overrides_and_rejects() {
+        use shadow_core::crypt::CryptMethod;
+
+        let (_d, root) = defs_root("ENCRYPT_METHOD YESCRYPT\n");
+        assert_eq!(
+            resolve_crypt_method(Some("SHA256"), &root).expect("SHA256"),
+            CryptMethod::Sha256
+        );
+        for bad in ["MD5", "DES", "BCRYPT", "nonsense"] {
+            assert!(
+                resolve_crypt_method(Some(bad), &root).is_err(),
+                "'{bad}' should be refused"
+            );
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Flag combinations chpasswd(8) rejects
+    // -----------------------------------------------------------------------
+
+    /// A rounds count without a scheme, and a scheme with pre-hashed input,
+    /// are both usage errors rather than options that quietly do nothing.
+    #[test]
+    fn test_exclusive_and_dependent_flags() {
+        for args in [
+            vec!["chpasswd", "-s", "5000"],
+            vec!["chpasswd", "-e", "-c", "SHA512"],
+            vec!["chpasswd", "-e", "-m"],
+        ] {
+            assert!(
+                uu_app().try_get_matches_from(args.clone()).is_err(),
+                "{args:?} should be a usage error"
+            );
+        }
+        // The combinations that are allowed still parse.
+        for args in [
+            vec!["chpasswd", "-c", "SHA512", "-s", "5000"],
+            vec!["chpasswd", "-e"],
+            vec!["chpasswd"],
+        ] {
+            assert!(
+                uu_app().try_get_matches_from(args.clone()).is_ok(),
+                "{args:?} should parse"
+            );
+        }
     }
 }

--- a/src/uu/newgrp/src/newgrp.rs
+++ b/src/uu/newgrp/src/newgrp.rs
@@ -23,7 +23,45 @@ use shadow_core::sysroot::SysRoot;
 use uucore::error::{UError, UResult};
 
 mod options {
-    pub const GROUP: &str = "group";
+    /// The `[-] [group]` operands, taken together so a leading `-` can be told
+    /// from a group name.
+    pub const OPERANDS: &str = "operands";
+}
+
+/// What the command line asked for.
+struct Operands<'a> {
+    /// `newgrp -`: reinitialize the environment as at login.
+    login: bool,
+    /// The target group, or `None` for the user's primary group.
+    group: Option<&'a str>,
+}
+
+/// Split `newgrp [-] [group]` into its two parts.
+///
+/// newgrp(1) spells the login form as a bare `-`, not as an option letter, and
+/// it may only come first. A second `-`, or anything after the group name, is
+/// a usage error rather than a group called `-`.
+fn parse_operands(operands: &[String]) -> Result<Operands<'_>, NewgrpError> {
+    let usage = || NewgrpError::Error("usage: newgrp [-] [group]".into());
+    match operands {
+        [] => Ok(Operands {
+            login: false,
+            group: None,
+        }),
+        [first] if first == "-" => Ok(Operands {
+            login: true,
+            group: None,
+        }),
+        [first] => Ok(Operands {
+            login: false,
+            group: Some(first.as_str()),
+        }),
+        [first, second] if first == "-" && second != "-" => Ok(Operands {
+            login: true,
+            group: Some(second.as_str()),
+        }),
+        _ => Err(usage()),
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -116,86 +154,14 @@ fn group_has_password(gshadow_path: &Path, group_name: &str) -> Option<String> {
     Some(entry.passwd.clone())
 }
 
-/// RAII guard that restores terminal echo on drop.
-struct EchoGuard {
-    tty: std::fs::File,
-    old_termios: rustix::termios::Termios,
-}
-
-impl EchoGuard {
-    /// Disable echo on the given tty file.
-    fn disable(tty: std::fs::File) -> Result<Self, NewgrpError> {
-        use std::os::unix::io::AsFd;
-
-        let old_termios = rustix::termios::tcgetattr(tty.as_fd())
-            .map_err(|e| NewgrpError::Error(format!("cannot get terminal attributes: {e}")))?;
-
-        let mut new_termios = old_termios.clone();
-        new_termios.local_modes &= !rustix::termios::LocalModes::ECHO;
-        rustix::termios::tcsetattr(
-            tty.as_fd(),
-            rustix::termios::OptionalActions::Now,
-            &new_termios,
-        )
-        .map_err(|e| NewgrpError::Error(format!("cannot disable echo: {e}")))?;
-
-        Ok(Self { tty, old_termios })
-    }
-}
-
-impl Drop for EchoGuard {
-    fn drop(&mut self) {
-        use std::os::unix::io::AsFd;
-        let _ = rustix::termios::tcsetattr(
-            self.tty.as_fd(),
-            rustix::termios::OptionalActions::Now,
-            &self.old_termios,
-        );
-    }
-}
-
-/// Read a password from `/dev/tty` with echo disabled.
+/// Read the group password, with echo off and interrupts blocked.
 ///
-/// The returned password is wrapped in `Zeroizing` to ensure it is
-/// scrubbed from memory when dropped.
+/// The shared helper is what keeps Ctrl-C at this prompt from leaving the
+/// terminal with echo disabled, and it falls back to stderr/stdin where there
+/// is no controlling terminal.
 fn read_password(prompt: &str) -> Result<zeroize::Zeroizing<String>, NewgrpError> {
-    use std::io::{BufRead, Write};
-
-    let tty = std::fs::File::options()
-        .read(true)
-        .write(true)
-        .open("/dev/tty")
-        .map_err(|e| NewgrpError::Error(format!("cannot open /dev/tty: {e}")))?;
-
-    // Write the prompt.
-    (&tty)
-        .write_all(prompt.as_bytes())
-        .map_err(|e| NewgrpError::Error(format!("cannot write prompt: {e}")))?;
-    (&tty)
-        .flush()
-        .map_err(|e| NewgrpError::Error(format!("cannot flush prompt: {e}")))?;
-
-    // Clone the tty handle: one for the guard (to restore echo), one for reading.
-    let tty_for_guard = tty
-        .try_clone()
-        .map_err(|e| NewgrpError::Error(format!("cannot clone tty handle: {e}")))?;
-
-    // Disable echo; restored automatically on drop.
-    let guard = EchoGuard::disable(tty_for_guard)?;
-
-    let mut buf = zeroize::Zeroizing::new(String::new());
-    let mut reader = std::io::BufReader::new(&tty);
-    reader
-        .read_line(&mut buf)
-        .map_err(|e| NewgrpError::Error(format!("cannot read password: {e}")))?;
-
-    // Echo was off, so print newline after the user presses Enter.
-    drop(guard);
-    let _ = (&tty).write_all(b"\n");
-
-    Ok(zeroize::Zeroizing::new(
-        buf.trim_end_matches('\n').to_string(),
-    ))
+    shadow_core::tty::read_password(prompt)
+        .map_err(|e| NewgrpError::Error(format!("cannot read the password: {e}")))
 }
 
 /// Verify a password against a crypt(3) hash.
@@ -213,10 +179,12 @@ fn verify_password(password: &str, hash: &str) -> Result<bool, NewgrpError> {
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    // newgrp execs a shell, so only suppress core dumps — do NOT raise
+    // newgrp execs a shell, so only suppress core dumps -- do NOT raise
     // RLIMIT_FSIZE as that would leak into the user's interactive session.
+    // The environment is deliberately not sanitized here either: without `-`,
+    // newgrp(1) keeps the caller's environment, and it hands that environment
+    // back to the caller's own uid, so there is nothing to protect it from.
     shadow_core::hardening::suppress_core_dumps();
-    let _clean_env = shadow_core::hardening::sanitized_env();
 
     let Some(matches) = shadow_core::cli::parse_args(uu_app(), args, |_| 1)? else {
         return Ok(());
@@ -227,10 +195,18 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         .map_err(|e| NewgrpError::Error(e.to_string()))?;
     let user_gid = get_current_gid()?;
 
-    let group_name = matches.get_one::<String>(options::GROUP);
+    let operands: Vec<String> = matches
+        .get_many::<String>(options::OPERANDS)
+        .map(|v| v.cloned().collect())
+        .unwrap_or_default();
+    let Operands {
+        login,
+        group: group_name,
+    } = parse_operands(&operands)?;
 
     // Resolve the target GID.
     let target_gid = if let Some(gname) = group_name {
+        let gname = &gname.to_string();
         // Look up the group in /etc/group.
         let group_path = root.group_path();
         let groups = group::read_group_file(&group_path).map_err(|e| {
@@ -295,18 +271,66 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let shell_cstr = CString::new(shell.as_str())
         .map_err(|_| NewgrpError::Error("invalid shell path".into()))?;
 
-    // Build argv: the shell name prefixed with '-' to indicate a login shell,
-    // matching traditional newgrp behavior.
-    let shell_basename = Path::new(&shell)
+    let basename = Path::new(&shell)
         .file_name()
         .map_or_else(|| "sh".to_string(), |n| n.to_string_lossy().to_string());
-    let login_name = format!("-{shell_basename}");
-    let login_cstr = CString::new(login_name.as_str())
+
+    if !login {
+        // newgrp(1): without `-`, "the current environment, including current
+        // working directory, remains unchanged". A login shell would re-read
+        // the profile files in that unchanged environment on every `newgrp`,
+        // so argv[0] carries no leading dash and the environment is inherited.
+        let argv0 = CString::new(basename.as_str())
+            .map_err(|_| NewgrpError::Error("invalid shell name".into()))?;
+        let err = shadow_core::process::execv(&shell_cstr, &[&argv0]);
+        return Err(NewgrpError::Error(format!("cannot exec {shell}: {err}")).into());
+    }
+
+    // newgrp(1) with `-`: "the user's environment will be reinitialized as
+    // though the user had logged in". That means a login shell, the home
+    // directory as the working directory, and a login environment rather than
+    // whatever the previous shell was carrying.
+    let argv0 = CString::new(format!("-{basename}"))
         .map_err(|_| NewgrpError::Error("invalid shell name".into()))?;
 
-    // execv replaces the current process. If it fails, we return an error.
-    let err = shadow_core::process::execv(&shell_cstr, &[&login_cstr]);
+    let home = shadow_core::hardening::lookup_passwd_entry_by_uid(real_uid)
+        .map(|e| e.home)
+        .unwrap_or_default();
+    if !home.is_empty() {
+        // A missing or unreadable home is not fatal; login(1) falls back to /.
+        let _ = rustix::process::chdir(Path::new(&home));
+    }
+
+    let env = login_environment(&username, &home, &shell);
+    let env_cstrings: Vec<CString> = env
+        .into_iter()
+        .map(|kv| CString::new(kv).map_err(|_| NewgrpError::Error("invalid environment".into())))
+        .collect::<Result<_, _>>()?;
+    let env_refs: Vec<&std::ffi::CStr> = env_cstrings.iter().map(CString::as_c_str).collect();
+
+    let err = shadow_core::process::execve(&shell_cstr, &[&argv0], &env_refs);
     Err(NewgrpError::Error(format!("cannot exec {shell}: {err}")).into())
+}
+
+/// The environment a login shell is entitled to expect.
+///
+/// Everything else the caller was carrying is dropped, which is the whole
+/// point of `newgrp -`. `TERM` and the locale variables are kept because a
+/// login session inherits them from the terminal, not from the profile.
+fn login_environment(user: &str, home: &str, shell: &str) -> Vec<String> {
+    let mut env = vec![
+        format!("HOME={home}"),
+        format!("SHELL={shell}"),
+        format!("USER={user}"),
+        format!("LOGNAME={user}"),
+        "PATH=/usr/local/bin:/usr/bin:/bin".to_string(),
+    ];
+    for (k, v) in std::env::vars() {
+        if k == "TERM" || k == "LANG" || k.starts_with("LC_") {
+            env.push(format!("{k}={v}"));
+        }
+    }
+    env
 }
 
 /// Build the clap `Command` for `newgrp`.
@@ -317,7 +341,15 @@ pub fn uu_app() -> Command {
         .override_usage("newgrp [group]")
         .version(shadow_core::cli::VERSION)
         .after_help(shadow_core::cli::AFTER_HELP)
-        .arg(Arg::new(options::GROUP).help("Target group").index(1))
+        .arg(
+            Arg::new(options::OPERANDS)
+                .help("optional '-' to reinitialize the environment, then the target group")
+                .value_name("[-] [group]")
+                .num_args(0..=2)
+                // A bare '-' is an operand here, not an unknown option.
+                .allow_hyphen_values(true)
+                .index(1),
+        )
 }
 
 #[cfg(test)]
@@ -415,25 +447,90 @@ mod tests {
         assert!(!err.use_stderr());
     }
 
-    #[test]
-    fn test_group_arg_parses() {
-        let matches = uu_app()
-            .try_get_matches_from(["newgrp", "docker"])
-            .expect("should parse");
-        assert_eq!(
-            matches
-                .get_one::<String>(options::GROUP)
-                .map(String::as_str),
-            Some("docker")
-        );
+    // -----------------------------------------------------------------------
+    // Operand parsing: newgrp [-] [group]
+    // -----------------------------------------------------------------------
+
+    fn operands(cli: &[&str]) -> Vec<String> {
+        let mut full = vec!["newgrp".to_string()];
+        full.extend(cli.iter().map(|s| (*s).to_string()));
+        uu_app()
+            .try_get_matches_from(full)
+            .expect("should parse")
+            .get_many::<String>(options::OPERANDS)
+            .map(|v| v.cloned().collect())
+            .unwrap_or_default()
     }
 
     #[test]
-    fn test_no_group_arg_parses() {
-        let matches = uu_app()
-            .try_get_matches_from(["newgrp"])
-            .expect("should parse");
-        assert!(matches.get_one::<String>(options::GROUP).is_none());
+    fn test_no_operands_is_the_primary_group() {
+        let ops = operands(&[]);
+        let parsed = parse_operands(&ops).expect("should parse");
+        assert!(!parsed.login);
+        assert_eq!(parsed.group, None);
+    }
+
+    #[test]
+    fn test_group_alone() {
+        let ops = operands(&["docker"]);
+        let parsed = parse_operands(&ops).expect("should parse");
+        assert!(!parsed.login);
+        assert_eq!(parsed.group, Some("docker"));
+    }
+
+    /// A bare `-` is newgrp(1)'s login form, not an unknown option and not a
+    /// group named "-".
+    #[test]
+    fn test_dash_requests_a_login_environment() {
+        let ops = operands(&["-"]);
+        let parsed = parse_operands(&ops).expect("should parse");
+        assert!(parsed.login);
+        assert_eq!(parsed.group, None);
+
+        let ops = operands(&["-", "docker"]);
+        let parsed = parse_operands(&ops).expect("should parse");
+        assert!(parsed.login);
+        assert_eq!(parsed.group, Some("docker"));
+    }
+
+    /// `-` may only come first, and only once.
+    #[test]
+    fn test_misplaced_dash_is_a_usage_error() {
+        for cli in [vec!["docker", "-"], vec!["-", "-"]] {
+            let ops = operands(&cli);
+            assert!(
+                parse_operands(&ops).is_err(),
+                "{cli:?} should be a usage error"
+            );
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Login environment
+    // -----------------------------------------------------------------------
+
+    /// `newgrp -` reinitializes the environment, so the shell must be given
+    /// the variables a login session defines and nothing the caller was
+    /// carrying.
+    #[test]
+    fn test_login_environment_is_a_login_session() {
+        let env = login_environment("alice", "/home/alice", "/bin/bash");
+        for expected in [
+            "HOME=/home/alice",
+            "SHELL=/bin/bash",
+            "USER=alice",
+            "LOGNAME=alice",
+        ] {
+            assert!(env.iter().any(|e| e == expected), "missing {expected}");
+        }
+        assert!(
+            env.iter().any(|e| e.starts_with("PATH=")),
+            "a login shell needs a PATH"
+        );
+        assert!(
+            !env.iter().any(|e| e.starts_with("LD_PRELOAD=")),
+            "the caller's environment must not be carried over"
+        );
     }
 
     // -----------------------------------------------------------------------

--- a/src/uu/passwd/src/passwd.rs
+++ b/src/uu/passwd/src/passwd.rs
@@ -69,6 +69,11 @@ mod exit_codes {
 enum PasswdError {
     /// Exit 1 — insufficient privileges.
     PermissionDenied(String),
+    /// Exit 1 — the account does not exist.
+    ///
+    /// Not an "unexpected failure": passwd(1) exits 1 for an unknown login,
+    /// and 3 is for something going wrong that the caller did not ask for.
+    UserNotFound(String),
     /// Exit 3 — an unexpected runtime failure.
     UnexpectedFailure(String),
     /// Exit 4 — `/etc/shadow` (or equivalent) does not exist.
@@ -86,6 +91,7 @@ impl fmt::Display for PasswdError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::PermissionDenied(msg)
+            | Self::UserNotFound(msg)
             | Self::UnexpectedFailure(msg)
             | Self::FileMissing(msg)
             | Self::FileBusy(msg)
@@ -100,7 +106,7 @@ impl std::error::Error for PasswdError {}
 impl UError for PasswdError {
     fn code(&self) -> i32 {
         match self {
-            Self::PermissionDenied(_) => 1,
+            Self::PermissionDenied(_) | Self::UserNotFound(_) => 1,
             Self::UnexpectedFailure(_) => 3,
             Self::FileMissing(_) => 4,
             Self::FileBusy(_) => 5,
@@ -493,7 +499,7 @@ fn cmd_status(root: &SysRoot, target_user: Option<&str>) -> UResult<()> {
     match target_user {
         Some(user) => {
             let Some(entry) = entries.iter().find(|e| e.name == user) else {
-                return Err(PasswdError::UnexpectedFailure(format!(
+                return Err(PasswdError::UserNotFound(format!(
                     "user '{user}' does not exist in {}",
                     shadow_path.display()
                 ))
@@ -662,22 +668,16 @@ fn format_status(entry: &ShadowEntry) -> String {
     )
 }
 
-/// Convert days since epoch to `YYYY-MM-DD` format (matching GNU `passwd -S`).
+/// Convert days since the epoch to the `YYYY-MM-DD` form `passwd -S` prints.
 ///
-/// Uses the Hinnant `civil_from_days` algorithm — pure Rust, no libc.
+/// A value that is not a representable date -- anything with write access to
+/// `/etc/shadow` can put one there -- shows as `never`, which is what GNU
+/// displays for a field it cannot make sense of.
 fn format_days_since_epoch(days: i64) -> String {
-    // Algorithm: https://howardhinnant.github.io/date_algorithms.html#civil_from_days
-    let z = days + 719_468;
-    let era = (if z >= 0 { z } else { z - 146_096 }) / 146_097;
-    let doe = z - era * 146_097;
-    let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146_096) / 365;
-    let y = yoe + era * 400;
-    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
-    let mp = (5 * doy + 2) / 153;
-    let d = doy - (153 * mp + 2) / 5 + 1;
-    let m = if mp < 10 { mp + 3 } else { mp - 9 };
-    let y = if m <= 2 { y + 1 } else { y };
-    format!("{y:04}-{m:02}-{d:02}")
+    shadow_core::date::civil_from_days(days).map_or_else(
+        || "never".to_string(),
+        |(y, m, d)| format!("{y:04}-{m:02}-{d:02}"),
+    )
 }
 
 /// Lock the shadow file, read entries, apply a mutation to one user's entry,
@@ -729,7 +729,7 @@ where
     // Find the target user.
     let Some(entry) = entries.iter_mut().find(|e| e.name == username) else {
         drop(lock);
-        return Err(PasswdError::UnexpectedFailure(format!(
+        return Err(PasswdError::UserNotFound(format!(
             "user '{username}' does not exist in {}",
             shadow_path.display()
         ))

--- a/tests/by-util/test_passwd.rs
+++ b/tests/by-util/test_passwd.rs
@@ -165,9 +165,9 @@ fn test_nonexistent_user_fails() {
     }
     let dir = setup_prefix("testuser:$6$hash:19500:0:99999:7:::\n");
     let code = run_with_prefix(&dir, &["-S", "nosuchuser"]);
-    assert_ne!(code, 0, "nonexistent user should fail");
-    // GNU passwd exits 3 for unexpected failures (user not found is exit 3).
-    assert_eq!(code, 3, "nonexistent user should exit 3");
+    // GNU passwd exits 1 for an unknown login (verified against shadow 4.17);
+    // 3 is reserved for an unexpected failure the caller did not ask for.
+    assert_eq!(code, 1, "nonexistent user should exit 1");
 }
 
 #[test]

--- a/tests/e2e/deploy-test.sh
+++ b/tests/e2e/deploy-test.sh
@@ -591,6 +591,114 @@ test_self_service() {
     userdel -r selftest_user 2>/dev/null || true
 }
 
+# ── Aging fields, batch input and newgrp ────────────────────────────
+
+# Print the value column of one `chage -l` line, e.g. aging_field 2 alice
+# for "Password expires".
+aging_field() {
+    chage -l "$2" | sed -n "$1p" | sed 's/.*: //'
+}
+
+test_aging_and_input() {
+    section "Aging fields, batch input, newgrp"
+
+    userdel -r aging_user 2>/dev/null || true
+    assert_ok "useradd -m aging_user" useradd -m aging_user
+
+    # A last-change day of 0 is `passwd -e`'s marker, not a date, and it makes
+    # both derived dates meaningless too.
+    assert_ok "chage -d 0 aging_user" chage -d 0 aging_user
+    assert_ok "last change reports 'password must be changed'" \
+        test "$(aging_field 1 aging_user)" = "password must be changed"
+    assert_ok "password expiry reports 'password must be changed'" \
+        test "$(aging_field 2 aging_user)" = "password must be changed"
+    assert_ok "password inactive reports 'password must be changed'" \
+        test "$(aging_field 3 aging_user)" = "password must be changed"
+
+    # The threshold above which a maximum age means "no expiry" is 10000.
+    assert_ok "chage -d 2026-01-01 -M 9999 aging_user" \
+        chage -d 2026-01-01 -M 9999 aging_user
+    assert_ok "max 9999 gives a real expiry date" \
+        test "$(aging_field 2 aging_user)" = "May 18, 2053"
+    assert_ok "chage -M 10000 aging_user" chage -M 10000 aging_user
+    assert_ok "max 10000 means never" \
+        test "$(aging_field 2 aging_user)" = "never"
+
+    # -1 clears a field; anything else negative is a usage error.
+    assert_ok "chage -M -1 clears the maximum" chage -M -1 aging_user
+    assert_ok "cleared maximum reads back as -1" \
+        test "$(aging_field 6 aging_user)" = "-1"
+    assert_fail "chage -M -5 is refused" chage -M -5 aging_user
+    assert_fail "chage -d -5 is refused" chage -d -5 aging_user
+
+    # An unknown login is an ordinary failure (1), not "no shadow file" (15).
+    assert_ok "chage -l on an unknown login exits 1" \
+        bash -c 'chage -l no-such-user-4b2 >/dev/null 2>&1; [ "$?" -eq 1 ]'
+    assert_ok "passwd -S on an unknown login exits 1" \
+        bash -c 'passwd -S no-such-user-4b2 >/dev/null 2>&1; [ "$?" -eq 1 ]'
+
+    # chpasswd takes its default hashing scheme from login.defs, as the rest
+    # of the system does; hard-coding one wrote weaker hashes than configured.
+    assert_ok "ENCRYPT_METHOD YESCRYPT in login.defs" \
+        bash -c "sed -i '/^ENCRYPT_METHOD/d' /etc/login.defs; echo 'ENCRYPT_METHOD YESCRYPT' >>/etc/login.defs"
+    assert_ok "chpasswd hashes aging_user" \
+        bash -c "echo 'aging_user:BatchPass123' | chpasswd"
+    assert_file_contains "chpasswd used yescrypt as configured" \
+        /etc/shadow 'aging_user:\$y\$'
+    assert_ok "ENCRYPT_METHOD SHA512 in login.defs" \
+        bash -c "sed -i 's/^ENCRYPT_METHOD.*/ENCRYPT_METHOD SHA512/' /etc/login.defs"
+    assert_ok "chpasswd hashes aging_user again" \
+        bash -c "echo 'aging_user:BatchPass456' | chpasswd"
+    assert_file_contains "chpasswd followed the changed configuration" \
+        /etc/shadow 'aging_user:\$6\$'
+    assert_ok "-c overrides the configured default" \
+        bash -c "echo 'aging_user:BatchPass789' | chpasswd -c SHA256"
+    assert_file_contains "explicit -c wins" /etc/shadow 'aging_user:\$5\$'
+
+    # Flag combinations chpasswd(8) documents as errors.
+    assert_ok "-s without -c is a usage error (exit 2)" \
+        bash -c 'echo "aging_user:x" | chpasswd -s 5000 >/dev/null 2>&1; [ "$?" -eq 2 ]'
+    assert_ok "-e with -c is a usage error (exit 2)" \
+        bash -c 'echo "aging_user:x" | chpasswd -e -c SHA512 >/dev/null 2>&1; [ "$?" -eq 2 ]'
+
+    # --prefix on chage and chpasswd, so their behaviour is testable without
+    # touching the live files.
+    local pfx
+    pfx=$(mktemp -d)
+    mkdir -p "$pfx/etc"
+    printf 'pfxuser:x:4000:4000::/home/pfxuser:/bin/sh\n' >"$pfx/etc/passwd"
+    printf 'pfxuser:!:19000:0:99999:7:::\n' >"$pfx/etc/shadow"
+    assert_ok "chage --prefix reads the prefixed shadow file" \
+        chage -P "$pfx" -l pfxuser
+    assert_ok "chage --prefix writes the prefixed shadow file" \
+        chage -P "$pfx" -M 42 pfxuser
+    assert_file_contains "prefixed maximum age written" \
+        "$pfx/etc/shadow" 'pfxuser:!:19000:0:42:'
+    assert_ok "chpasswd --prefix writes the prefixed shadow file" \
+        bash -c "echo 'pfxuser:PrefixPass1' | chpasswd -P '$pfx'"
+    assert_ok "the live shadow file was untouched by --prefix" \
+        bash -c "! grep -q '^pfxuser:' /etc/shadow"
+    rm -rf "$pfx"
+
+    # newgrp: without '-' the environment and working directory survive; with
+    # '-' the shell is a login shell in a reinitialized environment.
+    groupadd -f newgrp_grp >/dev/null 2>&1
+    usermod -aG newgrp_grp aging_user
+    assert_ok "newgrp switches the primary group" \
+        bash -c "su -s /bin/bash aging_user -c 'echo id -gn | newgrp newgrp_grp' | grep -qx newgrp_grp"
+    assert_ok "newgrp keeps the caller's environment" \
+        bash -c "su -s /bin/bash aging_user -c 'MARKER=kept; export MARKER; echo \"echo \\\$MARKER\" | newgrp newgrp_grp' | grep -qx kept"
+    assert_ok "newgrp - reinitializes the environment" \
+        bash -c "su -s /bin/bash aging_user -c 'MARKER=kept; export MARKER; echo \"echo m=\\\$MARKER\" | newgrp - newgrp_grp' | grep -qx 'm='"
+    assert_ok "newgrp - still switches the group" \
+        bash -c "su -s /bin/bash aging_user -c 'echo id -gn | newgrp - newgrp_grp' | grep -qx newgrp_grp"
+    assert_fail "newgrp rejects a misplaced dash" \
+        su -s /bin/bash aging_user -c "newgrp newgrp_grp - </dev/null"
+
+    groupdel newgrp_grp 2>/dev/null || true
+    userdel -r aging_user 2>/dev/null || true
+}
+
 # ── nscd cache invalidation ────────────────────────────────────────
 
 test_nscd() {
@@ -700,6 +808,7 @@ main() {
     test_individual_tools
     test_pam_auth
     test_self_service
+    test_aging_and_input
     test_nscd
     test_landlock
     test_ansible


### PR DESCRIPTION
Closes #248.

Everything below was checked against GNU shadow 4.17 in the Debian image before
being changed, and again with the real binaries in the end-to-end container
after. One claim in the issue did not survive that check and is not implemented,
see the last section.

### chage

- **A last change of 0 is not a date.** It is the "must change at next login"
  marker `passwd -e` writes, and it makes the two dates derived from it
  meaningless as well. GNU prints *password must be changed* on all three
  password lines; we printed 1970 dates for the two derived ones.
- **Password expiry is disabled at a maximum age of 10000 days, not 99999.**
  `-M 9999` shows a date, `-M 10000` shows `never`.
- **An unknown login exits 1, not 15.** `chage(1)` reserves 15 for *can't find
  the shadow password file*; a missing account is an ordinary failure.
- Gains `--prefix`, so it can be exercised without touching the live files.

### passwd

- **An unknown login exits 1, not 3.** 3 is for an unexpected failure, not for
  a login the caller named that does not exist. A test pinned the old value and
  has been rewritten to the verified one.

### chpasswd

- **The default hashing scheme now comes from `ENCRYPT_METHOD`.** It was
  hard-coded SHA-512. On Debian, which sets YESCRYPT, every password set through
  this tool was weaker than the one the same user would get from `passwd`. `-c`
  still overrides; an unreadable or unusable configuration falls back to SHA-512
  rather than refusing to set a password.
- **Two flag pairs the man page forbids were accepted and silently did
  nothing**: `-s` without `-c` (a rounds count with no scheme) and `-e` with
  `-c` (a scheme for input that is already hashed). Both are usage errors now,
  exiting 2 as `chpasswd(8)` documents.
- **A batch is resolved before it is applied.** An unknown login in the middle
  of a list used to leave the first half written.
- The per-pair linear scan became an index, taking the critical section out of
  quadratic time; it is held with signals blocked.
- Drops the `setuid(0)` before the write, and owns each input line in a
  zeroizing buffer. Gains `--prefix`.

### newgrp

- **`newgrp -` is implemented.** It looked for a group named `-` and reported it
  missing.
- **Not every shell is a login shell any more.** `argv[0]` carried a leading
  dash on every invocation, so the profile files were re-read on each
  `newgrp docker`, in an environment they had already been applied to. Without
  `-` the shell is now a plain shell inheriting the environment and working
  directory; with `-` it is a login shell, in the home directory, with an
  environment built explicitly.

### shadow-core

- The Hinnant calendar algorithms existed three times. One `date` module now
  holds both directions and the two display forms, **with the arithmetic
  checked**: `chage -l` adds `lastchg + max + inactive`, three values read from
  a file anyone who can write `/etc/shadow` chooses. Plain addition wraps in
  release builds and panics in debug ones. An unrepresentable date shows as
  `never`.
- The copy of the password `crypt(3)` needs as a C string was made with
  `CString::new` and freed **without zeroing**: the caller's `Zeroizing<String>`
  scrubs its own buffer and never learns about that one.
- The PAM response cleanup zeroed with `ptr::write_bytes` immediately before
  `free()`. That is a dead store the optimiser may delete, leaving the password
  in the heap. Volatile writes and a compiler fence cannot be elided.
- `PAM_TTY` and `PAM_RUSER` were never set, so `pam_unix` and `pam_faillock`
  logged `tty=?` with no requesting user. That makes their records useless for
  tracing a failed authentication, and stops `pam_faillock`'s per-tty handling
  from working at all.

### One issue claim that did not hold

The issue states that when a gshadow entry exists, `newgrp` takes **both** the
membership and the password from it. Four groups covering the cases say
otherwise:

| group | `/etc/group` members | `/etc/gshadow` | result |
|---|---|---|---|
| g1 | u1 | password set | admitted, no prompt |
| g2 | none | u1 listed as member | **denied** |
| g3 | none | u1 listed as admin, password set | **denied** |
| g4 | u1 | no password | admitted, no prompt |

Membership comes from `/etc/group`; the password comes from `/etc/gshadow`; a
user listed only in gshadow's member list is not admitted. That is what this
already did, so nothing changed there.

### Verification

All three man pages were rewritten. The deployment suite gains 35 assertions
run against the real binaries.

```
Passed: 186
Failed: 0
```
