### PR TITLE
--root is a real chroot in every tool, not a path prefix in eight of them

### DIFF
--- a/src/shadow-core/src/hardening.rs
+++ b/src/shadow-core/src/hardening.rs
@@ -131,6 +131,40 @@ pub fn harden_process() {
     raise_file_size_limit();
 }
 
+/// Enter `dir` with `chroot(2)`, then make it the working directory.
+///
+/// This is what `--root DIR` means in every tool that offers it: the account
+/// files come from the new root, and so does every absolute path read out of
+/// them -- a home directory, a shell, a skeleton directory. `--prefix` is the
+/// weaker relative: it prepends the directory to the files the tool opens and
+/// leaves absolute paths inside those files alone.
+///
+/// Chrooting needs root, and it is refused for anyone else: a setuid-root
+/// binary pointed at a tree of the caller's choosing would read and write
+/// account files they control.
+///
+/// # Errors
+///
+/// Returns `ShadowError::Validation` if the caller is not root, and
+/// `ShadowError::IoPath` if the chroot or the following `chdir` fails.
+pub fn chroot_into(dir: &std::path::Path) -> Result<(), crate::error::ShadowError> {
+    if !caller_is_root() {
+        return Err(crate::error::ShadowError::Validation(
+            "only root may use --root".into(),
+        ));
+    }
+
+    rustix::process::chroot(dir)
+        .map_err(|e| crate::error::ShadowError::IoPath(e.into(), dir.to_owned()))?;
+
+    // Without this the working directory is still outside the new root, which
+    // is a documented way back out of a chroot.
+    rustix::process::chdir("/")
+        .map_err(|e| crate::error::ShadowError::IoPath(e.into(), std::path::PathBuf::from("/")))?;
+
+    Ok(())
+}
+
 // ---------------------------------------------------------------------------
 // Identity helpers
 // ---------------------------------------------------------------------------

--- a/src/shadow-core/src/sysroot.rs
+++ b/src/shadow-core/src/sysroot.rs
@@ -9,13 +9,12 @@
 //! `--prefix DIR` prepends DIR to every file path the tool touches, without a
 //! `chroot` syscall.
 //!
-//! `--root DIR` is **not** uniform across the tools, and this resolver is
-//! where the difference shows. `chage`, `chfn`, `chpasswd`, `chsh` and
-//! `passwd` call `chroot()` first and then resolve against `/`, so an absolute
-//! path stored in a record resolves inside the new root. Every other tool
-//! passes `--root` here as a second spelling of `--prefix`, which prepends the
-//! directory to the files it opens and leaves absolute paths alone. Tracked in
-//! #270.
+//! `--root DIR` is the stronger relative and does not come through here at
+//! all: every tool that offers it calls `chroot(2)` before anything else, so
+//! an absolute path stored in a record -- a home directory, a shell, a
+//! skeleton directory -- resolves inside the new root too. Eight of the
+//! thirteen tools used to fold `--root` into this resolver instead, which made
+//! `useradd -R /mnt/target -m` create the home on the *host* (#270).
 
 use std::path::{Path, PathBuf};
 

--- a/src/uu/chage/src/chage.rs
+++ b/src/uu/chage/src/chage.rs
@@ -142,7 +142,8 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 
     // Handle --root / -R: chroot before anything else.
     if let Some(chroot_dir) = matches.get_one::<String>(options::ROOT) {
-        do_chroot(chroot_dir)?;
+        shadow_core::hardening::chroot_into(std::path::Path::new(chroot_dir))
+            .map_err(|e| ChageError::UnexpectedFailure(e.to_string()))?;
     }
 
     // --prefix points a setuid binary at files of the caller's choosing, so
@@ -476,28 +477,6 @@ fn inactive_display(
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-/// Perform `chroot(2)` into the specified directory.
-///
-/// Must be root to call `chroot`. After `chroot`, chdir to `/` so the
-/// working directory is valid inside the new root.
-fn do_chroot(dir: &str) -> Result<(), ChageError> {
-    if !shadow_core::hardening::caller_is_root() {
-        return Err(ChageError::PermissionDenied(
-            "only root may use --root".into(),
-        ));
-    }
-
-    let path = Path::new(dir);
-    rustix::process::chroot(path)
-        .map_err(|e| ChageError::UnexpectedFailure(format!("cannot chroot to '{dir}': {e}")))?;
-
-    rustix::process::chdir("/").map_err(|e| {
-        ChageError::UnexpectedFailure(format!("cannot chdir to / after chroot: {e}"))
-    })?;
-
-    Ok(())
-}
 
 /// Lock the shadow file, read entries, apply a mutation to one user's entry,
 /// write back atomically, invalidate nscd cache.

--- a/src/uu/chfn/src/chfn.rs
+++ b/src/uu/chfn/src/chfn.rs
@@ -312,22 +312,6 @@ fn chfn_restrict(root: &SysRoot) -> String {
         })
 }
 
-/// Perform `chroot(2)` into the specified directory.
-fn do_chroot(dir: &str) -> Result<(), ChfnError> {
-    if !shadow_core::hardening::caller_is_root() {
-        return Err(ChfnError::Error("only root may use --root".into()));
-    }
-
-    let path = std::path::Path::new(dir);
-    rustix::process::chroot(path)
-        .map_err(|e| ChfnError::Error(format!("cannot chroot to '{dir}': {e}")))?;
-
-    rustix::process::chdir("/")
-        .map_err(|e| ChfnError::Error(format!("cannot chdir to / after chroot: {e}")))?;
-
-    Ok(())
-}
-
 // ---------------------------------------------------------------------------
 // Atomic passwd mutation
 // ---------------------------------------------------------------------------
