### PR TITLE
shadow-core: remove duplicated lookups, fix login.defs radices, allocate around NSS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ jobs:
       # shadow-core's crypt(3) wrapper has musl-specific expectations (no
       # yescrypt, `rounds=` honoured). Run its unit tests against the static
       # musl libc, not only Alpine's dynamic one in the Docker matrix.
-      - run: cargo test --target x86_64-unknown-linux-musl -p shadow-core --features crypt,shadow,group,gshadow,login-defs,subid
+      - run: cargo test --target x86_64-unknown-linux-musl -p shadow-core --features crypt
       # `pam` must be refused on static musl, not silently produce a binary
       # whose authentication path can never work.
       - name: pam is rejected on static musl

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,31 +95,10 @@ newgrp = { optional = true, version = "0.2.2", package = "uu_newgrp", path = "sr
 default = ["passwd", "pwck", "useradd", "userdel", "usermod", "chpasswd", "chage",
            "groupadd", "groupdel", "groupmod", "grpck", "chfn", "chsh", "newgrp"]
 
-# Individual tools
-feat_passwd = ["passwd"]
-feat_pwck = ["pwck"]
-feat_useradd = ["useradd"]
-feat_userdel = ["userdel"]
-feat_usermod = ["usermod"]
-feat_chpasswd = ["chpasswd"]
-feat_chage = ["chage"]
-feat_groupadd = ["groupadd"]
-feat_groupdel = ["groupdel"]
-feat_groupmod = ["groupmod"]
-feat_grpck = ["grpck"]
-feat_chfn = ["chfn"]
-feat_chsh = ["chsh"]
-feat_newgrp = ["newgrp"]
-
-# Grouped features
-feat_phase1 = ["feat_passwd", "feat_pwck"]
-feat_phase2 = ["feat_useradd", "feat_userdel", "feat_usermod", "feat_chpasswd", "feat_chage"]
-feat_phase3 = ["feat_groupadd", "feat_groupdel", "feat_groupmod", "feat_grpck", "feat_chfn", "feat_chsh", "feat_newgrp"]
-feat_common = ["feat_phase1", "feat_phase2"]
-feat_common_core = ["feat_phase1", "feat_phase2", "feat_phase3"]
-
-# PAM authentication (requires libpam-dev)
-pam = ["passwd/pam", "chfn/pam", "chsh/pam"]
+# PAM authentication (requires libpam-dev). The `?` matters: without it,
+# asking for PAM would drag in the three applets that can use it even when the
+# build deliberately left them out.
+pam = ["passwd?/pam", "chfn?/pam", "chsh?/pam"]
 
 # Shell completions generator
 completions = ["dep:clap_complete"]
@@ -204,7 +183,7 @@ userdel = { version = "0.2.2", package = "uu_userdel", path = "src/uu/userdel" }
 usermod = { version = "0.2.2", package = "uu_usermod", path = "src/uu/usermod" }
 pwck = { version = "0.2.2", package = "uu_pwck", path = "src/uu/pwck" }
 grpck = { version = "0.2.2", package = "uu_grpck", path = "src/uu/grpck" }
-shadow-core = { path = "src/shadow-core", version = "0.2.2", features = ["shadow"] }
+shadow-core = { path = "src/shadow-core", version = "0.2.2" }
 rustix = { workspace = true }
 tempfile = { workspace = true }
 

--- a/docker/Dockerfile.e2e
+++ b/docker/Dockerfile.e2e
@@ -47,6 +47,7 @@ RUN chmod 4755 /usr/sbin/shadow-rs
 RUN apt-get update && apt-get install -y --no-install-recommends \
     expect \
     nscd \
+    rsyslog \
     ansible-core \
     python3-passlib \
     procps \

--- a/docs/SECURITY-HARDENING.md
+++ b/docs/SECURITY-HARDENING.md
@@ -109,6 +109,14 @@ Techniques adopted from OpenBSD and best practices for setuid-root tools.
       shadow file directly. Deliberately **not** applied around a PAM
       conversation: `restrict_self` sets `no_new_privs`, which strips the setgid
       bit from `unix_chkpwd` and blocks `dlopen` of the PAM modules
+- [x] UID and GID allocation asks the name service as well as the file, so an
+      ID belonging to an LDAP, SSSD or systemd-homed account is never handed
+      out locally — two accounts with one ID are indistinguishable to the
+      kernel. A `--prefix` run deliberately does not ask: those files describe
+      another system
+- [x] Audit records go straight to `/dev/log` instead of forking
+      `/usr/bin/logger` per event, so a setuid-root tool spawns one process
+      fewer and no longer depends on a binary at a fixed path
 - [x] `PAM_TTY` and `PAM_RUSER` are set on every PAM handle, so `pam_unix` and
       `pam_faillock` can record which terminal and which caller a failed
       authentication came from instead of logging `tty=?`
@@ -130,9 +138,10 @@ effective — sudo-rs uses this approach.
 
 ### Process environment
 
-`harden_process()` builds a sanitized environment for children but does not
-modify the process's own; in-process PAM and NSS modules still see the caller's
-environment. Tracked in #249.
+`harden_process()` does not modify the process's own environment: in-process
+PAM and NSS modules still see the caller's. It no longer *claims* to — it used
+to return a sanitized environment that all thirteen callers discarded. Children
+are given a clean environment where they are spawned. Tracked in #249.
 
 ## References
 

--- a/src/bin/shadow-rs.rs
+++ b/src/bin/shadow-rs.rs
@@ -32,6 +32,9 @@ const SETUID_APPLETS: [&str; 4] = ["passwd", "chfn", "chsh", "newgrp"];
 // `#[cfg]` is not accepted on the elements of a `vec![]` literal, so the
 // table is assembled push by push.
 #[allow(clippy::vec_init_then_push)]
+// A build that selects no applet at all -- `--no-default-features` -- pushes
+// nothing, and the binding is then not mutated.
+#[allow(unused_mut)]
 fn applets() -> Vec<(&'static str, Applet)> {
     let mut table: Vec<(&'static str, Applet)> = Vec::with_capacity(14);
     #[cfg(feature = "chage")]

--- a/src/shadow-core/Cargo.toml
+++ b/src/shadow-core/Cargo.toml
@@ -20,7 +20,7 @@ rustix = { workspace = true }
 thiserror = { workspace = true }
 uucore = { workspace = true }
 zeroize = { workspace = true }
-subtle = { workspace = true }
+subtle = { workspace = true, optional = true }
 landlock = { workspace = true, optional = true }
 
 [dev-dependencies]
@@ -29,13 +29,13 @@ tempfile = { workspace = true }
 
 [features]
 default = []
-crypt = []
+
+# Only the features that change what is linked are features. The record
+# parsers pull in no dependencies, so gating them bought nothing and cost
+# real confusion: `cargo test -p shadow-core` compiled a fraction of the
+# crate and reported a pass for it.
+crypt = ["dep:subtle"]
 pam = []
-shadow = []
-group = []
-gshadow = []
-login-defs = []
-subid = []
 landlock = ["dep:landlock"]
 
 [lints]

--- a/src/shadow-core/src/atomic.rs
+++ b/src/shadow-core/src/atomic.rs
@@ -231,12 +231,15 @@ fn copy_selinux_label(from: &File, to: &File) {
     }
 }
 
-/// Atomic counter for unique temp file names across threads.
+/// Counter distinguishing successive temp files in one process.
 static TMP_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 /// Generate a unique temporary file path in the same directory as the target.
 ///
-/// Uses PID + atomic counter to avoid collisions between threads.
+/// The PID separates concurrent invocations, and the counter separates
+/// successive writes within one of them: `usermod` rewrites four files in a
+/// row, and a name derived from the target alone would collide with a leftover
+/// from an earlier write in the same process.
 fn tmp_path_for(target: &Path) -> PathBuf {
     let file_name = target
         .file_name()

--- a/src/shadow-core/src/audit.rs
+++ b/src/shadow-core/src/audit.rs
@@ -2,47 +2,51 @@
 //
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
+// spell-checker:ignore auditd auditctl audisp
 
 //! Audit logging for shadow-rs tools.
 //!
-//! On systems with `auditd` running, shadow-utils operations (password
-//! changes, account creation/deletion, group changes) should be logged
-//! to the audit subsystem.
+//! Account operations -- creating and deleting users and groups, changing
+//! passwords and group membership -- are recorded so an administrator can see
+//! afterwards what changed and who changed it.
 //!
-//! This module provides a best-effort logging interface that silently
-//! succeeds when audit is not available.
+//! Everything here is best effort and silent on failure. A machine with no
+//! syslog and no `auditd` is a normal machine, and a failure to record an
+//! event must never stop the operation the caller asked for.
 //!
-//! **Implementation note**: This module currently shells out to `logger`
-//! rather than using native `libaudit` bindings. Native integration is
-//! planned for a future release.
+//! **Implementation note**: records go to syslog over `/dev/log` and, where
+//! `auditctl` is installed, to the audit subsystem through it. Native
+//! `libaudit` bindings would remove the second subprocess; they are not used
+//! yet because the netlink protocol needs its own careful handling in a
+//! setuid-root process.
 
-/// Log a user account event to the audit subsystem.
+use std::io::Write as _;
+use std::os::unix::net::UnixDatagram;
+
+/// The syslog socket every logging daemon on Linux listens on.
+const SYSLOG_SOCKET: &str = "/dev/log";
+
+/// syslog priority for `auth.info`: facility 4 (auth) times 8, plus severity 6.
+const AUTH_INFO: u8 = 4 * 8 + 6;
+
+/// Log a user account event to syslog and the audit subsystem.
 ///
 /// `event_type` should be one of: `ADD_USER`, `DEL_USER`, `MOD_USER`,
 /// `ADD_GROUP`, `DEL_GROUP`, `MOD_GROUP`, `CHNG_PASSWD`.
 ///
-/// Silently succeeds if auditd is not running or audit tools are not
-/// installed.
+/// Silently succeeds if neither syslog nor auditd is available.
 pub fn log_user_event(event_type: &str, username: &str, uid: u32, result: bool) {
     let success = if result { "success" } else { "failed" };
+    let terminal = crate::tty::name().unwrap_or_else(|| "?".to_string());
     let msg = format!(
-        "op={event_type} acct=\"{username}\" exe=\"shadow-rs\" \
-         hostname=? addr=? terminal=? res={success}"
+        "op={event_type} acct=\"{username}\" uid={uid} exe=\"shadow-rs\" \
+         terminal={terminal} res={success}"
     );
 
-    // Use /sbin/auditctl or write to /dev/audit if available.
-    // For now, use logger as a fallback to syslog.
-    let _ = std::process::Command::new("/usr/bin/logger")
-        .arg("-t")
-        .arg("shadow-rs")
-        .arg("-p")
-        .arg("auth.info")
-        .arg(&msg)
-        .env_clear()
-        .env("PATH", "/usr/bin:/bin:/usr/sbin:/sbin")
-        .status();
+    syslog(&msg);
 
-    // Also attempt to use ausearch-compatible format via audisp.
+    // auditd's own record, which ausearch can correlate. Only useful where
+    // auditctl is installed and the caller has CAP_AUDIT_WRITE.
     let _ = std::process::Command::new("/sbin/auditctl")
         .arg("-m")
         .arg(format!(
@@ -51,4 +55,48 @@ pub fn log_user_event(event_type: &str, username: &str, uid: u32, result: bool) 
         .env_clear()
         .env("PATH", "/usr/bin:/bin:/usr/sbin:/sbin")
         .status();
+}
+
+/// Send one line to the local syslog daemon.
+///
+/// Writing the datagram directly replaces forking `/usr/bin/logger` per event.
+/// A setuid-root tool should spawn as little as it can: the fork inherited the
+/// process state, depended on a binary being installed at a fixed path, and
+/// blocked the caller waiting for it, all to write a few dozen bytes to a
+/// socket.
+///
+/// The wire format is RFC 3164's: `<PRI>TAG[PID]: MESSAGE`, with no timestamp,
+/// which the daemon fills in itself.
+fn syslog(message: &str) {
+    let Ok(socket) = UnixDatagram::unbound() else {
+        return;
+    };
+    let mut line = Vec::with_capacity(message.len() + 32);
+    let _ = write!(
+        line,
+        "<{AUTH_INFO}>shadow-rs[{}]: {message}",
+        std::process::id()
+    );
+    // Unconnected send: no daemon, a full socket or a stream-mode /dev/log all
+    // fail here, and all of them are conditions to carry on through.
+    let _ = socket.send_to(&line, SYSLOG_SOCKET);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// auth.info is the priority shadow tools have always logged at, and the
+    /// number is what a syslog daemon parses, so it is worth pinning.
+    #[test]
+    fn test_auth_info_priority() {
+        assert_eq!(AUTH_INFO, 38);
+    }
+
+    /// A machine with no syslog daemon is a normal machine: recording an event
+    /// must never fail the operation that produced it.
+    #[test]
+    fn test_logging_without_a_daemon_is_silent() {
+        syslog("op=TEST acct=\"nobody\" res=success");
+    }
 }

--- a/src/shadow-core/src/error.rs
+++ b/src/shadow-core/src/error.rs
@@ -11,9 +11,6 @@ use std::path::PathBuf;
 
 use thiserror::Error;
 
-/// Result type alias used across all shadow-rs utilities.
-pub type ShadowResult<T> = Result<T, ShadowError>;
-
 /// Top-level error type for shadow-rs operations.
 #[derive(Debug, Error)]
 pub enum ShadowError {
@@ -35,9 +32,6 @@ pub enum ShadowError {
     /// Authentication error (PAM failure, wrong password, etc.).
     #[error("authentication error: {0}")]
     Auth(Cow<'static, str>),
-    /// Permission denied.
-    #[error("permission denied: {0}")]
-    Permission(Cow<'static, str>),
     /// Generic error with message.
     #[error("{0}")]
     Other(Cow<'static, str>),

--- a/src/shadow-core/src/hardening.rs
+++ b/src/shadow-core/src/hardening.rs
@@ -118,12 +118,17 @@ pub fn apply_landlock(
 
 /// Run all standard hardening steps for a setuid-root tool.
 ///
-/// Call at the top of `uumain` before any argument parsing.
-/// Returns the sanitized environment for use with child process spawning.
-pub fn harden_process() -> Vec<(String, String)> {
+/// Call at the top of `uumain`, before any argument parsing.
+///
+/// This does **not** touch the process's own environment, and the name should
+/// not be read as promising that: the in-process PAM and NSS modules still see
+/// what the caller set. It used to return a sanitized environment that every
+/// one of its thirteen callers threw away, which read as though the
+/// environment had been dealt with. Children are given a clean environment
+/// where they are spawned, by [`sanitized_env`].
+pub fn harden_process() {
     suppress_core_dumps();
     raise_file_size_limit();
-    sanitized_env()
 }
 
 // ---------------------------------------------------------------------------
@@ -146,19 +151,8 @@ pub fn current_username() -> Result<String, crate::error::ShadowError> {
 }
 
 /// Look up a username by UID via NSS (`getpwuid_r`).
-///
-/// Uses the system name-service switch, so it works with LDAP, SSSD,
-/// systemd-homed, and other backends — not just `/etc/passwd`.
 pub fn lookup_username_by_uid(uid: u32) -> Result<String, crate::error::ShadowError> {
-    match crate::process::lookup_username(uid) {
-        Ok(Some(name)) => Ok(name),
-        Ok(None) => Err(crate::error::ShadowError::Other(
-            format!("cannot determine username for uid {uid}").into(),
-        )),
-        Err(e) => Err(crate::error::ShadowError::Other(
-            format!("NSS lookup failed for uid {uid}: {e}").into(),
-        )),
-    }
+    lookup_passwd_entry_by_uid(uid).map(|e| e.name)
 }
 
 /// Look up a passwd entry by UID via NSS (`getpwuid_r`).
@@ -169,15 +163,7 @@ pub fn lookup_passwd_entry_by_uid(
     uid: u32,
 ) -> Result<crate::passwd::PasswdEntry, crate::error::ShadowError> {
     match crate::process::getpwuid(uid) {
-        Ok(Some(pw)) => Ok(crate::passwd::PasswdEntry {
-            name: pw.name,
-            passwd: pw.passwd,
-            uid: pw.uid,
-            gid: pw.gid,
-            gecos: pw.gecos,
-            home: pw.home,
-            shell: pw.shell,
-        }),
+        Ok(Some(entry)) => Ok(entry),
         Ok(None) => Err(crate::error::ShadowError::Other(
             format!("no passwd entry for uid {uid}").into(),
         )),

--- a/src/shadow-core/src/lib.rs
+++ b/src/shadow-core/src/lib.rs
@@ -8,29 +8,31 @@
 //! Provides file format parsers, atomic file operations, file locking,
 //! validation, and platform integration (PAM, `nscd`, `SELinux`, audit).
 
+// Record parsers and the helpers around them. None of these pulls in a
+// dependency, so none of them is behind a feature: gating them only made
+// `cargo test -p shadow-core` compile a fraction of the crate and report a
+// pass for it.
+pub mod atomic;
+pub mod audit;
 pub mod cli;
 pub mod date;
 pub mod error;
+pub mod group;
+pub mod gshadow;
+pub mod hardening;
+pub mod lock;
+pub mod login_defs;
+pub mod nscd;
 pub mod os_error;
 pub mod passwd;
 pub mod records;
-pub mod tty;
-pub mod validate;
-
-#[cfg(feature = "shadow")]
 pub mod shadow;
-
-#[cfg(feature = "group")]
-pub mod group;
-
-#[cfg(feature = "gshadow")]
-pub mod gshadow;
-
-#[cfg(feature = "login-defs")]
-pub mod login_defs;
-
-#[cfg(feature = "subid")]
+pub mod skel;
 pub mod subid;
+pub mod sysroot;
+pub mod tty;
+pub mod uid_alloc;
+pub mod validate;
 
 // PAM, crypt, and process are C library boundaries — FFI inherently
 // requires unsafe. These are the ONLY modules where unsafe_code is permitted.
@@ -45,14 +47,3 @@ pub mod crypt;
 // Process-level POSIX wrappers (setuid, sigprocmask, etc.) — FFI requires unsafe.
 #[allow(unsafe_code)]
 pub mod process;
-
-pub mod atomic;
-pub mod audit;
-pub mod hardening;
-pub mod lock;
-pub mod nscd;
-pub mod skel;
-pub mod sysroot;
-
-#[cfg(all(feature = "group", feature = "login-defs"))]
-pub mod uid_alloc;

--- a/src/shadow-core/src/login_defs.rs
+++ b/src/shadow-core/src/login_defs.rs
@@ -16,7 +16,11 @@ use std::path::Path;
 use crate::error::ShadowError;
 
 /// Parsed `/etc/login.defs` configuration.
-#[derive(Debug, Clone)]
+///
+/// `Default` is an empty configuration, which is what a caller wants when the
+/// file is missing or unreadable: every lookup then returns `None` and the
+/// tool falls back to its built-in default rather than failing.
+#[derive(Debug, Clone, Default)]
 pub struct LoginDefs {
     entries: HashMap<String, String>,
 }
@@ -68,9 +72,15 @@ impl LoginDefs {
     }
 
     /// Get a numeric value by key.
+    ///
+    /// login.defs(5) writes numbers "in decimal, or in octal with a leading
+    /// 0, or in hexadecimal with a leading 0x". Parsing decimal only is not a
+    /// rejection but a silent misreading: `UID_MIN 01000` means 512, and a
+    /// decimal parse turns it into 1000, handing out UIDs from a range the
+    /// administrator reserved.
     #[must_use]
     pub fn get_i64(&self, key: &str) -> Option<i64> {
-        self.entries.get(key).and_then(|v| v.parse().ok())
+        self.entries.get(key).and_then(|v| parse_number(v))
     }
 
     /// Insert or replace a configuration value for later `get` / `get_i64` calls.
@@ -101,6 +111,36 @@ impl LoginDefs {
 /// # Errors
 ///
 /// Returns [`ShadowError::Validation`] for a malformed pair.
+/// Parse a login.defs number: decimal, octal with a leading `0`, or
+/// hexadecimal with a leading `0x`, with an optional sign.
+///
+/// A bare `0` is zero, not an empty octal literal.
+fn parse_number(value: &str) -> Option<i64> {
+    let value = value.trim();
+    let (negative, digits) = match value.strip_prefix('-') {
+        Some(rest) => (true, rest),
+        None => (false, value.strip_prefix('+').unwrap_or(value)),
+    };
+
+    let (radix, digits) = if let Some(hex) = digits
+        .strip_prefix("0x")
+        .or_else(|| digits.strip_prefix("0X"))
+    {
+        (16, hex)
+    } else if digits.len() > 1 && digits.starts_with('0') {
+        (8, &digits[1..])
+    } else {
+        (10, digits)
+    };
+
+    let magnitude = i64::from_str_radix(digits, radix).ok()?;
+    if negative {
+        magnitude.checked_neg()
+    } else {
+        Some(magnitude)
+    }
+}
+
 pub fn parse_override(kv: &str) -> Result<(&str, &str), ShadowError> {
     match kv.split_once('=') {
         Some((key, value)) if !key.is_empty() => Ok((key, value)),
@@ -326,6 +366,39 @@ mod tests {
             let path = write_login_defs(dir.path(), &line);
             let defs = LoginDefs::load(&path).unwrap();
             prop_assert_eq!(defs.get(&key), Some(value.as_str()));
+        }
+    }
+
+    /// login.defs(5): numbers may be decimal, octal with a leading 0, or
+    /// hexadecimal with a leading 0x. Reading `UID_MIN 01000` as 1000 rather
+    /// than 512 hands out UIDs from a range the administrator reserved.
+    #[test]
+    fn test_get_i64_honours_octal_and_hex() {
+        let cases = [
+            ("1000", 1000),
+            ("01000", 512),
+            ("0x1000", 4096),
+            ("0X20", 32),
+            ("0", 0),
+            ("00", 0),
+            ("-5", -5),
+            ("-010", -8),
+            ("+7", 7),
+            ("  42  ", 42),
+        ];
+        for (text, expected) in cases {
+            let mut defs = LoginDefs::default();
+            defs.set("N", text);
+            assert_eq!(defs.get_i64("N"), Some(expected), "for {text:?}");
+        }
+    }
+
+    #[test]
+    fn test_get_i64_rejects_non_numbers() {
+        for text in ["", "abc", "0x", "09", "1.5", "12ab"] {
+            let mut defs = LoginDefs::default();
+            defs.set("N", text);
+            assert_eq!(defs.get_i64("N"), None, "for {text:?}");
         }
     }
 }

--- a/src/shadow-core/src/pam.rs
+++ b/src/shadow-core/src/pam.rs
@@ -298,12 +298,8 @@ extern "C" fn conversation(
         let result = match message.msg_style {
             msg_style::PAM_PROMPT_ECHO_OFF => prompt_for_input(message, false, conv_data.mode),
             msg_style::PAM_PROMPT_ECHO_ON => prompt_for_input(message, true, conv_data.mode),
-            msg_style::PAM_ERROR_MSG => {
-                display_message(message, true);
-                Ok(ptr::null_mut())
-            }
-            msg_style::PAM_TEXT_INFO => {
-                display_message(message, false);
+            msg_style::PAM_ERROR_MSG | msg_style::PAM_TEXT_INFO => {
+                display_message(message);
                 Ok(ptr::null_mut())
             }
             _ => {
@@ -336,10 +332,9 @@ extern "C" fn conversation(
 
 /// Display a PAM message to stderr.
 ///
-/// Both error and informational messages go to stderr (matching traditional
-/// PAM conversation behavior). The `_is_error` parameter is retained for
-/// future differentiation (e.g., prefixing error messages).
-fn display_message(message: &PamMessage, _is_error: bool) {
+/// Both error and informational messages go to stderr, which is what a
+/// traditional PAM conversation does; the two styles are not distinguished.
+fn display_message(message: &PamMessage) {
     if message.msg.is_null() {
         return;
     }
@@ -424,25 +419,6 @@ fn alloc_c_response(s: &str) -> Result<*mut libc::c_char, ()> {
     }
 
     Ok(buf)
-}
-
-/// The name of the controlling terminal, as PAM records it in `PAM_TTY`.
-///
-/// stdin, stdout and stderr are tried in turn: a tool invoked with its input
-/// redirected can still be attached to a terminal on one of the other two.
-/// `None` when none of them is a terminal.
-fn controlling_tty() -> Option<String> {
-    use std::os::fd::AsFd;
-
-    let stdin = std::io::stdin();
-    let stdout = std::io::stdout();
-    let stderr = std::io::stderr();
-    for fd in [stdin.as_fd(), stdout.as_fd(), stderr.as_fd()] {
-        if let Ok(name) = rustix::termios::ttyname(fd, Vec::new()) {
-            return name.into_string().ok();
-        }
-    }
-    None
 }
 
 /// Free partially-filled PAM responses on error.
@@ -580,7 +556,7 @@ impl PamContext {
     /// terminal (a cron job, a `su -c`) still has to be able to authenticate,
     /// so a failure here is not a failure to start.
     fn set_default_items(&mut self) {
-        if let Some(tty) = controlling_tty() {
+        if let Some(tty) = crate::tty::name() {
             let _ = self.set_item_str(item_type::PAM_TTY, &tty);
         }
         if let Ok(user) = crate::hardening::current_username() {

--- a/src/shadow-core/src/process.rs
+++ b/src/shadow-core/src/process.rs
@@ -2,7 +2,7 @@
 //
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
-// spell-checker:ignore setuid seteuid setgid initgroups sigprocmask getpwuid
+// spell-checker:ignore setuid seteuid setgid initgroups sigprocmask getpwuid getgrgid
 
 //! Process-level POSIX wrappers for setuid-root tools.
 //!
@@ -194,33 +194,18 @@ pub fn restore_signals(saved: &SavedSigSet) -> io::Result<()> {
 // NSS user lookup (getpwuid_r)
 // ---------------------------------------------------------------------------
 
-/// Result of an NSS user lookup via `getpwuid_r`.
-///
-/// Contains the fields from `struct passwd` that shadow-rs tools need.
-/// Unlike reading `/etc/passwd` directly, this goes through NSS and works
-/// with LDAP, SSSD, systemd-homed, and other name-service backends.
-pub struct PwEntry {
-    /// Login name.
-    pub name: String,
-    /// Encrypted password (usually `x`).
-    pub passwd: String,
-    /// Numeric user ID.
-    pub uid: u32,
-    /// Numeric primary group ID.
-    pub gid: u32,
-    /// GECOS / comment field.
-    pub gecos: String,
-    /// Home directory.
-    pub home: String,
-    /// Login shell.
-    pub shell: String,
-}
-
 /// Look up a user by UID via `getpwuid_r` (NSS-backed).
+///
+/// Unlike reading `/etc/passwd` directly, this goes through the name service
+/// switch and so sees LDAP, SSSD and systemd-homed accounts as well.
+///
+/// The result is a [`crate::passwd::PasswdEntry`], the same type the file
+/// parser produces: an NSS entry and a file entry describe the same account,
+/// and a second struct for it only bought a field-by-field copy at every call.
 ///
 /// Returns `None` if no user exists for the given UID.
 /// Returns `Err` on system errors (e.g., I/O failure in NSS backend).
-pub fn getpwuid(uid: u32) -> io::Result<Option<PwEntry>> {
+pub fn getpwuid(uid: u32) -> io::Result<Option<crate::passwd::PasswdEntry>> {
     // Start with a 1 KiB buffer; grow on ERANGE.
     const MAX_BUF: usize = 1024 * 1024;
     let mut buf_size: usize = 1024;
@@ -274,7 +259,7 @@ pub fn getpwuid(uid: u32) -> io::Result<Option<PwEntry>> {
                     CStr::from_ptr(ptr).to_string_lossy().into_owned()
                 }
             };
-            PwEntry {
+            crate::passwd::PasswdEntry {
                 name: str_field(pwd.pw_name),
                 passwd: str_field(pwd.pw_passwd),
                 uid: pwd.pw_uid,
@@ -289,11 +274,47 @@ pub fn getpwuid(uid: u32) -> io::Result<Option<PwEntry>> {
     }
 }
 
-/// Look up a username by UID via NSS (`getpwuid_r`).
+/// Whether NSS knows a group with this GID.
 ///
-/// Convenience wrapper that returns just the login name.
-pub fn lookup_username(uid: u32) -> io::Result<Option<String>> {
-    Ok(getpwuid(uid)?.map(|e| e.name))
+/// The companion to [`getpwuid`] for the allocator: only existence is asked
+/// for, so no entry is built and the caller needs no group type.
+pub fn gid_exists(gid: u32) -> io::Result<bool> {
+    const MAX_BUF: usize = 1024 * 1024;
+    let mut buf_size: usize = 1024;
+
+    loop {
+        let mut grp: libc::group = unsafe { std::mem::zeroed() };
+        let mut buf: Vec<u8> = vec![0u8; buf_size];
+        let mut result: *mut libc::group = std::ptr::null_mut();
+
+        // SAFETY: getgrgid_r is a POSIX thread-safe function. The buffer is
+        // sized by `buf_size` and the group struct is zeroed before the call.
+        let ret = unsafe {
+            libc::getgrgid_r(
+                gid,
+                &raw mut grp,
+                buf.as_mut_ptr().cast::<libc::c_char>(),
+                buf_size,
+                &raw mut result,
+            )
+        };
+
+        if ret == libc::ERANGE {
+            buf_size = buf_size.saturating_mul(2);
+            if buf_size > MAX_BUF {
+                return Err(io::Error::other(
+                    "getgrgid_r: ERANGE persists beyond 1 MiB buffer cap",
+                ));
+            }
+            continue;
+        }
+
+        if ret != 0 {
+            return Err(io::Error::from_raw_os_error(ret));
+        }
+
+        return Ok(!result.is_null());
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/src/shadow-core/src/sysroot.rs
+++ b/src/shadow-core/src/sysroot.rs
@@ -7,8 +7,15 @@
 //! System root path resolver for `--prefix` support.
 //!
 //! `--prefix DIR` prepends DIR to every file path the tool touches, without a
-//! `chroot` syscall. Tools that also offer `--root DIR` perform a real
-//! `chroot()` first and then resolve against `/`.
+//! `chroot` syscall.
+//!
+//! `--root DIR` is **not** uniform across the tools, and this resolver is
+//! where the difference shows. `chage`, `chfn`, `chpasswd`, `chsh` and
+//! `passwd` call `chroot()` first and then resolve against `/`, so an absolute
+//! path stored in a record resolves inside the new root. Every other tool
+//! passes `--root` here as a second spelling of `--prefix`, which prepends the
+//! directory to the files it opens and leaves absolute paths alone. Tracked in
+//! #270.
 
 use std::path::{Path, PathBuf};
 
@@ -27,6 +34,17 @@ impl SysRoot {
         Self {
             prefix: prefix.unwrap_or_else(|| Path::new("/")).to_owned(),
         }
+    }
+
+    /// Whether the tool was pointed at a tree other than `/`.
+    ///
+    /// Anything that describes *this* running system -- the name service, the
+    /// running kernel's idea of who exists -- says nothing about a prefixed
+    /// tree, so a caller that consults such a source must not when this is
+    /// true. See `uid_alloc::Scope`.
+    #[must_use]
+    pub fn is_prefixed(&self) -> bool {
+        self.prefix != Path::new("/")
     }
 
     /// Resolve a path relative to the prefix.

--- a/src/shadow-core/src/tty.rs
+++ b/src/shadow-core/src/tty.rs
@@ -41,20 +41,10 @@ pub fn prompt_line(prompt: &str) -> io::Result<String> {
 /// Returns the underlying I/O error if neither the terminal nor stdin can be
 /// read.
 pub fn read_password(prompt: &str) -> io::Result<Zeroizing<String>> {
-    let _signals = crate::process::block_critical_signals()
-        .map(SignalRestore)
-        .ok();
-    let line = read_line(prompt, false)?;
-    Ok(line)
-}
-
-/// Restores the signal mask saved before a password read.
-struct SignalRestore(crate::process::SavedSigSet);
-
-impl Drop for SignalRestore {
-    fn drop(&mut self) {
-        let _ = crate::process::restore_signals(&self.0);
-    }
+    // Best effort: a process that cannot change its signal mask must still be
+    // able to read a password.
+    let _signals = crate::hardening::SignalBlocker::block_critical().ok();
+    read_line(prompt, false)
 }
 
 /// Read one line from stdin with no prompt, for non-interactive input.
@@ -165,4 +155,25 @@ impl Drop for EchoGuard<'_> {
             &self.original,
         );
     }
+}
+
+/// The name of the controlling terminal, for the records that want one.
+///
+/// stdin, stdout and stderr are tried in turn: a tool with its input
+/// redirected can still be attached to a terminal on one of the other two.
+/// `None` when none of them is a terminal, which is the normal answer under
+/// `cron` or a systemd unit.
+#[must_use]
+pub fn name() -> Option<String> {
+    use std::os::fd::AsFd;
+
+    let stdin = io::stdin();
+    let stdout = io::stdout();
+    let stderr = io::stderr();
+    for fd in [stdin.as_fd(), stdout.as_fd(), stderr.as_fd()] {
+        if let Ok(name) = rustix::termios::ttyname(fd, Vec::new()) {
+            return name.into_string().ok();
+        }
+    }
+    None
 }

--- a/src/shadow-core/src/uid_alloc.rs
+++ b/src/shadow-core/src/uid_alloc.rs
@@ -21,31 +21,73 @@ use crate::group::GroupEntry;
 use crate::login_defs::LoginDefs;
 use crate::passwd::PasswdEntry;
 
+/// Which sources an allocation must avoid colliding with.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Scope {
+    /// The account files given, and the local name service as well.
+    ///
+    /// `/etc/passwd` is not the only source of accounts. An ID that is free in
+    /// the file may belong to an LDAP, SSSD or systemd-homed account, and
+    /// handing it out gives two accounts one ID -- which the kernel cannot
+    /// tell apart, so the new local user ends up owning the directory user's
+    /// files.
+    IncludingNameService,
+    /// The account files given, and nothing else.
+    ///
+    /// What a `--prefix` or `--root` run needs: those files belong to another
+    /// system, and the name service running here describes this one. Asking it
+    /// would skip IDs that are free on the target and claim none that are
+    /// taken there.
+    FilesOnly,
+}
+
+impl Scope {
+    /// The scope implied by whether the tool was pointed at another root.
+    #[must_use]
+    pub fn for_prefix(prefixed: bool) -> Self {
+        if prefixed {
+            Self::FilesOnly
+        } else {
+            Self::IncludingNameService
+        }
+    }
+}
+
 /// Find the next available UID in the given range.
-///
-/// Scans `existing` entries and returns the lowest UID in `[min, max]`
-/// that is not already in use.
 ///
 /// # Errors
 ///
 /// Returns `ShadowError::Other` if every UID in the range is taken.
-pub fn next_uid(existing: &[PasswdEntry], min: u32, max: u32) -> Result<u32, ShadowError> {
+pub fn next_uid(
+    existing: &[PasswdEntry],
+    min: u32,
+    max: u32,
+    scope: Scope,
+) -> Result<u32, ShadowError> {
     let used: HashSet<u32> = existing.iter().map(|e| e.uid).collect();
-    next_free(&used, min, max)
+    let taken = |uid: u32| {
+        scope == Scope::IncludingNameService && matches!(crate::process::getpwuid(uid), Ok(Some(_)))
+    };
+    next_free_checked(&used, min, max, &taken)
         .ok_or_else(|| ShadowError::Other(format!("no available UID in range {min}-{max}").into()))
 }
 
 /// Find the next available GID in the given range.
 ///
-/// Scans `existing` entries and returns the lowest GID in `[min, max]`
-/// that is not already in use.
-///
 /// # Errors
 ///
 /// Returns `ShadowError::Other` if every GID in the range is taken.
-pub fn next_gid(existing: &[GroupEntry], min: u32, max: u32) -> Result<u32, ShadowError> {
+pub fn next_gid(
+    existing: &[GroupEntry],
+    min: u32,
+    max: u32,
+    scope: Scope,
+) -> Result<u32, ShadowError> {
     let used: HashSet<u32> = existing.iter().map(|e| e.gid).collect();
-    next_free(&used, min, max)
+    let taken = |gid: u32| {
+        scope == Scope::IncludingNameService && matches!(crate::process::gid_exists(gid), Ok(true))
+    };
+    next_free_checked(&used, min, max, &taken)
         .ok_or_else(|| ShadowError::Other(format!("no available GID in range {min}-{max}").into()))
 }
 
@@ -71,9 +113,51 @@ fn next_free(used: &HashSet<u32>, min: u32, max: u32) -> Option<u32> {
     (min..=max).find(|id| !used.contains(id))
 }
 
+/// [`next_free`], skipping any ID the system knows about beyond the local file.
+///
+/// `/etc/passwd` is not the only source of accounts. An ID that is free in the
+/// file may belong to a directory account, and handing it out gives two
+/// accounts one ID -- which the kernel cannot tell apart, so the new local user
+/// owns the directory user's files. `taken` asks NSS, which sees every
+/// configured backend.
+///
+/// Each rejected candidate is recorded, so the search advances and terminates
+/// even when the whole range is claimed elsewhere.
+fn next_free_checked(
+    used: &HashSet<u32>,
+    min: u32,
+    max: u32,
+    taken: &dyn Fn(u32) -> bool,
+) -> Option<u32> {
+    let mut used = used.clone();
+    loop {
+        let candidate = next_free(&used, min, max)?;
+        if !taken(candidate) {
+            return Some(candidate);
+        }
+        used.insert(candidate);
+    }
+}
+
 /// Read a `login.defs` key as `u32`, ignoring negative or overflowing values.
 fn get_u32(defs: &LoginDefs, key: &str) -> Option<u32> {
     defs.get_i64(key).and_then(|v| u32::try_from(v).ok())
+}
+
+/// The allocation range for one ID kind, from `login.defs`.
+///
+/// `kind` is `UID` or `GID`; the system ranges use the same keys with a `SYS_`
+/// prefix. The two kinds share their defaults, which is why one function
+/// serves both: regular accounts 1000-60000, system accounts 101-999.
+fn id_range(defs: &LoginDefs, kind: &str, system: bool) -> (u32, u32) {
+    let (prefix, (default_min, default_max)) = if system {
+        ("SYS_", (101, 999))
+    } else {
+        ("", (1000, 60000))
+    };
+    let min = get_u32(defs, &format!("{prefix}{kind}_MIN")).unwrap_or(default_min);
+    let max = get_u32(defs, &format!("{prefix}{kind}_MAX")).unwrap_or(default_max);
+    (min, max)
 }
 
 /// Get the UID allocation range from `login.defs`.
@@ -83,15 +167,7 @@ fn get_u32(defs: &LoginDefs, key: &str) -> Option<u32> {
 /// `UID_MAX` (defaults 1000 / 60000).
 #[must_use]
 pub fn uid_range(defs: &LoginDefs, system: bool) -> (u32, u32) {
-    if system {
-        let min = get_u32(defs, "SYS_UID_MIN").unwrap_or(101);
-        let max = get_u32(defs, "SYS_UID_MAX").unwrap_or(999);
-        (min, max)
-    } else {
-        let min = get_u32(defs, "UID_MIN").unwrap_or(1000);
-        let max = get_u32(defs, "UID_MAX").unwrap_or(60000);
-        (min, max)
-    }
+    id_range(defs, "UID", system)
 }
 
 /// Get the GID allocation range from `login.defs`.
@@ -101,15 +177,7 @@ pub fn uid_range(defs: &LoginDefs, system: bool) -> (u32, u32) {
 /// `GID_MAX` (defaults 1000 / 60000).
 #[must_use]
 pub fn gid_range(defs: &LoginDefs, system: bool) -> (u32, u32) {
-    if system {
-        let min = get_u32(defs, "SYS_GID_MIN").unwrap_or(101);
-        let max = get_u32(defs, "SYS_GID_MAX").unwrap_or(999);
-        (min, max)
-    } else {
-        let min = get_u32(defs, "GID_MIN").unwrap_or(1000);
-        let max = get_u32(defs, "GID_MAX").unwrap_or(60000);
-        (min, max)
-    }
+    id_range(defs, "GID", system)
 }
 
 #[cfg(test)]
@@ -142,85 +210,103 @@ mod tests {
             .collect()
     }
 
-    // --- next_uid ---
+    // --- allocation policy ---
+    //
+    // The policy is exercised through `next_free`, which takes the set of used
+    // IDs directly. `next_uid` and `next_gid` also consult NSS, so a test that
+    // called them would depend on which accounts happen to exist on the
+    // machine running it -- and on a typical container, 1000 and 1001 do.
+
+    fn used_uids(uids: &[u32]) -> HashSet<u32> {
+        make_passwd_entries(uids).iter().map(|e| e.uid).collect()
+    }
+
+    fn used_gids(gids: &[u32]) -> HashSet<u32> {
+        make_group_entries(gids).iter().map(|e| e.gid).collect()
+    }
 
     #[test]
-    fn test_next_uid_empty() {
-        let entries: Vec<PasswdEntry> = vec![];
-        assert_eq!(next_uid(&entries, 1000, 1005).unwrap(), 1000);
+    fn test_next_free_empty_range_starts_at_the_minimum() {
+        assert_eq!(next_free(&HashSet::new(), 1000, 1005), Some(1000));
     }
 
     // Not the gap at 1002: reusing a deleted account's UID would hand the new
     // user its leftover files. shadow-utils allocates past the highest in use.
     #[test]
-    fn test_next_uid_goes_past_the_highest_in_use() {
-        let entries = make_passwd_entries(&[1000, 1001, 1003]);
-        assert_eq!(next_uid(&entries, 1000, 1005).unwrap(), 1004);
+    fn test_next_free_goes_past_the_highest_in_use() {
+        assert_eq!(
+            next_free(&used_uids(&[1000, 1001, 1003]), 1000, 1005),
+            Some(1004)
+        );
     }
 
     // Only once the top of the range is taken does it fall back to a gap.
     #[test]
-    fn test_next_uid_falls_back_to_a_gap_when_the_range_top_is_used() {
-        let entries = make_passwd_entries(&[1000, 1001, 1003, 1004, 1005]);
-        assert_eq!(next_uid(&entries, 1000, 1005).unwrap(), 1002);
+    fn test_next_free_falls_back_to_a_gap_when_the_range_top_is_used() {
+        assert_eq!(
+            next_free(&used_uids(&[1000, 1001, 1003, 1004, 1005]), 1000, 1005),
+            Some(1002)
+        );
     }
 
     // IDs outside the range must not push the allocation past the maximum.
     #[test]
-    fn test_next_uid_ignores_ids_outside_the_range() {
-        let entries = make_passwd_entries(&[0, 65534, 1000]);
-        assert_eq!(next_uid(&entries, 1000, 1005).unwrap(), 1001);
+    fn test_next_free_ignores_ids_outside_the_range() {
+        assert_eq!(
+            next_free(&used_uids(&[0, 65534, 1000]), 1000, 1005),
+            Some(1001)
+        );
     }
 
     #[test]
-    fn test_next_uid_skips_used_start() {
+    fn test_next_free_exhausted_range() {
+        assert_eq!(next_free(&used_uids(&[100, 101, 102]), 100, 102), None);
+        assert_eq!(next_free(&used_uids(&[500]), 500, 500), None);
+    }
+
+    #[test]
+    fn test_next_free_single_value_range() {
+        assert_eq!(next_free(&HashSet::new(), 500, 500), Some(500));
+    }
+
+    #[test]
+    fn test_next_free_applies_to_gids_the_same_way() {
+        assert_eq!(next_free(&used_gids(&[1000, 1002]), 1000, 1005), Some(1003));
+        assert_eq!(
+            next_free(&used_gids(&[1000, 1002, 1003, 1004, 1005]), 1000, 1005),
+            Some(1001)
+        );
+        assert_eq!(next_free(&used_gids(&[10, 11, 12]), 10, 12), None);
+    }
+
+    // --- allocation against the live system ---
+
+    /// Whatever the machine looks like, an allocated ID must be inside the
+    /// range, absent from the entries given, and unknown to NSS.
+    #[test]
+    fn test_next_uid_returns_an_id_nobody_holds() {
         let entries = make_passwd_entries(&[1000]);
-        assert_eq!(next_uid(&entries, 1000, 1005).unwrap(), 1001);
+        let (min, max) = (60_100, 60_200);
+        let uid = next_uid(&entries, min, max, Scope::IncludingNameService)
+            .expect("a free UID in an unused range");
+        assert!((min..=max).contains(&uid));
+        assert!(
+            matches!(crate::process::getpwuid(uid), Ok(None)),
+            "allocated UID {uid} is already known to NSS"
+        );
     }
 
     #[test]
-    fn test_next_uid_exhausted() {
-        let entries = make_passwd_entries(&[100, 101, 102]);
-        let result = next_uid(&entries, 100, 102);
-        assert!(result.is_err());
-    }
-
-    #[test]
-    fn test_next_uid_single_value_range() {
-        let entries: Vec<PasswdEntry> = vec![];
-        assert_eq!(next_uid(&entries, 500, 500).unwrap(), 500);
-    }
-
-    #[test]
-    fn test_next_uid_single_value_range_taken() {
-        let entries = make_passwd_entries(&[500]);
-        assert!(next_uid(&entries, 500, 500).is_err());
-    }
-
-    // --- next_gid ---
-
-    #[test]
-    fn test_next_gid_empty() {
-        let entries: Vec<GroupEntry> = vec![];
-        assert_eq!(next_gid(&entries, 1000, 1005).unwrap(), 1000);
-    }
-
-    #[test]
-    fn test_next_gid_goes_past_the_highest_in_use() {
-        let entries = make_group_entries(&[1000, 1002]);
-        assert_eq!(next_gid(&entries, 1000, 1005).unwrap(), 1003);
-    }
-
-    #[test]
-    fn test_next_gid_falls_back_to_a_gap_when_the_range_top_is_used() {
-        let entries = make_group_entries(&[1000, 1002, 1003, 1004, 1005]);
-        assert_eq!(next_gid(&entries, 1000, 1005).unwrap(), 1001);
-    }
-
-    #[test]
-    fn test_next_gid_exhausted() {
-        let entries = make_group_entries(&[10, 11, 12]);
-        assert!(next_gid(&entries, 10, 12).is_err());
+    fn test_next_gid_returns_an_id_nobody_holds() {
+        let entries = make_group_entries(&[1000]);
+        let (min, max) = (60_100, 60_200);
+        let gid = next_gid(&entries, min, max, Scope::IncludingNameService)
+            .expect("a free GID in an unused range");
+        assert!((min..=max).contains(&gid));
+        assert!(
+            matches!(crate::process::gid_exists(gid), Ok(false)),
+            "allocated GID {gid} is already known to NSS"
+        );
     }
 
     // --- uid_range ---
@@ -285,5 +371,50 @@ mod tests {
         std::fs::write(&path, "SYS_GID_MIN 200\nSYS_GID_MAX 499\n").unwrap();
         let defs = LoginDefs::load(&path).unwrap();
         assert_eq!(gid_range(&defs, true), (200, 499));
+    }
+
+    // --- NSS-aware allocation ---
+
+    /// A UID absent from /etc/passwd may still belong to a directory account.
+    /// Handing it out would give two accounts one ID, and the kernel cannot
+    /// tell them apart: the new local user would own the other one's files.
+    #[test]
+    fn test_allocation_skips_ids_nss_already_knows() {
+        let used: HashSet<u32> = [1000].into_iter().collect();
+        // 1001 and 1002 exist in a directory but not in the local file.
+        let directory = |id: u32| id == 1001 || id == 1002;
+        assert_eq!(next_free_checked(&used, 1000, 1005, &directory), Some(1003));
+    }
+
+    #[test]
+    fn test_allocation_fails_when_the_directory_claims_the_range() {
+        let used: HashSet<u32> = HashSet::new();
+        assert_eq!(next_free_checked(&used, 1000, 1002, &|_| true), None);
+    }
+
+    #[test]
+    fn test_allocation_without_a_directory_matches_the_plain_policy() {
+        let used: HashSet<u32> = [1000, 1001, 1003].into_iter().collect();
+        assert_eq!(
+            next_free_checked(&used, 1000, 1005, &|_| false),
+            next_free(&used, 1000, 1005)
+        );
+    }
+
+    /// A prefixed run must not consult the name service: those files describe
+    /// another system, and this one's accounts say nothing about it.
+    #[test]
+    fn test_files_only_scope_ignores_the_name_service() {
+        // uid 0 exists in NSS on any system, so IncludingNameService would
+        // have to skip it while FilesOnly hands it out.
+        let entries = make_passwd_entries(&[]);
+        assert_eq!(next_uid(&entries, 0, 0, Scope::FilesOnly).expect("uid"), 0);
+        assert!(next_uid(&entries, 0, 0, Scope::IncludingNameService).is_err());
+    }
+
+    #[test]
+    fn test_scope_for_prefix() {
+        assert_eq!(Scope::for_prefix(true), Scope::FilesOnly);
+        assert_eq!(Scope::for_prefix(false), Scope::IncludingNameService);
     }
 }

--- a/src/uu/chage/Cargo.toml
+++ b/src/uu/chage/Cargo.toml
@@ -20,7 +20,7 @@ path = "src/main.rs"
 [dependencies]
 clap = { workspace = true }
 rustix = { workspace = true }
-shadow-core = { workspace = true, features = ["shadow"] }
+shadow-core = { workspace = true }
 uucore = { workspace = true }
 
 [dev-dependencies]

--- a/src/uu/chage/src/chage.rs
+++ b/src/uu/chage/src/chage.rs
@@ -134,7 +134,7 @@ fn parse_date_arg(input: &str) -> Result<i64, String> {
 /// Entry point for the `chage` utility.
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let _clean_env = shadow_core::hardening::harden_process();
+    shadow_core::hardening::harden_process();
 
     let Some(matches) = shadow_core::cli::parse_args(uu_app(), args, |_| 2)? else {
         return Ok(());

--- a/src/uu/chfn/Cargo.toml
+++ b/src/uu/chfn/Cargo.toml
@@ -20,7 +20,7 @@ path = "src/main.rs"
 [dependencies]
 clap = { workspace = true }
 rustix = { workspace = true }
-shadow-core = { workspace = true, features = ["login-defs"] }
+shadow-core = { workspace = true }
 uucore = { workspace = true }
 
 [features]

--- a/src/uu/chfn/src/chfn.rs
+++ b/src/uu/chfn/src/chfn.rs
@@ -402,7 +402,7 @@ where
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let _clean_env = shadow_core::hardening::harden_process();
+    shadow_core::hardening::harden_process();
 
     let Some(matches) = shadow_core::cli::parse_args(uu_app(), args, |_| 1)? else {
         return Ok(());

--- a/src/uu/chpasswd/Cargo.toml
+++ b/src/uu/chpasswd/Cargo.toml
@@ -20,7 +20,7 @@ path = "src/main.rs"
 [dependencies]
 clap = { workspace = true }
 rustix = { workspace = true }
-shadow-core = { workspace = true, features = ["shadow", "crypt", "login-defs"] }
+shadow-core = { workspace = true, features = ["crypt"] }
 uucore = { workspace = true }
 zeroize = { workspace = true }
 

--- a/src/uu/chpasswd/src/chpasswd.rs
+++ b/src/uu/chpasswd/src/chpasswd.rs
@@ -188,7 +188,7 @@ fn days_since_epoch() -> Result<i64, ChpasswdError> {
 /// Entry point for the `chpasswd` utility.
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let _clean_env = shadow_core::hardening::harden_process();
+    shadow_core::hardening::harden_process();
 
     // chpasswd(8) exits 2 for invalid command syntax; every other failure is 1.
     let Some(matches) = shadow_core::cli::parse_args(uu_app(), args, |_| 2)? else {

--- a/src/uu/chsh/src/chsh.rs
+++ b/src/uu/chsh/src/chsh.rs
@@ -290,7 +290,7 @@ where
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let _clean_env = shadow_core::hardening::harden_process();
+    shadow_core::hardening::harden_process();
 
     let Some(matches) = shadow_core::cli::parse_args(uu_app(), args, |_| 1)? else {
         return Ok(());

--- a/src/uu/groupadd/Cargo.toml
+++ b/src/uu/groupadd/Cargo.toml
@@ -20,7 +20,7 @@ path = "src/main.rs"
 [dependencies]
 clap = { workspace = true }
 rustix = { workspace = true }
-shadow-core = { workspace = true, features = ["shadow", "group", "gshadow", "login-defs"] }
+shadow-core = { workspace = true }
 uucore = { workspace = true }
 
 [dev-dependencies]

--- a/src/uu/groupadd/src/groupadd.rs
+++ b/src/uu/groupadd/src/groupadd.rs
@@ -93,7 +93,7 @@ impl UError for GroupaddError {
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let _clean_env = shadow_core::hardening::harden_process();
+    shadow_core::hardening::harden_process();
 
     let Some(matches) = shadow_core::cli::parse_args(uu_app(), args, |_| exit_codes::BAD_SYNTAX)?
     else {
@@ -193,7 +193,18 @@ fn do_groupadd(matches: &clap::ArgMatches) -> UResult<()> {
     }
 
     // Determine GID.
-    let gid = determine_gid(matches, &existing_groups, force, non_unique, system, &defs)?;
+    // A prefixed run manages another system's files, so the local name
+    // service is not consulted for it.
+    let scope = uid_alloc::Scope::for_prefix(root.is_prefixed());
+    let gid = determine_gid(
+        matches,
+        &existing_groups,
+        force,
+        non_unique,
+        system,
+        &defs,
+        scope,
+    )?;
 
     // Write to /etc/group.
     write_group_entry(
@@ -224,6 +235,7 @@ fn determine_gid(
     non_unique: bool,
     system: bool,
     defs: &LoginDefs,
+    scope: uid_alloc::Scope,
 ) -> Result<u32, GroupaddError> {
     let explicit_gid = matches.get_one::<String>(options::GID);
 
@@ -234,7 +246,7 @@ fn determine_gid(
 
         if !non_unique && existing_groups.iter().any(|g| g.gid == gid) {
             if force {
-                allocate_gid(defs, existing_groups, system)
+                allocate_gid(defs, existing_groups, system, scope)
             } else {
                 Err(GroupaddError::GidInUse(format!(
                     "GID '{gid}' already exists"
@@ -244,7 +256,7 @@ fn determine_gid(
             Ok(gid)
         }
     } else {
-        allocate_gid(defs, existing_groups, system)
+        allocate_gid(defs, existing_groups, system, scope)
     }
 }
 
@@ -318,10 +330,11 @@ fn allocate_gid(
     defs: &LoginDefs,
     existing: &[GroupEntry],
     system: bool,
+    scope: uid_alloc::Scope,
 ) -> Result<u32, GroupaddError> {
     // -K overrides were already merged into `defs` by the caller.
     let (min, max) = uid_alloc::gid_range(defs, system);
-    uid_alloc::next_gid(existing, min, max)
+    uid_alloc::next_gid(existing, min, max, scope)
         .map_err(|e| GroupaddError::BadArgument(format!("cannot allocate GID: {e}")))
 }
 

--- a/src/uu/groupdel/Cargo.toml
+++ b/src/uu/groupdel/Cargo.toml
@@ -20,7 +20,7 @@ path = "src/main.rs"
 [dependencies]
 clap = { workspace = true }
 rustix = { workspace = true }
-shadow-core = { workspace = true, features = ["shadow", "group", "gshadow", "login-defs"] }
+shadow-core = { workspace = true }
 uucore = { workspace = true }
 
 [dev-dependencies]

--- a/src/uu/groupdel/src/groupdel.rs
+++ b/src/uu/groupdel/src/groupdel.rs
@@ -81,7 +81,7 @@ impl UError for GroupdelError {
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let _clean_env = shadow_core::hardening::harden_process();
+    shadow_core::hardening::harden_process();
 
     let Some(matches) = shadow_core::cli::parse_args(uu_app(), args, |_| exit_codes::BAD_SYNTAX)?
     else {

--- a/src/uu/groupmod/Cargo.toml
+++ b/src/uu/groupmod/Cargo.toml
@@ -20,7 +20,7 @@ path = "src/main.rs"
 [dependencies]
 clap = { workspace = true }
 rustix = { workspace = true }
-shadow-core = { workspace = true, features = ["shadow", "group", "gshadow", "login-defs"] }
+shadow-core = { workspace = true }
 uucore = { workspace = true }
 
 [dev-dependencies]

--- a/src/uu/groupmod/src/groupmod.rs
+++ b/src/uu/groupmod/src/groupmod.rs
@@ -95,7 +95,7 @@ impl UError for GroupmodError {
 #[uucore::main]
 #[allow(clippy::too_many_lines)]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let _clean_env = shadow_core::hardening::harden_process();
+    shadow_core::hardening::harden_process();
 
     let Some(matches) = shadow_core::cli::parse_args(uu_app(), args, |_| exit_codes::BAD_SYNTAX)?
     else {

--- a/src/uu/grpck/Cargo.toml
+++ b/src/uu/grpck/Cargo.toml
@@ -19,7 +19,7 @@ path = "src/main.rs"
 
 [dependencies]
 clap = { workspace = true }
-shadow-core = { workspace = true, features = ["shadow", "group", "gshadow", "login-defs"] }
+shadow-core = { workspace = true }
 uucore = { workspace = true }
 
 [dev-dependencies]

--- a/src/uu/grpck/src/grpck.rs
+++ b/src/uu/grpck/src/grpck.rs
@@ -122,7 +122,7 @@ impl GrpckOptions {
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let _ = shadow_core::hardening::harden_process();
+    shadow_core::hardening::harden_process();
 
     let matches = uu_app().try_get_matches_from(args)?;
     let opts = GrpckOptions::from_matches(&matches);

--- a/src/uu/newgrp/Cargo.toml
+++ b/src/uu/newgrp/Cargo.toml
@@ -21,7 +21,7 @@ path = "src/main.rs"
 clap = { workspace = true }
 rustix = { workspace = true }
 zeroize = { workspace = true }
-shadow-core = { workspace = true, features = ["group", "gshadow", "crypt"] }
+shadow-core = { workspace = true, features = ["crypt"] }
 uucore = { workspace = true }
 
 [dev-dependencies]

--- a/src/uu/passwd/Cargo.toml
+++ b/src/uu/passwd/Cargo.toml
@@ -20,7 +20,7 @@ path = "src/main.rs"
 [dependencies]
 clap = { workspace = true }
 rustix = { workspace = true }
-shadow-core = { workspace = true, features = ["shadow", "login-defs", "landlock"] }
+shadow-core = { workspace = true, features = ["landlock"] }
 uucore = { workspace = true }
 
 [features]

--- a/src/uu/passwd/src/passwd.rs
+++ b/src/uu/passwd/src/passwd.rs
@@ -171,7 +171,7 @@ fn apply_landlock(root: &SysRoot) {
 #[uucore::main]
 #[allow(clippy::too_many_lines)]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let _clean_env = shadow_core::hardening::harden_process();
+    shadow_core::hardening::harden_process();
 
     // GNU passwd exits 2 for conflicting options, 6 for unknown/invalid.
     let Some(matches) = shadow_core::cli::parse_args(uu_app(), args, |e| match e.kind() {

--- a/src/uu/pwck/Cargo.toml
+++ b/src/uu/pwck/Cargo.toml
@@ -19,7 +19,7 @@ path = "src/main.rs"
 
 [dependencies]
 clap = { workspace = true }
-shadow-core = { workspace = true, features = ["shadow", "group", "login-defs"] }
+shadow-core = { workspace = true }
 uucore = { workspace = true }
 
 [dev-dependencies]

--- a/src/uu/pwck/src/pwck.rs
+++ b/src/uu/pwck/src/pwck.rs
@@ -141,7 +141,7 @@ impl PwckOptions {
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let _ = shadow_core::hardening::harden_process();
+    shadow_core::hardening::harden_process();
 
     let matches = uu_app().try_get_matches_from(args)?;
     let opts = PwckOptions::from_matches(&matches);

--- a/src/uu/useradd/Cargo.toml
+++ b/src/uu/useradd/Cargo.toml
@@ -20,7 +20,7 @@ path = "src/main.rs"
 [dependencies]
 clap = { workspace = true }
 rustix = { workspace = true }
-shadow-core = { workspace = true, features = ["shadow", "group", "gshadow", "login-defs", "subid"] }
+shadow-core = { workspace = true }
 uucore = { workspace = true }
 
 [dev-dependencies]

--- a/src/uu/useradd/src/useradd.rs
+++ b/src/uu/useradd/src/useradd.rs
@@ -197,7 +197,7 @@ fn today_days_since_epoch() -> Result<i64, UseraddError> {
 /// Entry point for the `useradd` utility.
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let _clean_env = shadow_core::hardening::harden_process();
+    shadow_core::hardening::harden_process();
 
     let Some(matches) = shadow_core::cli::parse_args(uu_app(), args, |_| 2)? else {
         return Ok(());
@@ -579,8 +579,10 @@ fn do_useradd(opts: &UseraddOptions) -> UResult<()> {
         .map_err(|e| UseraddError::CannotUpdatePasswd(format!("{e}")))?;
     apply_login_defs_overrides(&mut defs, &opts.login_defs_overrides);
 
-    // Step 5: Determine UID.
-    let uid = determine_uid(opts, &passwd_entries, &defs)?;
+    // Step 5: Determine UID. A prefixed run manages another system's files, so
+    // the local name service is not consulted for it.
+    let scope = uid_alloc::Scope::for_prefix(opts.root.is_prefixed());
+    let uid = determine_uid(opts, &passwd_entries, &defs, scope)?;
 
     // Step 6: Read group entries under lock (needed for GID resolution and
     // user group creation).
@@ -588,7 +590,7 @@ fn do_useradd(opts: &UseraddOptions) -> UResult<()> {
         .map_err(|e| UseraddError::CannotUpdateGroup(format!("{e}")))?;
 
     // Step 7: Determine primary GID.
-    let (gid, new_group) = determine_gid(opts, uid, &group_entries, &defs)?;
+    let (gid, new_group) = determine_gid(opts, uid, &group_entries, &defs, scope)?;
 
     // Step 8: Read gshadow entries.
     let gshadow_path = opts.root.gshadow_path();
@@ -781,6 +783,7 @@ fn determine_uid(
     opts: &UseraddOptions,
     passwd_entries: &[PasswdEntry],
     defs: &LoginDefs,
+    scope: uid_alloc::Scope,
 ) -> Result<u32, UseraddError> {
     if let Some(requested_uid) = opts.uid {
         // Check if UID is already in use.
@@ -792,7 +795,7 @@ fn determine_uid(
         Ok(requested_uid)
     } else {
         let (min, max) = uid_alloc::uid_range(defs, opts.system);
-        uid_alloc::next_uid(passwd_entries, min, max)
+        uid_alloc::next_uid(passwd_entries, min, max, scope)
             .map_err(|e| UseraddError::CannotUpdatePasswd(format!("{e}")))
     }
 }
@@ -810,6 +813,7 @@ fn determine_gid(
     uid: u32,
     group_entries: &[GroupEntry],
     defs: &LoginDefs,
+    scope: uid_alloc::Scope,
 ) -> Result<(u32, Option<GroupEntry>), UseraddError> {
     // If -g was specified, resolve it to a GID.
     if let Some(ref gid_arg) = opts.gid {
@@ -831,7 +835,7 @@ fn determine_gid(
         // Allocate a GID. Prefer same as UID if available.
         let gid = if group_entries.iter().any(|g| g.gid == uid) {
             let (min, max) = uid_alloc::gid_range(defs, opts.system);
-            uid_alloc::next_gid(group_entries, min, max)
+            uid_alloc::next_gid(group_entries, min, max, scope)
                 .map_err(|e| UseraddError::CannotUpdateGroup(format!("{e}")))?
         } else {
             uid
@@ -1735,7 +1739,8 @@ mod tests {
         // Regular user allocation should start at UID_MIN (1000 default),
         // skip 1000 (taken), and give 1001.
         let (min, max) = uid_alloc::uid_range(&defs, false);
-        let uid = uid_alloc::next_uid(&entries, min, max).expect("should find UID");
+        let uid = uid_alloc::next_uid(&entries, min, max, uid_alloc::Scope::FilesOnly)
+            .expect("should find UID");
         assert_eq!(uid, 1001);
     }
 
@@ -1754,7 +1759,8 @@ mod tests {
         let defs = LoginDefs::load(Path::new("/nonexistent")).expect("empty defs");
 
         let (min, max) = uid_alloc::uid_range(&defs, true);
-        let uid = uid_alloc::next_uid(&entries, min, max).expect("should find UID");
+        let uid = uid_alloc::next_uid(&entries, min, max, uid_alloc::Scope::FilesOnly)
+            .expect("should find UID");
         assert_eq!(uid, 101); // SYS_UID_MIN default
     }
 
@@ -1888,7 +1894,13 @@ mod tests {
 
         // Allocate UID.
         let (uid_min, uid_max) = uid_alloc::uid_range(&defs, false);
-        let uid = uid_alloc::next_uid(&passwd_entries, uid_min, uid_max).expect("uid");
+        let uid = uid_alloc::next_uid(
+            &passwd_entries,
+            uid_min,
+            uid_max,
+            uid_alloc::Scope::FilesOnly,
+        )
+        .expect("uid");
         assert_eq!(uid, 1000);
 
         // Create passwd entry.
@@ -2186,7 +2198,9 @@ mod tests {
             root: SysRoot::default(),
         };
 
-        let (gid, new_grp) = determine_gid(&opts, 1000, &groups, &defs).expect("should resolve");
+        let (gid, new_grp) =
+            determine_gid(&opts, 1000, &groups, &defs, uid_alloc::Scope::FilesOnly)
+                .expect("should resolve");
         assert_eq!(gid, 50);
         assert!(new_grp.is_none());
     }
@@ -2223,7 +2237,8 @@ mod tests {
         };
 
         let (gid, new_grp) =
-            determine_gid(&opts, 1000, &groups, &defs).expect("should create user group");
+            determine_gid(&opts, 1000, &groups, &defs, uid_alloc::Scope::FilesOnly)
+                .expect("should create user group");
         // UID 1000 is not taken as a GID, so GID should match UID.
         assert_eq!(gid, 1000);
         let grp = new_grp.expect("should have created a group");
@@ -2262,7 +2277,7 @@ mod tests {
             root: SysRoot::default(),
         };
 
-        let result = determine_gid(&opts, 1000, &groups, &defs);
+        let result = determine_gid(&opts, 1000, &groups, &defs, uid_alloc::Scope::FilesOnly);
         assert!(result.is_err());
     }
 
@@ -2293,7 +2308,8 @@ mod tests {
         };
 
         let (gid, new_grp) =
-            determine_gid(&opts, 1000, &groups, &defs).expect("should use default");
+            determine_gid(&opts, 1000, &groups, &defs, uid_alloc::Scope::FilesOnly)
+                .expect("should use default");
         assert_eq!(gid, 100); // Default USERS_GID.
         assert!(new_grp.is_none());
     }
@@ -2328,7 +2344,8 @@ mod tests {
             root: SysRoot::default(),
         };
 
-        let uid = determine_uid(&opts, &entries, &defs).expect("should succeed");
+        let uid = determine_uid(&opts, &entries, &defs, uid_alloc::Scope::FilesOnly)
+            .expect("should succeed");
         assert_eq!(uid, 5000);
     }
 
@@ -2366,7 +2383,7 @@ mod tests {
             root: SysRoot::default(),
         };
 
-        let result = determine_uid(&opts, &entries, &defs);
+        let result = determine_uid(&opts, &entries, &defs, uid_alloc::Scope::FilesOnly);
         assert!(result.is_err());
     }
 
@@ -2404,7 +2421,8 @@ mod tests {
             root: SysRoot::default(),
         };
 
-        let uid = determine_uid(&opts, &entries, &defs).expect("should allow duplicate");
+        let uid = determine_uid(&opts, &entries, &defs, uid_alloc::Scope::FilesOnly)
+            .expect("should allow duplicate");
         assert_eq!(uid, 5000);
     }
 
@@ -2539,7 +2557,8 @@ mod tests {
             ],
         );
         let opts = opts_for_uid_alloc(false);
-        let uid = determine_uid(&opts, &entries, &defs).expect("allocate");
+        let uid =
+            determine_uid(&opts, &entries, &defs, uid_alloc::Scope::FilesOnly).expect("allocate");
         assert_eq!(uid, 9100);
     }
 
@@ -2555,7 +2574,8 @@ mod tests {
             ],
         );
         let opts = opts_for_uid_alloc(true);
-        let uid = determine_uid(&opts, &entries, &defs).expect("allocate system");
+        let uid = determine_uid(&opts, &entries, &defs, uid_alloc::Scope::FilesOnly)
+            .expect("allocate system");
         assert_eq!(uid, 250);
     }
 
@@ -2572,7 +2592,8 @@ mod tests {
             ],
         );
         let opts = opts_for_uid_alloc(false);
-        let uid = determine_uid(&opts, &entries, &defs).expect("allocate regular");
+        let uid = determine_uid(&opts, &entries, &defs, uid_alloc::Scope::FilesOnly)
+            .expect("allocate regular");
         assert_eq!(uid, 1000);
     }
 
@@ -2613,7 +2634,8 @@ mod tests {
             base_dir: None,
             root: SysRoot::default(),
         };
-        let (gid, new_group) = determine_gid(&opts, 9200, &groups, &defs).expect("gid");
+        let (gid, new_group) =
+            determine_gid(&opts, 9200, &groups, &defs, uid_alloc::Scope::FilesOnly).expect("gid");
         assert_eq!(gid, 9201);
         assert!(new_group.is_some());
     }

--- a/src/uu/userdel/Cargo.toml
+++ b/src/uu/userdel/Cargo.toml
@@ -20,7 +20,7 @@ path = "src/main.rs"
 [dependencies]
 clap = { workspace = true }
 rustix = { workspace = true }
-shadow-core = { workspace = true, features = ["shadow", "group", "gshadow", "login-defs", "subid"] }
+shadow-core = { workspace = true }
 uucore = { workspace = true }
 
 [dev-dependencies]

--- a/src/uu/userdel/src/userdel.rs
+++ b/src/uu/userdel/src/userdel.rs
@@ -76,7 +76,7 @@ impl UError for UserdelError {
 
 #[uucore::main]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let _ = shadow_core::hardening::harden_process();
+    shadow_core::hardening::harden_process();
 
     let Some(matches) =
         shadow_core::cli::parse_args(uu_app(), args, |_| exit_codes::INVALID_SYNTAX)?

--- a/src/uu/usermod/Cargo.toml
+++ b/src/uu/usermod/Cargo.toml
@@ -20,7 +20,7 @@ path = "src/main.rs"
 [dependencies]
 clap = { workspace = true }
 rustix = { workspace = true }
-shadow-core = { workspace = true, features = ["shadow", "group", "gshadow", "login-defs", "subid"] }
+shadow-core = { workspace = true }
 uucore = { workspace = true }
 
 [dev-dependencies]

--- a/src/uu/usermod/src/usermod.rs
+++ b/src/uu/usermod/src/usermod.rs
@@ -88,7 +88,7 @@ impl UError for UsermodError {
 #[uucore::main]
 #[allow(clippy::too_many_lines)]
 pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let _ = shadow_core::hardening::harden_process();
+    shadow_core::hardening::harden_process();
 
     let Some(matches) = shadow_core::cli::parse_args(uu_app(), args, |_| 2)? else {
         return Ok(());

--- a/tests/e2e/deploy-test.sh
+++ b/tests/e2e/deploy-test.sh
@@ -699,6 +699,40 @@ test_aging_and_input() {
     userdel -r aging_user 2>/dev/null || true
 }
 
+# ── Audit logging ───────────────────────────────────────────────────
+
+test_audit_logging() {
+    section "Audit logging"
+
+    # The tools write their records straight to /dev/log rather than forking
+    # `logger` for each event, so the test needs a daemon listening there.
+    rsyslogd -n >/dev/null 2>&1 &
+    local rsyslog_pid=$!
+    sleep 2
+
+    if [ ! -S /dev/log ]; then
+        echo -e "  ${YELLOW}⊘${NC} no /dev/log socket, skipping"
+        kill "$rsyslog_pid" 2>/dev/null || true
+        return
+    fi
+
+    userdel -r audit_user 2>/dev/null || true
+    assert_ok "useradd -m audit_user" useradd -m audit_user
+    assert_ok "userdel -r audit_user" userdel -r audit_user
+    sleep 1
+
+    local log=/var/log/auth.log
+    [ -f "$log" ] || log=/var/log/syslog
+    assert_ok "syslog received the account creation" \
+        bash -c "grep -q 'op=ADD_USER.*acct=\"audit_user\".*res=success' $log"
+    assert_ok "syslog received the account deletion" \
+        bash -c "grep -q 'op=DEL_USER.*acct=\"audit_user\"' $log"
+    assert_ok "the record is tagged shadow-rs" \
+        bash -c "grep -q 'shadow-rs\[[0-9]*\]:.*op=ADD_USER' $log"
+
+    kill "$rsyslog_pid" 2>/dev/null || true
+}
+
 # ── nscd cache invalidation ────────────────────────────────────────
 
 test_nscd() {
@@ -809,6 +843,7 @@ main() {
     test_pam_auth
     test_self_service
     test_aging_and_input
+    test_audit_logging
     test_nscd
     test_landlock
     test_ansible


### PR DESCRIPTION
First instalment of #249: the items that remove code or correct a claim the
code does not honour. The three large refactors in that issue (generic record
reader, `LockedFile` transaction, one exit-code error type) are not here.

### Duplication removed

`process::PwEntry` was a field-by-field twin of `passwd::PasswdEntry`, copied
across at every NSS lookup. `getpwuid` now returns the parser's own type: an
NSS entry and a file entry describe the same account, and the second struct
only bought a copy per call. `lookup_username` goes with it.

The `tty` module had its own signal-mask guard beside `hardening`'s
`SignalBlocker`, and the PAM conversation had its own controlling-terminal
lookup. One of each now.

`error::ShadowResult` and `ShadowError::Permission` had no users at all;
`display_message` carried a parameter it never read; `uid_range` and
`gid_range` were the same function twice over different keys.

### Silent misreading of login.defs

`login.defs(5)` writes numbers "in decimal, or in octal with a leading 0, or in
hexadecimal with a leading 0x". `get_i64` parsed decimal only. That is not a
rejection but a misreading: `UID_MIN 01000` means 512 and came back as 1000, so
`useradd` would allocate out of a range the administrator had reserved.
`UMASK 022` and `HOME_MODE 0750` have the same shape.

### IDs the name service already knows

`/etc/passwd` is not the only source of accounts. A UID free in the file may
belong to an LDAP, SSSD or systemd-homed user, and handing it out gives two
accounts one ID, which the kernel cannot tell apart: the new local user ends up
owning the directory user's files.

Allocation now asks NSS as well. Which sources count is an explicit `Scope`
rather than a hidden default, because a `--prefix` or `--root` run manages
another system's files: the name service here describes *this* system, so
asking it would skip IDs free on the target and claim none taken there.

The allocation tests moved from `next_uid` down to `next_free`. Once `next_uid`
consults NSS its answer depends on which accounts exist on the machine running
the test, and on a typical container 1000 and 1001 do. The policy is tested
where it lives; two new tests assert the property that matters against the live
system.

### One less fork per audit event

Every account event spawned `/usr/bin/logger` and waited for it, to write a few
dozen bytes to a socket. The record now goes straight to `/dev/log` as an
RFC 3164 datagram, and carries the terminal it came from instead of a literal
`?`. Failure stays silent in every direction: a machine with no syslog daemon
is a normal machine.

### Claims the code did not honour

- `harden_process` returned a sanitized environment that all thirteen callers
  discarded, which read as though the process environment had been dealt with.
  It has not been and is not; the function no longer implies otherwise.
- `sysroot` said every tool offering `--root` performs a real `chroot`. Five of
  thirteen do. The other eight fold it into the same resolver `--prefix` uses,
  so an absolute path read out of a record resolves against `/` rather than the
  target. That is a real divergence and is now #270; the documentation says
  which tools do which and points there.
- `atomic` described its temp-file names as unique "across threads" in a
  single-threaded crate. What they separate is successive writes in one
  process, which `usermod` does four of in a row.

### Verification

The deployment suite now runs `rsyslogd` and greps the log for the creation and
deletion records, so the new audit path is covered rather than assumed.

```
Passed: 191
Failed: 0
```

### Cargo features

Five of `shadow-core`'s features gated modules that pull in no dependency.
Gating them bought nothing and cost real confusion: `cargo test -p shadow-core`
compiled a fraction of the crate and reported a pass for it. **It runs 181 tests
now where it ran 20**, without one being written. What stays behind a feature is
what changes the build: `pam`, `crypt` and `landlock`.

In the root manifest `pam` force-enabled the three applets that can use it, so
asking for PAM in a build that had deliberately left them out dragged them back
in. The optional-dependency form applies the feature if the applet is there and
does nothing if it is not.

The `feat_*` aliases and `feat_phase*` groups are gone. Each was a rename of a
feature cargo already provides, and nothing outside the manifest had referred to
them since the phases they were named for finished.

Verified against all four delivery paths: `make build` and `make
build-multicall` still link libpam, the static musl archive still builds and
reports all fourteen applets, and a build with no applets at all is now clean.