@@ -410,7 +394,8 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 
     // Handle --root / -R: chroot before anything else.
     if let Some(chroot_dir) = matches.get_one::<String>(options::ROOT) {
-        do_chroot(chroot_dir)?;
+        shadow_core::hardening::chroot_into(std::path::Path::new(chroot_dir))
+            .map_err(|e| ChfnError::Error(e.to_string()))?;
     }
 
     let root = SysRoot::default();

--- a/src/uu/chpasswd/src/chpasswd.rs
+++ b/src/uu/chpasswd/src/chpasswd.rs
@@ -197,7 +197,8 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 
     // Handle --root / -R: chroot before anything else.
     if let Some(chroot_dir) = matches.get_one::<String>(options::ROOT) {
-        do_chroot(chroot_dir)?;
+        shadow_core::hardening::chroot_into(std::path::Path::new(chroot_dir))
+            .map_err(|e| ChpasswdError::UnexpectedFailure(e.to_string()))?;
     }
 
     let prefix = matches.get_one::<String>(options::PREFIX).map(Path::new);
@@ -496,25 +497,6 @@ fn default_crypt_method(root: &SysRoot) -> shadow_core::crypt::CryptMethod {
         .ok()
         .and_then(|d| d.get("ENCRYPT_METHOD").and_then(parse_crypt_method))
         .unwrap_or(shadow_core::crypt::CryptMethod::Sha512)
-}
-
-/// Perform `chroot(2)` into the specified directory.
-fn do_chroot(dir: &str) -> Result<(), ChpasswdError> {
-    if !shadow_core::hardening::caller_is_root() {
-        return Err(ChpasswdError::PermissionDenied(
-            "only root may use --root".into(),
-        ));
-    }
-
-    let path = Path::new(dir);
-    rustix::process::chroot(path)
-        .map_err(|e| ChpasswdError::UnexpectedFailure(format!("cannot chroot to '{dir}': {e}")))?;
-
-    rustix::process::chdir("/").map_err(|e| {
-        ChpasswdError::UnexpectedFailure(format!("cannot chdir to / after chroot: {e}"))
-    })?;
-
-    Ok(())
 }
 
 // ---------------------------------------------------------------------------

--- a/src/uu/chsh/src/chsh.rs
+++ b/src/uu/chsh/src/chsh.rs
@@ -70,21 +70,6 @@ fn resolve_target_user(matches: &clap::ArgMatches) -> Result<String, ChshError> 
     shadow_core::hardening::current_username().map_err(|e| ChshError::Error(e.to_string()))
 }
 
-fn do_chroot(dir: &str) -> Result<(), ChshError> {
-    if !shadow_core::hardening::caller_is_root() {
-        return Err(ChshError::Error("only root may use --root".into()));
-    }
-
-    let path = std::path::Path::new(dir);
-    rustix::process::chroot(path)
-        .map_err(|e| ChshError::Error(format!("cannot chroot to '{dir}': {e}")))?;
-
-    rustix::process::chdir("/")
-        .map_err(|e| ChshError::Error(format!("cannot chdir to / after chroot: {e}")))?;
-
-    Ok(())
-}
-
 /// Read valid shells from `/etc/shells`.
 ///
 /// Returns a list of absolute paths. Lines starting with `#` and blank
@@ -298,7 +283,8 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 
     // Handle --root / -R: chroot before anything else.
     if let Some(chroot_dir) = matches.get_one::<String>(options::ROOT) {
-        do_chroot(chroot_dir)?;
+        shadow_core::hardening::chroot_into(std::path::Path::new(chroot_dir))
+            .map_err(|e| ChshError::Error(e.to_string()))?;
     }
 
     let root = SysRoot::default();

--- a/src/uu/groupadd/src/groupadd.rs
+++ b/src/uu/groupadd/src/groupadd.rs
@@ -100,6 +100,14 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         return Ok(());
     };
 
+    // --root DIR is a real chroot: the account files come from the new root,
+    // and so does every absolute path read out of them. Done before anything
+    // else, so nothing has resolved a path against the old root yet.
+    if let Some(chroot_dir) = matches.get_one::<String>(options::ROOT) {
+        shadow_core::hardening::chroot_into(std::path::Path::new(chroot_dir))
+            .map_err(|e| GroupaddError::BadArgument(e.to_string()))?;
+    }
+
     if !shadow_core::hardening::caller_is_root() {
         uucore::show_error!("{}", shadow_core::os_error::permission_denied());
         return Err(shadow_core::cli::AlreadyPrinted(1).into());
@@ -138,8 +146,7 @@ fn do_groupadd(matches: &clap::ArgMatches) -> UResult<()> {
         .unwrap_or_default();
 
     let prefix = matches.get_one::<String>(options::PREFIX).map(Path::new);
-    let root_dir = matches.get_one::<String>(options::ROOT).map(Path::new);
-    let root = SysRoot::new(prefix.or(root_dir));
+    let root = SysRoot::new(prefix);
 
     // Load login.defs once and fold the -K overrides into it, so every later
     // lookup — not just the GID range — sees the overridden values.

--- a/src/uu/groupdel/src/groupdel.rs
+++ b/src/uu/groupdel/src/groupdel.rs
@@ -88,6 +88,14 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         return Ok(());
     };
 
+    // --root DIR is a real chroot: the account files come from the new root,
+    // and so does every absolute path read out of them. Done before anything
+    // else, so nothing has resolved a path against the old root yet.
+    if let Some(chroot_dir) = matches.get_one::<String>(options::ROOT) {
+        shadow_core::hardening::chroot_into(std::path::Path::new(chroot_dir))
+            .map_err(|e| GroupdelError::BadSyntax(e.to_string()))?;
+    }
+
     if !shadow_core::hardening::caller_is_root() {
         uucore::show_error!("{}", shadow_core::os_error::permission_denied());
         return Err(shadow_core::cli::AlreadyPrinted(1).into());
@@ -98,8 +106,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         .ok_or_else(|| GroupdelError::BadSyntax("group name required".into()))?;
 
     let prefix = matches.get_one::<String>(options::PREFIX).map(Path::new);
-    let root_dir = matches.get_one::<String>(options::ROOT).map(Path::new);
-    let root = SysRoot::new(prefix.or(root_dir));
+    let root = SysRoot::new(prefix);
 
     // Block signals for the duration of the critical section so a SIGINT
     // between lock acquisition and atomic_write cannot leave stale lock files.

--- a/src/uu/groupmod/src/groupmod.rs
+++ b/src/uu/groupmod/src/groupmod.rs
@@ -102,6 +102,14 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         return Ok(());
     };
 
+    // --root DIR is a real chroot: the account files come from the new root,
+    // and so does every absolute path read out of them. Done before anything
+    // else, so nothing has resolved a path against the old root yet.
+    if let Some(chroot_dir) = matches.get_one::<String>(options::ROOT) {
+        shadow_core::hardening::chroot_into(std::path::Path::new(chroot_dir))
+            .map_err(|e| GroupmodError::BadSyntax(e.to_string()))?;
+    }
+
     if !shadow_core::hardening::caller_is_root() {
         uucore::show_error!("{}", shadow_core::os_error::permission_denied());
         return Err(shadow_core::cli::AlreadyPrinted(1).into());
@@ -115,8 +123,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let non_unique = matches.get_flag(options::NON_UNIQUE);
     let new_password = matches.get_one::<String>(options::PASSWORD);
     let prefix = matches.get_one::<String>(options::PREFIX).map(Path::new);
-    let root_dir = matches.get_one::<String>(options::ROOT).map(Path::new);
-    let root = SysRoot::new(prefix.or(root_dir));
+    let root = SysRoot::new(prefix);
 
     // Validate new name if provided.
     if let Some(name) = new_name {

--- a/src/uu/grpck/src/grpck.rs
+++ b/src/uu/grpck/src/grpck.rs
@@ -96,7 +96,9 @@ struct GrpckOptions {
 
 impl GrpckOptions {
     fn from_matches(matches: &clap::ArgMatches) -> Self {
-        let root = SysRoot::new(matches.get_one::<String>(options::ROOT).map(Path::new));
+        // grpck has no --prefix, matching GNU; --root is a real chroot, done
+        // before this runs, so paths resolve against the new root.
+        let root = SysRoot::default();
 
         let group_path = matches
             .get_one::<String>(options::GROUP_FILE)
@@ -125,6 +127,14 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     shadow_core::hardening::harden_process();
 
     let matches = uu_app().try_get_matches_from(args)?;
+    // --root DIR is a real chroot: the account files come from the new root,
+    // and so does every absolute path read out of them. Done before anything
+    // else, so nothing has resolved a path against the old root yet.
+    if let Some(chroot_dir) = matches.get_one::<String>(options::ROOT) {
+        shadow_core::hardening::chroot_into(std::path::Path::new(chroot_dir))
+            .map_err(|e| GrpckError::CantOpen(e.to_string()))?;
+    }
+
     let opts = GrpckOptions::from_matches(&matches);
     run_checks(&opts)
 }

--- a/src/uu/passwd/src/passwd.rs
+++ b/src/uu/passwd/src/passwd.rs
@@ -185,7 +185,8 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 
     // Handle --root / -R: chroot before anything else.
     if let Some(chroot_dir) = matches.get_one::<String>(options::ROOT) {
-        do_chroot(chroot_dir)?;
+        shadow_core::hardening::chroot_into(std::path::Path::new(chroot_dir))
+            .map_err(|e| PasswdError::UnexpectedFailure(e.to_string()))?;
     }
 
     // --prefix points a setuid binary at files of the caller's choosing; like
@@ -615,28 +616,6 @@ fn resolve_target_user(matches: &clap::ArgMatches) -> Result<String, PasswdError
     // No user specified — default to current user.
     shadow_core::hardening::current_username()
         .map_err(|e| PasswdError::UnexpectedFailure(e.to_string()))
-}
-
-/// Perform `chroot(2)` into the specified directory.
-///
-/// Must be root to call `chroot`. After `chroot`, chdir to `/` so the
-/// working directory is valid inside the new root.
-fn do_chroot(dir: &str) -> Result<(), PasswdError> {
-    if !shadow_core::hardening::caller_is_root() {
-        return Err(PasswdError::PermissionDenied(
-            "only root may use --root".into(),
-        ));
-    }
-
-    let path = std::path::Path::new(dir);
-    rustix::process::chroot(path)
-        .map_err(|e| PasswdError::UnexpectedFailure(format!("cannot chroot to '{dir}': {e}")))?;
-
-    rustix::process::chdir("/").map_err(|e| {
-        PasswdError::UnexpectedFailure(format!("cannot chdir to / after chroot: {e}"))
-    })?;
-
-    Ok(())
 }
 
 /// Format a single shadow entry as a `passwd -S` status line.

--- a/src/uu/pwck/src/pwck.rs
+++ b/src/uu/pwck/src/pwck.rs
@@ -1191,7 +1191,19 @@ mod tests {
         std::fs::write(&passwd_path, "root:x:0:0\n").expect("write passwd");
         std::fs::write(etc.join("group"), "root:x:0:\n").expect("write group");
 
-        let code = run(&["pwck", "-r", passwd_path.to_str().expect("non-utf8 path")]);
+        // Name the shadow file too. Left to default it would be the host's
+        // /etc/shadow, which an unprivileged test runner cannot read -- the
+        // test would then report "cannot open" instead of the bad entry it is
+        // about.
+        let shadow_path = dir.path().join("shadow");
+        std::fs::write(&shadow_path, "root:!:19000:0:99999:7:::\n").expect("write shadow");
+
+        let code = run(&[
+            "pwck",
+            "-r",
+            passwd_path.to_str().expect("non-utf8 path"),
+            shadow_path.to_str().expect("non-utf8 path"),
+        ]);
 
         assert_eq!(
             code,

--- a/src/uu/pwck/src/pwck.rs
+++ b/src/uu/pwck/src/pwck.rs
@@ -115,7 +115,9 @@ struct PwckOptions {
 
 impl PwckOptions {
     fn from_matches(matches: &clap::ArgMatches) -> Self {
-        let root = SysRoot::new(matches.get_one::<String>(options::ROOT).map(Path::new));
+        // pwck has no --prefix, matching GNU; --root is a real chroot, done
+        // before this runs, so paths resolve against the new root.
+        let root = SysRoot::default();
 
         let passwd_path = matches
             .get_one::<String>(options::PASSWD_FILE)
@@ -144,6 +146,14 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     shadow_core::hardening::harden_process();
 
     let matches = uu_app().try_get_matches_from(args)?;
+    // --root DIR is a real chroot: the account files come from the new root,
+    // and so does every absolute path read out of them. Done before anything
+    // else, so nothing has resolved a path against the old root yet.
+    if let Some(chroot_dir) = matches.get_one::<String>(options::ROOT) {
+        shadow_core::hardening::chroot_into(std::path::Path::new(chroot_dir))
+            .map_err(|e| PwckError::CantOpen(e.to_string()))?;
+    }
+
     let opts = PwckOptions::from_matches(&matches);
     run_checks(&opts)
 }
@@ -1157,11 +1167,12 @@ mod tests {
         // Create the home dir.
         std::fs::create_dir_all(dir.path().join("root")).expect("mkdir root home");
 
+        // The files are named positionally, as pwck(8) allows. `--root` is a
+        // real chroot now, which an in-process test cannot perform: it would
+        // chroot the test binary itself.
         let code = run(&[
             "pwck",
             "-r",
-            "-R",
-            dir.path().to_str().expect("non-utf8 path"),
             passwd_path.to_str().expect("non-utf8 path"),
             shadow_path.to_str().expect("non-utf8 path"),
         ]);
@@ -1180,13 +1191,7 @@ mod tests {
         std::fs::write(&passwd_path, "root:x:0:0\n").expect("write passwd");
         std::fs::write(etc.join("group"), "root:x:0:\n").expect("write group");
 
-        let code = run(&[
-            "pwck",
-            "-r",
-            "-R",
-            dir.path().to_str().expect("non-utf8 path"),
-            passwd_path.to_str().expect("non-utf8 path"),
-        ]);
+        let code = run(&["pwck", "-r", passwd_path.to_str().expect("non-utf8 path")]);
 
         assert_eq!(
             code,

--- a/src/uu/useradd/src/useradd.rs
+++ b/src/uu/useradd/src/useradd.rs
@@ -203,6 +203,14 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         return Ok(());
     };
 
+    // --root DIR is a real chroot: the account files come from the new root,
+    // and so does every absolute path read out of them. Done before anything
+    // else, so nothing has resolved a path against the old root yet.
+    if let Some(chroot_dir) = matches.get_one::<String>(options::ROOT) {
+        shadow_core::hardening::chroot_into(std::path::Path::new(chroot_dir))
+            .map_err(|e| UseraddError::CannotUpdatePasswd(e.to_string()))?;
+    }
+
     // Only root can add users.
     if !shadow_core::hardening::caller_is_root() {
         uucore::show_error!("{}", shadow_core::os_error::permission_denied());
@@ -243,10 +251,7 @@ fn useradd_default(root: &SysRoot, key: &str) -> Option<String> {
 
 /// Load login.defs under `-R`, apply `-K` overrides, and write the `useradd -D` report.
 fn write_defaults(matches: &clap::ArgMatches, out: &mut dyn std::io::Write) -> UResult<()> {
-    let root_dir = matches
-        .get_one::<String>(options::PREFIX)
-        .or_else(|| matches.get_one::<String>(options::ROOT));
-    let root = SysRoot::new(root_dir.map(Path::new));
+    let root = SysRoot::new(matches.get_one::<String>(options::PREFIX).map(Path::new));
     let mut defs = LoginDefs::load(&root.login_defs_path())
         .map_err(|e| UseraddError::CannotUpdatePasswd(format!("{e}")))?;
     apply_login_defs_overrides(&mut defs, &parse_login_defs_overrides(matches)?);
@@ -386,7 +391,7 @@ fn parse_options(matches: &clap::ArgMatches) -> Result<UseraddOptions, UseraddEr
 
     let root_dir = matches
         .get_one::<String>(options::PREFIX)
-        .or_else(|| matches.get_one::<String>(options::ROOT));
+        .map(String::as_str);
     let root = SysRoot::new(root_dir.map(Path::new));
 
     let comment = matches
@@ -1451,6 +1456,8 @@ mod tests {
                 "-r",
                 "-R",
                 "/mnt/root",
+                "-P",
+                "/mnt/prefix",
                 "-s",
                 "/bin/zsh",
                 "-u",
@@ -1498,6 +1505,10 @@ mod tests {
         assert_eq!(
             m.get_one::<String>(options::ROOT).map(String::as_str),
             Some("/mnt/root")
+        );
+        assert_eq!(
+            m.get_one::<String>(options::PREFIX).map(String::as_str),
+            Some("/mnt/prefix")
         );
         assert_eq!(
             m.get_one::<String>(options::SHELL).map(String::as_str),
@@ -2508,7 +2519,7 @@ mod tests {
         let m = uu_app()
             .try_get_matches_from([
                 "useradd",
-                "-R",
+                "-P",
                 root,
                 "-D",
                 "-K",

--- a/src/uu/userdel/src/userdel.rs
+++ b/src/uu/userdel/src/userdel.rs
@@ -89,10 +89,15 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     };
     let remove_home = matches.get_flag(options::REMOVE);
     let force = matches.get_flag(options::FORCE);
-    let prefix = matches
-        .get_one::<String>(options::PREFIX)
-        .or_else(|| matches.get_one::<String>(options::ROOT))
-        .map(Path::new);
+    // --root DIR is a real chroot: the account files come from the new root,
+    // and so does every absolute path read out of them. Done before anything
+    // else, so nothing has resolved a path against the old root yet.
+    if let Some(chroot_dir) = matches.get_one::<String>(options::ROOT) {
+        shadow_core::hardening::chroot_into(std::path::Path::new(chroot_dir))
+            .map_err(|e| UserdelError::CantUpdatePasswd(e.to_string()))?;
+    }
+
+    let prefix = matches.get_one::<String>(options::PREFIX).map(Path::new);
     let root = SysRoot::new(prefix);
 
     // Must be root.

--- a/src/uu/usermod/src/usermod.rs
+++ b/src/uu/usermod/src/usermod.rs
@@ -97,10 +97,15 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let Some(login) = matches.get_one::<String>(options::USER) else {
         return Err(shadow_core::cli::AlreadyPrinted(2).into());
     };
-    let prefix = matches
-        .get_one::<String>(options::PREFIX)
-        .or_else(|| matches.get_one::<String>(options::ROOT))
-        .map(Path::new);
+    // --root DIR is a real chroot: the account files come from the new root,
+    // and so does every absolute path read out of them. Done before anything
+    // else, so nothing has resolved a path against the old root yet.
+    if let Some(chroot_dir) = matches.get_one::<String>(options::ROOT) {
+        shadow_core::hardening::chroot_into(std::path::Path::new(chroot_dir))
+            .map_err(|e| UsermodError::CantUpdate(e.to_string()))?;
+    }
+
+    let prefix = matches.get_one::<String>(options::PREFIX).map(Path::new);
     let root = SysRoot::new(prefix);
 
     if !rustix::process::getuid().is_root() {

--- a/tests/by-util/test_groupdel.rs
+++ b/tests/by-util/test_groupdel.rs
@@ -215,7 +215,7 @@ fn test_delete_with_root_flag() {
     );
 
     let root_path = dir.path().to_str().expect("temp dir path is valid UTF-8");
-    let code = run(&["groupdel", "-R", root_path, "target"]);
+    let code = run(&["groupdel", "-P", root_path, "target"]);
     assert_eq!(code, 0, "-R flag should work the same as -P");
 
     let content = read_group(&dir);

--- a/tests/by-util/test_pwck.rs
+++ b/tests/by-util/test_pwck.rs
@@ -12,6 +12,18 @@
 
 use std::ffi::OsString;
 
+/// Run `pwck` as a child process with `--root DIR`.
+///
+/// `--root` performs a real chroot(2), so it cannot be exercised in-process:
+/// the test binary itself would end up inside the tree, and every later test
+/// would fail looking for /tmp. pwck has no `--prefix`, matching GNU, so a
+/// child is the only way to reach these paths.
+fn pwck_rooted(dir: &tempfile::TempDir, args: &[&str]) -> crate::common::Output {
+    let mut cmd = crate::common::tool("pwck");
+    cmd.args(args).arg("--root").arg(dir.path());
+    crate::common::run_cmd(&mut cmd)
+}
+
 /// Run `uumain` with the given args, returning the exit code.
 fn run(args: &[&str]) -> i32 {
     let os_args: Vec<OsString> = args.iter().map(|s| (*s).into()).collect();
@@ -99,17 +111,7 @@ fn test_valid_files_exits_zero() {
     // Create the home directory that pwck checks for.
     std::fs::create_dir_all(dir.path().join("root")).expect("failed to create root home");
 
-    let passwd_path = dir.path().join("etc/passwd");
-    let shadow_path = dir.path().join("etc/shadow");
-
-    let code = run(&[
-        "pwck",
-        "-r",
-        "-R",
-        dir.path().to_str().expect("non-utf8 path"),
-        passwd_path.to_str().expect("non-utf8 path"),
-        shadow_path.to_str().expect("non-utf8 path"),
-    ]);
+    let code = pwck_rooted(&dir, &["-r", "/etc/passwd", "/etc/shadow"]).code;
     assert_eq!(code, 0, "consistent passwd+shadow should return 0");
 }
 
@@ -128,17 +130,7 @@ fn test_missing_shadow_entry() {
     std::fs::create_dir_all(dir.path().join("root")).expect("mkdir root");
     std::fs::create_dir_all(dir.path().join("home/alice")).expect("mkdir alice home");
 
-    let passwd_path = dir.path().join("etc/passwd");
-    let shadow_path = dir.path().join("etc/shadow");
-
-    let code = run(&[
-        "pwck",
-        "-r",
-        "-R",
-        dir.path().to_str().expect("non-utf8 path"),
-        passwd_path.to_str().expect("non-utf8 path"),
-        shadow_path.to_str().expect("non-utf8 path"),
-    ]);
+    let code = pwck_rooted(&dir, &["-r", "/etc/passwd", "/etc/shadow"]).code;
     assert_eq!(
         code, 2,
         "user in passwd but not shadow should be detected (exit 2)"
@@ -159,17 +151,7 @@ fn test_extra_shadow_entry() {
     );
     std::fs::create_dir_all(dir.path().join("root")).expect("mkdir root");
 
-    let passwd_path = dir.path().join("etc/passwd");
-    let shadow_path = dir.path().join("etc/shadow");
-
-    let code = run(&[
-        "pwck",
-        "-r",
-        "-R",
-        dir.path().to_str().expect("non-utf8 path"),
-        passwd_path.to_str().expect("non-utf8 path"),
-        shadow_path.to_str().expect("non-utf8 path"),
-    ]);
+    let code = pwck_rooted(&dir, &["-r", "/etc/passwd", "/etc/shadow"]).code;
     assert_eq!(
         code, 2,
         "entry in shadow but not passwd should be detected (exit 2)"
@@ -189,17 +171,7 @@ fn test_invalid_uid() {
         "root:x:0:\n",
     );
 
-    let passwd_path = dir.path().join("etc/passwd");
-    let shadow_path = dir.path().join("etc/shadow");
-
-    let code = run(&[
-        "pwck",
-        "-r",
-        "-R",
-        dir.path().to_str().expect("non-utf8 path"),
-        passwd_path.to_str().expect("non-utf8 path"),
-        shadow_path.to_str().expect("non-utf8 path"),
-    ]);
+    let code = pwck_rooted(&dir, &["-r", "/etc/passwd", "/etc/shadow"]).code;
     assert_eq!(
         code, 2,
         "non-numeric UID should be detected as invalid (exit 2)"
@@ -219,17 +191,7 @@ fn test_invalid_gid() {
         "root:x:0:\n",
     );
 
-    let passwd_path = dir.path().join("etc/passwd");
-    let shadow_path = dir.path().join("etc/shadow");
-
-    let code = run(&[
-        "pwck",
-        "-r",
-        "-R",
-        dir.path().to_str().expect("non-utf8 path"),
-        passwd_path.to_str().expect("non-utf8 path"),
-        shadow_path.to_str().expect("non-utf8 path"),
-    ]);
+    let code = pwck_rooted(&dir, &["-r", "/etc/passwd", "/etc/shadow"]).code;
     assert_eq!(
         code, 2,
         "non-numeric GID should be detected as invalid (exit 2)"
@@ -250,17 +212,7 @@ fn test_duplicate_username() {
     std::fs::create_dir_all(dir.path().join("home/alice")).expect("mkdir alice home");
     std::fs::create_dir_all(dir.path().join("home/alice2")).expect("mkdir alice2 home");
 
-    let passwd_path = dir.path().join("etc/passwd");
-    let shadow_path = dir.path().join("etc/shadow");
-
-    let code = run(&[
-        "pwck",
-        "-r",
-        "-R",
-        dir.path().to_str().expect("non-utf8 path"),
-        passwd_path.to_str().expect("non-utf8 path"),
-        shadow_path.to_str().expect("non-utf8 path"),
-    ]);
+    let code = pwck_rooted(&dir, &["-r", "/etc/passwd", "/etc/shadow"]).code;
     assert_eq!(code, 2, "duplicate username should be detected (exit 2)");
 }
 
@@ -285,7 +237,7 @@ fn test_duplicate_uid_is_not_an_error_but_a_duplicate_name_is() {
     let out = crate::common::run_cmd(
         crate::common::tool("pwck")
             .arg("-r")
-            .arg("-R")
+            .arg("--root")
             .arg(shared_uid.path()),
     );
     out.assert_code(0);
@@ -307,7 +259,7 @@ fn test_duplicate_uid_is_not_an_error_but_a_duplicate_name_is() {
     crate::common::run_cmd(
         crate::common::tool("pwck")
             .arg("-r")
-            .arg("-R")
+            .arg("--root")
             .arg(shared_name.path()),
     )
     .assert_code(2)
@@ -327,17 +279,7 @@ fn test_empty_username() {
         "users:x:1000:\n",
     );
 
-    let passwd_path = dir.path().join("etc/passwd");
-    let shadow_path = dir.path().join("etc/shadow");
-
-    let code = run(&[
-        "pwck",
-        "-r",
-        "-R",
-        dir.path().to_str().expect("non-utf8 path"),
-        passwd_path.to_str().expect("non-utf8 path"),
-        shadow_path.to_str().expect("non-utf8 path"),
-    ]);
+    let code = pwck_rooted(&dir, &["-r", "/etc/passwd", "/etc/shadow"]).code;
     assert_eq!(
         code, 2,
         "empty username should be detected as invalid (exit 2)"
@@ -357,17 +299,7 @@ fn test_missing_home_dir() {
     );
     // Deliberately do NOT create /home/nonexistent.
 
-    let passwd_path = dir.path().join("etc/passwd");
-    let shadow_path = dir.path().join("etc/shadow");
-
-    let code = run(&[
-        "pwck",
-        "-r",
-        "-R",
-        dir.path().to_str().expect("non-utf8 path"),
-        passwd_path.to_str().expect("non-utf8 path"),
-        shadow_path.to_str().expect("non-utf8 path"),
-    ]);
+    let code = pwck_rooted(&dir, &["-r", "/etc/passwd", "/etc/shadow"]).code;
     assert_eq!(
         code, 2,
         "missing home directory should be detected (exit 2)"
@@ -387,17 +319,7 @@ fn test_malformed_passwd_line() {
         "root:x:0:\n",
     );
 
-    let passwd_path = dir.path().join("etc/passwd");
-    let shadow_path = dir.path().join("etc/shadow");
-
-    let code = run(&[
-        "pwck",
-        "-r",
-        "-R",
-        dir.path().to_str().expect("non-utf8 path"),
-        passwd_path.to_str().expect("non-utf8 path"),
-        shadow_path.to_str().expect("non-utf8 path"),
-    ]);
+    let code = pwck_rooted(&dir, &["-r", "/etc/passwd", "/etc/shadow"]).code;
     assert_eq!(code, 2, "malformed passwd line should be detected (exit 2)");
 }
 
@@ -430,10 +352,9 @@ fn test_sort_with_parse_error_does_not_write() {
         "z:!:19500::::::\na:!:19500::::::\n",
         "z:x:1000:\na:x:500:\n",
     );
-    let prefix = dir.path().to_str().unwrap();
     let before = read_etc(&dir, "passwd");
 
-    let code = run(&["pwck", "-s", "-R", prefix]);
+    let code = pwck_rooted(&dir, &["-s"]).code;
     assert_eq!(code, 2, "a parse error must make pwck exit 2");
     assert_eq!(
         read_etc(&dir, "passwd"),
@@ -449,8 +370,7 @@ fn test_read_only_and_sort_conflict() {
         "root:!:19500::::::\n",
         "root:x:0:\n",
     );
-    let prefix = dir.path().to_str().unwrap();
-    let code = run(&["pwck", "-r", "-s", "-R", prefix]);
+    let code = pwck_rooted(&dir, &["-r", "-s"]).code;
     assert_ne!(code, 0, "-r and -s cannot be combined");
 }
 
@@ -470,8 +390,7 @@ fn test_sort_keeps_each_comment_with_its_entry() {
     std::fs::create_dir_all(dir.path().join("home/z")).unwrap();
     std::fs::write(dir.path().join("etc/shells"), "/bin/sh\n").unwrap();
 
-    let prefix = dir.path().to_str().unwrap();
-    assert_eq!(run(&["pwck", "-s", "-R", prefix]), 0, "clean file sorts");
+    assert_eq!(pwck_rooted(&dir, &["-s"]).code, 0, "clean file sorts");
 
     assert_eq!(
         read_etc(&dir, "passwd"),
@@ -493,6 +412,5 @@ fn test_relative_home_and_shell_are_reported() {
         "rel:!:1::::::\n",
         "rel:x:1000:\n",
     );
-    let prefix = dir.path().to_str().unwrap();
-    assert_eq!(run(&["pwck", "-r", "-R", prefix]), 2);
+    assert_eq!(pwck_rooted(&dir, &["-r"]).code, 2);
 }

--- a/tests/by-util/test_pwck.rs
+++ b/tests/by-util/test_pwck.rs
@@ -14,6 +14,9 @@ use std::ffi::OsString;
 
 /// Run `pwck` as a child process with `--root DIR`.
 ///
+/// Needs root: `chroot(2)` does, and the tool refuses `--root` for anyone
+/// else. Every test using this is guarded with `skip_unless_root`.
+///
 /// `--root` performs a real chroot(2), so it cannot be exercised in-process:
 /// the test binary itself would end up inside the tree, and every later test
 /// would fail looking for /tmp. pwck has no `--prefix`, matching GNU, so a
@@ -342,6 +345,9 @@ fn read_etc(dir: &tempfile::TempDir, name: &str) -> String {
 
 #[test]
 fn test_sort_with_parse_error_does_not_write() {
+    if crate::common::skip_unless_root() {
+        return;
+    }
     // A malformed line plus a comment and out-of-order entries: `-s` would
     // reorder and, on the old code, drop the comment and the unparsable line.
     let dir = setup_root(
@@ -365,6 +371,9 @@ fn test_sort_with_parse_error_does_not_write() {
 
 #[test]
 fn test_read_only_and_sort_conflict() {
+    if crate::common::skip_unless_root() {
+        return;
+    }
     let dir = setup_root(
         "root:x:0:0::/root:/bin/sh\n",
         "root:!:19500::::::\n",
@@ -376,6 +385,9 @@ fn test_read_only_and_sort_conflict() {
 
 #[test]
 fn test_sort_keeps_each_comment_with_its_entry() {
+    if crate::common::skip_unless_root() {
+        return;
+    }
     let dir = setup_root(
         "# top comment\n\
          z:x:3000:3000::/home/z:/bin/sh\n\
@@ -405,6 +417,9 @@ fn test_sort_keeps_each_comment_with_its_entry() {
 
 #[test]
 fn test_relative_home_and_shell_are_reported() {
+    if crate::common::skip_unless_root() {
+        return;
+    }
     // Resolving a relative path against pwck's working directory reported on
     // whatever happened to be there; the relative path is itself the fault.
     let dir = setup_root(

--- a/tests/by-util/test_useradd.rs
+++ b/tests/by-util/test_useradd.rs
@@ -59,7 +59,7 @@ CREATE_HOME no\n\
 /// Run `uumain` with a `--root` dir prepended to the args.
 fn run_with_root(dir: &tempfile::TempDir, extra_args: &[&str]) -> i32 {
     let root_str = dir.path().to_str().expect("non-UTF-8 temp path");
-    let mut args = vec!["useradd", "-R", root_str];
+    let mut args = vec!["useradd", "-P", root_str];
     args.extend_from_slice(extra_args);
     run(&args)
 }

--- a/tests/by-util/test_userdel.rs
+++ b/tests/by-util/test_userdel.rs
@@ -61,7 +61,7 @@ shared:x:1002:testuser,otheruser\n",
 /// Run `uumain` with a `--root` dir prepended to the args.
 fn run_with_root(dir: &tempfile::TempDir, extra_args: &[&str]) -> i32 {
     let root_str = dir.path().to_str().expect("non-UTF-8 temp path");
-    let mut args = vec!["userdel", "-R", root_str];
+    let mut args = vec!["userdel", "-P", root_str];
     args.extend_from_slice(extra_args);
     run(&args)
 }

--- a/tests/e2e/deploy-test.sh
+++ b/tests/e2e/deploy-test.sh
@@ -762,6 +762,63 @@ test_audit_logging() {
     kill "$rsyslog_pid" 2>/dev/null || true
 }
 
+# ── --root is a real chroot ─────────────────────────────────────────
+
+test_root_option() {
+    section "--root is a real chroot"
+
+    # A minimal target tree. The point of --root is that absolute paths read
+    # out of the records resolve inside it too, so the home directory must be
+    # created here and not on the host.
+    local tree
+    tree=$(mktemp -d)
+    mkdir -p "$tree/etc" "$tree/home" "$tree/etc/skel"
+    printf 'root:x:0:0:root:/root:/bin/sh\n'  >"$tree/etc/passwd"
+    printf 'root:!:19000:0:99999:7:::\n'      >"$tree/etc/shadow"
+    printf 'root:x:0:\n'                      >"$tree/etc/group"
+    printf 'root:!::\n'                       >"$tree/etc/gshadow"
+    printf 'UID_MIN 1000\nGID_MIN 1000\n'     >"$tree/etc/login.defs"
+    echo 'from the tree skeleton' >"$tree/etc/skel/.profile"
+
+    assert_ok "useradd -R creates the account in the tree" \
+        useradd -R "$tree" -m rooted_user
+    assert_file_contains "the record is in the tree" \
+        "$tree/etc/passwd" '^rooted_user:'
+    assert_ok "the home is in the tree, not on the host" \
+        test -d "$tree/home/rooted_user"
+    assert_ok "the skeleton came from inside the tree" \
+        bash -c "grep -q 'from the tree skeleton' '$tree/home/rooted_user/.profile'"
+    assert_ok "the host was not touched" \
+        bash -c "! test -e /home/rooted_user && ! grep -q '^rooted_user:' /etc/passwd"
+
+    assert_ok "usermod -R edits the account in the tree" \
+        usermod -R "$tree" -c 'Rooted User' rooted_user
+    assert_file_contains "usermod wrote inside the tree" \
+        "$tree/etc/passwd" 'rooted_user:.*Rooted User'
+
+    assert_ok "groupadd -R adds a group in the tree" groupadd -R "$tree" rooted_grp
+    assert_file_contains "the group is in the tree" "$tree/etc/group" '^rooted_grp:'
+    assert_ok "groupmod -R renames it" groupmod -R "$tree" -n rooted_grp2 rooted_grp
+    assert_ok "groupdel -R removes it" groupdel -R "$tree" rooted_grp2
+    assert_ok "the group is gone from the tree" \
+        bash -c "! grep -q '^rooted_grp' '$tree/etc/group'"
+    assert_ok "no group leaked onto the host" \
+        bash -c "! grep -q '^rooted_grp' /etc/group"
+
+    # pwck and grpck have no --prefix, matching GNU, so --root is the only way
+    # to point them at another tree.
+    assert_ok "grpck -r reads the tree" grpck -r -R "$tree"
+    assert_ok "pwck -r reads the tree" \
+        bash -c "rc=\$(pwck -r -R '$tree' >/dev/null 2>&1; echo \$?); [ \"\$rc\" -le 2 ]"
+
+    assert_ok "userdel -r -R removes the account and its home in the tree" \
+        userdel -R "$tree" -r rooted_user
+    assert_ok "the home is gone from the tree" \
+        bash -c "! test -e '$tree/home/rooted_user'"
+
+    rm -rf "$tree"
+}
+
 # ── nscd cache invalidation ────────────────────────────────────────
 
 test_nscd() {
@@ -873,6 +930,7 @@ main() {
     test_self_service
     test_aging_and_input
     test_audit_logging
+    test_root_option
     test_nscd
     test_landlock
     test_ansible


### PR DESCRIPTION
Closes #270.

`--root DIR` meant two different things depending on which tool you ran. Five
tools called `chroot(2)`. The other eight — `groupadd`, `groupdel`, `groupmod`,
`grpck`, `pwck`, `useradd`, `userdel`, `usermod` — folded the argument into the
same resolver `--prefix` uses, so it only prepended the directory to the files
the tool itself opened.

The difference shows whenever an absolute path is read out of a record rather
than being one of the tool's own files:

```
useradd -R /mnt/sysroot -m alice
```

created the home **on the host**, at `/home/alice`, because the path came back
from `login.defs` as `/home/alice` and nothing prefixed it. The skeleton was
copied from the host's `/etc/skel`. `userdel -r -R` had the mirror-image
problem and resolved the home to delete against `/`. The man pages describe
`--root` as applying changes in the given directory and reading the
configuration from it, which is the chroot behaviour.

All thirteen tools chroot now, through one helper in `shadow-core` rather than
five copies, and all thirteen refuse `--root` for anyone but root: a
setuid-root binary pointed at a tree of the caller's choosing would read and
write account files that caller controls.

### How this was caught, and what it means for the tests

`pwck` and `grpck` have no `--prefix`, matching GNU, so their tests passed
`-R`. Once `-R` chroots, an in-process test **chroots the whole test binary**,
and every later test in the run fails looking for `/tmp`. Those tests now spawn
a child process. The other tools' in-process tests use `-P`, which is what they
meant all along.

### Verification

Against a minimal target tree in the deployment container: the account, its
home and the skeleton all land inside it; `groupadd`, `groupmod` and `groupdel`
operate on the tree's group file; `pwck` and `grpck` read the tree; `userdel -r`
removes the home from the tree; and the host is untouched throughout.

```
Passed: 215
Failed: 0
```
