### PR TITLE
shadow-core: a locked-file transaction, and seven tools using it

### DIFF
--- a/src/shadow-core/src/group.rs
+++ b/src/shadow-core/src/group.rs
@@ -180,6 +180,12 @@ pub fn write_group_with_layout<W: Write>(
     })
 }
 
+impl crate::transaction::Record for GroupEntry {
+    fn validate_fields(&self) -> Result<(), ShadowError> {
+        Self::validate_fields(self)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/shadow-core/src/gshadow.rs
+++ b/src/shadow-core/src/gshadow.rs
@@ -190,6 +190,12 @@ pub fn write_gshadow_with_layout<W: Write>(
     })
 }
 
+impl crate::transaction::Record for GshadowEntry {
+    fn validate_fields(&self) -> Result<(), ShadowError> {
+        Self::validate_fields(self)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/shadow-core/src/lib.rs
+++ b/src/shadow-core/src/lib.rs
@@ -30,6 +30,7 @@ pub mod shadow;
 pub mod skel;
 pub mod subid;
 pub mod sysroot;
+pub mod transaction;
 pub mod tty;
 pub mod uid_alloc;
 pub mod validate;

--- a/src/shadow-core/src/passwd.rs
+++ b/src/shadow-core/src/passwd.rs
@@ -204,6 +204,12 @@ pub fn write_passwd_with_layout<W: Write>(
     })
 }
 
+impl crate::transaction::Record for PasswdEntry {
+    fn validate_fields(&self) -> Result<(), ShadowError> {
+        Self::validate_fields(self)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/shadow-core/src/shadow.rs
+++ b/src/shadow-core/src/shadow.rs
@@ -315,6 +315,12 @@ pub fn write_shadow_with_layout<W: Write>(
     })
 }
 
+impl crate::transaction::Record for ShadowEntry {
+    fn validate_fields(&self) -> Result<(), ShadowError> {
+        Self::validate_fields(self)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/shadow-core/src/subid.rs
+++ b/src/shadow-core/src/subid.rs
@@ -165,6 +165,12 @@ pub fn write_subid_with_layout<W: Write>(
     })
 }
 
+impl crate::transaction::Record for SubIdEntry {
+    fn validate_fields(&self) -> Result<(), ShadowError> {
+        Self::validate_fields(self)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/shadow-core/src/transaction.rs
+++ b/src/shadow-core/src/transaction.rs
@@ -1,0 +1,347 @@
+// This file is part of the shadow-rs package.
+//
+// For the full copyright and license information, please view the LICENSE
+// file that was distributed with this source code.
+
+//! A record file held under its lock for the duration of a change.
+//!
+//! Every tool repeats the same five steps: take the lock, read under it,
+//! change the entries, write atomically, release. Written out by hand at each
+//! of the thirty-odd call sites, the order is easy to get wrong, and it was:
+//! `pwck -s` sorted entries it had read *before* taking the lock, so a change
+//! another process made in between was silently reverted.
+//!
+//! [`LockedFile`] makes the correct order the only one available. `open` locks
+//! and then reads; `entries_mut` hands out the data; `commit` validates,
+//! writes atomically and releases; dropping without committing releases
+//! without writing. There is no way to read outside the lock or write after
+//! releasing it, because neither is expressible.
+//!
+//! Signals are blocked for the lifetime of the value. A `SIGINT` between
+//! acquiring the lock and finishing the write would otherwise leave a stale
+//! lock file behind, which every later run has to wait out.
+
+use std::fmt::Display;
+use std::path::{Path, PathBuf};
+use std::str::FromStr;
+
+use crate::atomic;
+use crate::error::ShadowError;
+use crate::hardening::SignalBlocker;
+use crate::lock::FileLock;
+use crate::records::{self, Layout, Named};
+
+/// A record type a [`LockedFile`] can read, change and write back.
+///
+/// The three halves of the format in one place: parsing, rendering, and the
+/// check that a value cannot corrupt the record it is written into.
+pub trait Record: FromStr<Err = ShadowError> + Display + Named {
+    /// Reject a field value that would break the file format.
+    ///
+    /// # Errors
+    ///
+    /// Returns `ShadowError::Validation` naming the offending field.
+    fn validate_fields(&self) -> Result<(), ShadowError>;
+}
+
+/// A record file, locked, read, and waiting to be written back.
+///
+/// Dropping this without calling [`LockedFile::commit`] releases the lock and
+/// leaves the file untouched, which is what every error path wants.
+pub struct LockedFile<T> {
+    path: PathBuf,
+    /// Taken in `open`, released by `commit` or by `Drop`.
+    lock: Option<FileLock>,
+    entries: Vec<T>,
+    layout: Layout,
+    /// Restores the signal mask when the transaction ends, whichever way.
+    _signals: SignalBlocker,
+}
+
+impl<T: Record> LockedFile<T> {
+    /// Lock `path`, then read it.
+    ///
+    /// In that order: reading first and locking afterwards leaves a window in
+    /// which another process can change the file, and the change is then lost
+    /// when this one writes.
+    ///
+    /// # Errors
+    ///
+    /// Returns `ShadowError::Lock` if the lock cannot be taken within the
+    /// timeout, and `ShadowError::Parse` or `ShadowError::IoPath` if the file
+    /// cannot be read.
+    pub fn open(path: &Path) -> Result<Self, ShadowError> {
+        let signals = SignalBlocker::block_critical()?;
+        let lock = FileLock::acquire(path)?;
+        // On any failure from here on, `lock` drops and the file is untouched.
+        let (entries, layout) = records::read_with_layout::<T>(path)?;
+        Ok(Self {
+            path: path.to_owned(),
+            lock: Some(lock),
+            entries,
+            layout,
+            _signals: signals,
+        })
+    }
+
+    /// Like [`LockedFile::open`], but a file that does not exist reads as
+    /// empty instead of failing.
+    ///
+    /// For the tools that create a record file where there was none -- a
+    /// `groupadd` into a fresh `--prefix` tree, for instance. `open` stays
+    /// strict on purpose: for `passwd` and `chage` a missing `/etc/shadow` is
+    /// its own error with its own exit code, and reading it as "no accounts"
+    /// would report every login as unknown instead.
+    ///
+    /// The lock is still taken first, so two processes cannot both decide the
+    /// file is absent and both create it.
+    ///
+    /// # Errors
+    ///
+    /// As [`LockedFile::open`], except that a missing file is not an error.
+    pub fn open_or_empty(path: &Path) -> Result<Self, ShadowError> {
+        let signals = SignalBlocker::block_critical()?;
+        let lock = FileLock::acquire(path)?;
+        let (entries, layout) = if path.exists() {
+            records::read_with_layout::<T>(path)?
+        } else {
+            (Vec::new(), Layout::default())
+        };
+        Ok(Self {
+            path: path.to_owned(),
+            lock: Some(lock),
+            entries,
+            layout,
+            _signals: signals,
+        })
+    }
+
+    /// The entries as read, in file order.
+    #[must_use]
+    pub fn entries(&self) -> &[T] {
+        &self.entries
+    }
+
+    /// The entries, to be changed before committing.
+    pub fn entries_mut(&mut self) -> &mut Vec<T> {
+        &mut self.entries
+    }
+
+    /// The entry with this name, if the file has one.
+    #[must_use]
+    pub fn find(&self, name: &str) -> Option<&T> {
+        self.entries.iter().find(|e| e.name() == name)
+    }
+
+    /// The entry with this name, to be changed.
+    pub fn find_mut(&mut self, name: &str) -> Option<&mut T> {
+        self.entries.iter_mut().find(|e| e.name() == name)
+    }
+
+    /// The path this transaction is against.
+    #[must_use]
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    /// Validate every entry, write the file atomically, and release the lock.
+    ///
+    /// The comments, blank lines and NIS compatibility lines the file carried
+    /// are put back where they were, each still attached to the entry it
+    /// preceded.
+    ///
+    /// # Errors
+    ///
+    /// Returns `ShadowError::Validation` if an entry holds a value that would
+    /// corrupt the record -- in which case nothing is written -- and
+    /// `ShadowError::IoPath` if the write fails.
+    pub fn commit(mut self) -> Result<(), ShadowError> {
+        let entries = &self.entries;
+        let layout = &self.layout;
+        let result = atomic::atomic_write(&self.path, |mut file| {
+            // `write_with_layout` takes `&mut W`, and `atomic_write` hands over
+            // a `&mut dyn Write`; borrowing it again makes `W` the fat pointer,
+            // which is sized, rather than the unsized `dyn Write`.
+            records::write_with_layout(entries, layout, &mut file, |entry, w| {
+                entry.validate_fields()?;
+                writeln!(w, "{entry}")?;
+                Ok(())
+            })
+        });
+
+        // Release before returning either way: an error path that held the
+        // lock until the process exited would block every concurrent tool for
+        // as long as the caller took to report it.
+        drop(self.lock.take());
+        result
+    }
+
+    /// Like [`LockedFile::commit`], but remove the file when nothing is left
+    /// in it.
+    ///
+    /// For `/etc/group`, `/etc/gshadow` and the subid files an absent file and
+    /// an empty one mean the same thing, and the atomic writer refuses to
+    /// produce a zero-length file: a truncated account file is a far more
+    /// common failure than a deliberately empty one, so it is treated as a
+    /// bug. Deleting the last group therefore has to unlink.
+    ///
+    /// Not for `/etc/passwd` or `/etc/shadow`, where an empty file is not a
+    /// state anyone wants to reach by accident; those use `commit`.
+    ///
+    /// The file is only removed when it carried no comments or other preserved
+    /// lines either. A file that is all comments still says something.
+    ///
+    /// # Errors
+    ///
+    /// As [`LockedFile::commit`], plus `ShadowError::IoPath` if the file
+    /// cannot be removed.
+    pub fn commit_or_remove(mut self) -> Result<(), ShadowError> {
+        if !self.entries.is_empty() || !self.layout.is_empty() {
+            return self.commit();
+        }
+        let result = std::fs::remove_file(&self.path).or_else(|e| {
+            // Already gone is the state we wanted.
+            if e.kind() == std::io::ErrorKind::NotFound {
+                Ok(())
+            } else {
+                Err(ShadowError::IoPath(e, self.path.clone()))
+            }
+        });
+        drop(self.lock.take());
+        result
+    }
+
+    /// Release the lock and discard the changes.
+    ///
+    /// The same as dropping the value; useful where the intent is worth
+    /// stating.
+    pub fn abandon(self) {
+        drop(self);
+    }
+}
+
+impl<T> Drop for LockedFile<T> {
+    fn drop(&mut self) {
+        // `commit` has already taken it; this covers every other exit.
+        drop(self.lock.take());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::passwd::PasswdEntry;
+
+    fn temp_passwd(content: &str) -> (tempfile::TempDir, PathBuf) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("passwd");
+        std::fs::write(&path, content).expect("write");
+        (dir, path)
+    }
+
+    const TWO: &str = "alice:x:1000:1000::/home/alice:/bin/sh\n\
+                       bob:x:1001:1001::/home/bob:/bin/sh\n";
+
+    #[test]
+    fn test_commit_writes_the_changes() {
+        let (_d, path) = temp_passwd(TWO);
+        let mut file = LockedFile::<PasswdEntry>::open(&path).expect("open");
+        file.find_mut("alice").expect("alice").shell = "/bin/bash".into();
+        file.commit().expect("commit");
+
+        let content = std::fs::read_to_string(&path).expect("read");
+        assert!(content.contains("alice:x:1000:1000::/home/alice:/bin/bash"));
+        assert!(content.contains("bob:x:1001:1001::/home/bob:/bin/sh"));
+    }
+
+    /// Every error path wants this: the file is left exactly as it was.
+    #[test]
+    fn test_dropping_without_committing_changes_nothing() {
+        let (_d, path) = temp_passwd(TWO);
+        {
+            let mut file = LockedFile::<PasswdEntry>::open(&path).expect("open");
+            file.find_mut("alice").expect("alice").shell = "/bin/bash".into();
+            // No commit.
+        }
+        assert_eq!(std::fs::read_to_string(&path).expect("read"), TWO);
+    }
+
+    /// And the lock is gone afterwards, so the next transaction can start.
+    #[test]
+    fn test_the_lock_is_released_either_way() {
+        let (_d, path) = temp_passwd(TWO);
+        drop(LockedFile::<PasswdEntry>::open(&path).expect("first open"));
+        LockedFile::<PasswdEntry>::open(&path)
+            .expect("a released lock must be takeable again")
+            .commit()
+            .expect("commit");
+        LockedFile::<PasswdEntry>::open(&path).expect("still takeable after a commit");
+    }
+
+    /// A value that would corrupt the record stops the write; the file keeps
+    /// its previous contents rather than half of them.
+    #[test]
+    fn test_an_invalid_entry_aborts_the_write() {
+        let (_d, path) = temp_passwd(TWO);
+        let mut file = LockedFile::<PasswdEntry>::open(&path).expect("open");
+        file.find_mut("alice").expect("alice").gecos = "has:a:separator".into();
+        assert!(file.commit().is_err(), "a colon in a field must be refused");
+        assert_eq!(std::fs::read_to_string(&path).expect("read"), TWO);
+    }
+
+    /// Comments and blank lines survive a change, still attached to the entry
+    /// they preceded.
+    #[test]
+    fn test_layout_is_preserved() {
+        let text = "# the first account\nalice:x:1000:1000::/home/alice:/bin/sh\n\n# and bob\nbob:x:1001:1001::/home/bob:/bin/sh\n";
+        let (_d, path) = temp_passwd(text);
+        let mut file = LockedFile::<PasswdEntry>::open(&path).expect("open");
+        file.find_mut("bob").expect("bob").shell = "/bin/bash".into();
+        file.commit().expect("commit");
+
+        let content = std::fs::read_to_string(&path).expect("read");
+        assert_eq!(
+            content,
+            "# the first account\nalice:x:1000:1000::/home/alice:/bin/sh\n\n# and bob\nbob:x:1001:1001::/home/bob:/bin/bash\n"
+        );
+    }
+
+    #[test]
+    fn test_entries_are_read_in_file_order() {
+        let (_d, path) = temp_passwd(TWO);
+        let file = LockedFile::<PasswdEntry>::open(&path).expect("open");
+        let names: Vec<&str> = file.entries().iter().map(|e| e.name.as_str()).collect();
+        assert_eq!(names, ["alice", "bob"]);
+        assert!(file.find("ghost").is_none());
+    }
+
+    #[test]
+    fn test_adding_and_removing_entries() {
+        let (_d, path) = temp_passwd(TWO);
+        let mut file = LockedFile::<PasswdEntry>::open(&path).expect("open");
+        file.entries_mut().retain(|e| e.name != "bob");
+        file.entries_mut().push(PasswdEntry {
+            name: "carol".into(),
+            passwd: "x".into(),
+            uid: 1002,
+            gid: 1002,
+            gecos: String::new(),
+            home: "/home/carol".into(),
+            shell: "/bin/sh".into(),
+        });
+        file.commit().expect("commit");
+
+        let content = std::fs::read_to_string(&path).expect("read");
+        assert!(content.contains("alice:"));
+        assert!(!content.contains("bob:"));
+        assert!(content.contains("carol:x:1002:1002::/home/carol:/bin/sh"));
+    }
+
+    /// A file that does not parse is an error at `open`, before anything is
+    /// changed, rather than a silent loss of the lines that failed.
+    #[test]
+    fn test_a_malformed_file_fails_to_open() {
+        let (_d, path) = temp_passwd("alice:x:1000:1000::/home/alice:/bin/sh\nnot-a-record\n");
+        assert!(LockedFile::<PasswdEntry>::open(&path).is_err());
+    }
+}

--- a/src/uu/chage/src/chage.rs
+++ b/src/uu/chage/src/chage.rs
@@ -15,10 +15,10 @@ use std::path::Path;
 use clap::{Arg, ArgAction, Command};
 
 use shadow_core::date;
-use shadow_core::lock::FileLock;
+use shadow_core::nscd;
 use shadow_core::shadow::{self, ShadowEntry};
 use shadow_core::sysroot::SysRoot;
-use shadow_core::{atomic, nscd};
+use shadow_core::transaction::LockedFile;
 
 use uucore::error::{UError, UResult};
 
@@ -480,76 +480,46 @@ fn inactive_display(
 
 /// Lock the shadow file, read entries, apply a mutation to one user's entry,
 /// write back atomically, invalidate nscd cache.
+/// Map a failure to start the transaction onto chage(1)'s exit codes.
+///
+/// A file another process holds is exit 5, distinct from a file that cannot be
+/// read at all, which is 15. Collapsing the two would report a transient
+/// contention as a missing shadow file.
+fn open_error(e: shadow_core::error::ShadowError, path: &Path) -> ChageError {
+    match e {
+        shadow_core::error::ShadowError::Lock(_) => {
+            ChageError::FileBusy(format!("cannot lock {}: try again later", path.display()))
+        }
+        other => ChageError::ShadowNotFound(format!("Cannot open {}: {other}", path.display())),
+    }
+}
+
 fn mutate_shadow<F>(root: &SysRoot, username: &str, mutate: F) -> UResult<()>
 where
     F: FnOnce(&mut ShadowEntry) -> Result<(), String>,
 {
-    // Consolidate real + effective UID to root for file operations.
-    // Some filesystem configurations check real UID.
-    if rustix::process::geteuid().is_root() {
-        let _ = shadow_core::process::setuid(0);
-    }
-
-    // Block signals for the entire critical section (lock -> write -> unlock).
-    let _signals = shadow_core::hardening::SignalBlocker::block_critical()
-        .map_err(|e| ChageError::UnexpectedFailure(e.to_string()))?;
-
+    // euid 0 is all the lock and the atomic write need; setuid(0) would also
+    // raise the real uid, after which caller_is_root() answers true for
+    // everyone for the rest of the process.
     let shadow_path = root.shadow_path();
 
-    // Acquire lock.
-    let lock = FileLock::acquire(&shadow_path).map_err(|_| {
-        ChageError::FileBusy(format!(
-            "cannot lock {}: try again later",
-            shadow_path.display()
-        ))
-    })?;
+    // The transaction locks, then reads, and releases on every path out --
+    // including the error returns below, where the file is left untouched.
+    let mut shadow =
+        LockedFile::<ShadowEntry>::open(&shadow_path).map_err(|e| open_error(e, &shadow_path))?;
 
-    // Read current entries.
-    let (mut entries, layout) = match shadow::read_shadow_with_layout(&shadow_path) {
-        Ok(e) => e,
-        Err(e) => {
-            drop(lock);
-            return Err(ChageError::ShadowNotFound(format!(
-                "Cannot open {}: {e}",
-                shadow_path.display()
-            ))
-            .into());
-        }
-    };
-
-    // Find the target user.
-    let Some(entry) = entries.iter_mut().find(|e| e.name == username) else {
-        drop(lock);
+    let Some(entry) = shadow.find_mut(username) else {
         return Err(ChageError::UserNotFound(format!(
             "user '{username}' does not exist in {}",
             shadow_path.display()
         ))
         .into());
     };
+    mutate(entry).map_err(ChageError::UnexpectedFailure)?;
 
-    // Apply the mutation.
-    if let Err(msg) = mutate(entry) {
-        drop(lock);
-        return Err(ChageError::UnexpectedFailure(msg).into());
-    }
-
-    // Write back atomically.
-    let write_result = atomic::atomic_write(&shadow_path, |file| {
-        shadow::write_shadow_with_layout(&entries, &layout, file)?;
-        Ok(())
-    });
-
-    if let Err(e) = write_result {
-        drop(lock);
-        return Err(ChageError::UnexpectedFailure(format!(
-            "failed to write {}: {e}",
-            shadow_path.display()
-        ))
-        .into());
-    }
-
-    // Release lock and invalidate caches.
-    drop(lock);
+    shadow.commit().map_err(|e| {
+        ChageError::UnexpectedFailure(format!("failed to write {}: {e}", shadow_path.display()))
+    })?;
     nscd::invalidate_cache("shadow");
 
     Ok(())

--- a/src/uu/chfn/src/chfn.rs
+++ b/src/uu/chfn/src/chfn.rs
@@ -14,10 +14,10 @@ use std::io::Write as _;
 
 use clap::{Arg, ArgAction, Command};
 
-use shadow_core::lock::FileLock;
+use shadow_core::nscd;
 use shadow_core::passwd::{self, PasswdEntry};
 use shadow_core::sysroot::SysRoot;
-use shadow_core::{atomic, nscd};
+use shadow_core::transaction::LockedFile;
 
 use uucore::error::{UError, UResult};
 
@@ -325,58 +325,27 @@ where
     // euid 0 is all the lock and the atomic write need. Calling setuid(0)
     // here would also change the *real* uid, after which caller_is_root() --
     // which is deliberately real-uid based -- would answer true for everyone.
-
-    let _signals = shadow_core::hardening::SignalBlocker::block_critical()
-        .map_err(|e| ChfnError::Error(e.to_string()))?;
-
     let passwd_path = root.passwd_path();
 
-    let lock = FileLock::acquire(&passwd_path).map_err(|_| {
-        ChfnError::Error(format!(
-            "cannot lock {}: try again later",
-            passwd_path.display()
-        ))
-    })?;
+    // The transaction locks, then reads, and releases on every path out --
+    // including the two error returns below, where the file is left untouched.
+    let mut passwd = LockedFile::<PasswdEntry>::open(&passwd_path)
+        .map_err(|e| ChfnError::Error(format!("cannot open {}: {e}", passwd_path.display())))?;
 
-    let (mut entries, layout) = match passwd::read_passwd_with_layout(&passwd_path) {
-        Ok(e) => e,
-        Err(e) => {
-            drop(lock);
-            return Err(
-                ChfnError::Error(format!("cannot read {}: {e}", passwd_path.display())).into(),
-            );
-        }
-    };
-
-    let Some(entry) = entries.iter_mut().find(|e| e.name == username) else {
-        drop(lock);
+    let Some(entry) = passwd.find_mut(username) else {
         return Err(ChfnError::Error(format!(
             "user '{username}' does not exist in {}",
             passwd_path.display()
         ))
         .into());
     };
+    mutate(entry).map_err(ChfnError::Error)?;
 
-    if let Err(msg) = mutate(entry) {
-        drop(lock);
-        return Err(ChfnError::Error(msg).into());
-    }
+    passwd
+        .commit()
+        .map_err(|e| ChfnError::Error(format!("failed to write {}: {e}", passwd_path.display())))?;
 
-    let write_result = atomic::atomic_write(&passwd_path, |file| {
-        passwd::write_passwd_with_layout(&entries, &layout, file)?;
-        Ok(())
-    });
-
-    if let Err(e) = write_result {
-        drop(lock);
-        return Err(
-            ChfnError::Error(format!("failed to write {}: {e}", passwd_path.display())).into(),
-        );
-    }
-
-    drop(lock);
     nscd::invalidate_cache("passwd");
-
     Ok(())
 }
 

--- a/src/uu/chpasswd/src/chpasswd.rs
+++ b/src/uu/chpasswd/src/chpasswd.rs
@@ -15,10 +15,10 @@ use std::path::Path;
 
 use clap::{Arg, ArgAction, Command};
 
-use shadow_core::lock::FileLock;
-use shadow_core::shadow::{self};
+use shadow_core::nscd;
+use shadow_core::shadow::ShadowEntry;
 use shadow_core::sysroot::SysRoot;
-use shadow_core::{atomic, nscd};
+use shadow_core::transaction::LockedFile;
 
 use uucore::error::{UError, UResult};
 
@@ -359,41 +359,30 @@ fn apply_password_changes(
         hashed.push((pair.username.as_str(), hash));
     }
 
-    // Block signals for the entire critical section.
-    let _signals = shadow_core::hardening::SignalBlocker::block_critical()
-        .map_err(|e| ChpasswdError::UnexpectedFailure(e.to_string()))?;
-
     let shadow_path = root.shadow_path();
 
-    // Acquire lock.
-    let lock = FileLock::acquire(&shadow_path).map_err(|_| {
-        ChpasswdError::FileBusy(format!(
+    // The transaction locks, then reads, and releases on every path out --
+    // including the error returns below, where the file is left untouched.
+    let mut shadow = LockedFile::<ShadowEntry>::open(&shadow_path).map_err(|e| match e {
+        shadow_core::error::ShadowError::Lock(_) => ChpasswdError::FileBusy(format!(
             "cannot lock {}: try again later",
             shadow_path.display()
-        ))
+        )),
+        other => ChpasswdError::UnexpectedFailure(format!(
+            "Cannot open {}: {other}",
+            shadow_path.display()
+        )),
     })?;
-
-    // Read current entries.
-    let (mut entries, layout) = match shadow::read_shadow_with_layout(&shadow_path) {
-        Ok(e) => e,
-        Err(e) => {
-            drop(lock);
-            return Err(ChpasswdError::UnexpectedFailure(format!(
-                "Cannot open {}: {e}",
-                shadow_path.display()
-            ))
-            .into());
-        }
-    };
 
     let today = days_since_epoch()?;
 
     // Index by name once. A linear scan per pair made the critical section --
     // held with signals blocked -- quadratic in a batch the size of the file.
-    let index: std::collections::HashMap<&str, usize> = entries
+    let index: std::collections::HashMap<String, usize> = shadow
+        .entries()
         .iter()
         .enumerate()
-        .map(|(i, e)| (e.name.as_str(), i))
+        .map(|(i, e)| (e.name.clone(), i))
         .collect();
 
     // Resolve every pair before writing any, so an unknown account in the
@@ -401,7 +390,6 @@ fn apply_password_changes(
     let mut targets = Vec::with_capacity(hashed.len());
     for (username, hash) in hashed {
         let Some(&i) = index.get(username) else {
-            drop(lock);
             return Err(ChpasswdError::InvalidInput(format!(
                 "user '{username}' does not exist in {}",
                 shadow_path.display()
@@ -412,8 +400,7 @@ fn apply_password_changes(
     }
 
     for (i, hash) in targets {
-        let Some(entry) = entries.get_mut(i) else {
-            drop(lock);
+        let Some(entry) = shadow.entries_mut().get_mut(i) else {
             return Err(ChpasswdError::UnexpectedFailure(
                 "shadow entry vanished between indexing and writing".into(),
             )
@@ -423,23 +410,10 @@ fn apply_password_changes(
         entry.last_change = Some(today);
     }
 
-    // Write back atomically.
-    let write_result = atomic::atomic_write(&shadow_path, |file| {
-        shadow::write_shadow_with_layout(&entries, &layout, file)?;
-        Ok(())
-    });
+    shadow.commit().map_err(|e| {
+        ChpasswdError::UnexpectedFailure(format!("failed to write {}: {e}", shadow_path.display()))
+    })?;
 
-    if let Err(e) = write_result {
-        drop(lock);
-        return Err(ChpasswdError::UnexpectedFailure(format!(
-            "failed to write {}: {e}",
-            shadow_path.display()
-        ))
-        .into());
-    }
-
-    // Release lock and invalidate caches.
-    drop(lock);
     nscd::invalidate_cache("shadow");
 
     Ok(())

--- a/src/uu/chsh/src/chsh.rs
+++ b/src/uu/chsh/src/chsh.rs
@@ -15,10 +15,10 @@ use std::path::Path;
 
 use clap::{Arg, ArgAction, Command};
 
-use shadow_core::lock::FileLock;
+use shadow_core::nscd;
 use shadow_core::passwd::{self, PasswdEntry};
 use shadow_core::sysroot::SysRoot;
-use shadow_core::{atomic, nscd};
+use shadow_core::transaction::LockedFile;
 
 use uucore::error::{UError, UResult};
 
@@ -214,58 +214,27 @@ where
     // euid 0 is all the lock and the atomic write need. setuid(0) would also
     // change the *real* uid, after which caller_is_root() -- deliberately real
     // uid based -- would answer true for every caller.
-
-    let _signals = shadow_core::hardening::SignalBlocker::block_critical()
-        .map_err(|e| ChshError::Error(e.to_string()))?;
-
     let passwd_path = root.passwd_path();
 
-    let lock = FileLock::acquire(&passwd_path).map_err(|_| {
-        ChshError::Error(format!(
-            "cannot lock {}: try again later",
-            passwd_path.display()
-        ))
-    })?;
+    // The transaction locks, then reads, and releases on every path out --
+    // including the error returns below, where the file is left untouched.
+    let mut passwd = LockedFile::<PasswdEntry>::open(&passwd_path)
+        .map_err(|e| ChshError::Error(format!("cannot open {}: {e}", passwd_path.display())))?;
 
-    let (mut entries, layout) = match passwd::read_passwd_with_layout(&passwd_path) {
-        Ok(e) => e,
-        Err(e) => {
-            drop(lock);
-            return Err(
-                ChshError::Error(format!("cannot read {}: {e}", passwd_path.display())).into(),
-            );
-        }
-    };
-
-    let Some(entry) = entries.iter_mut().find(|e| e.name == username) else {
-        drop(lock);
+    let Some(entry) = passwd.find_mut(username) else {
         return Err(ChshError::Error(format!(
             "user '{username}' does not exist in {}",
             passwd_path.display()
         ))
         .into());
     };
+    mutate(entry).map_err(ChshError::Error)?;
 
-    if let Err(msg) = mutate(entry) {
-        drop(lock);
-        return Err(ChshError::Error(msg).into());
-    }
+    passwd
+        .commit()
+        .map_err(|e| ChshError::Error(format!("failed to write {}: {e}", passwd_path.display())))?;
 
-    let write_result = atomic::atomic_write(&passwd_path, |file| {
-        passwd::write_passwd_with_layout(&entries, &layout, file)?;
-        Ok(())
-    });
-
-    if let Err(e) = write_result {
-        drop(lock);
-        return Err(
-            ChshError::Error(format!("failed to write {}: {e}", passwd_path.display())).into(),
-        );
-    }
-
-    drop(lock);
     nscd::invalidate_cache("passwd");
-
     Ok(())
 }
 

--- a/src/uu/groupadd/src/groupadd.rs
+++ b/src/uu/groupadd/src/groupadd.rs
@@ -14,14 +14,13 @@ use std::path::Path;
 use clap::{Arg, ArgAction, Command};
 use uucore::error::{UError, UResult};
 
-use shadow_core::atomic;
 use shadow_core::audit;
-use shadow_core::group::{self, GroupEntry};
-use shadow_core::gshadow::{self, GshadowEntry};
-use shadow_core::lock::FileLock;
+use shadow_core::group::GroupEntry;
+use shadow_core::gshadow::GshadowEntry;
 use shadow_core::login_defs::{self, LoginDefs};
 use shadow_core::nscd;
 use shadow_core::sysroot::SysRoot;
+use shadow_core::transaction::LockedFile;
 use shadow_core::uid_alloc;
 use shadow_core::validate;
 
@@ -168,26 +167,16 @@ fn do_groupadd(matches: &clap::ArgMatches) -> UResult<()> {
 
     let group_path = root.group_path();
 
-    // Block signals for the duration of the critical section so a SIGINT
-    // between lock acquisition and atomic_write cannot leave stale lock files.
-    let _signals = shadow_core::hardening::SignalBlocker::block_critical()
-        .map_err(|e| GroupaddError::CantUpdate(format!("cannot block signals: {e}")))?;
-
-    // Take the lock *before* reading. The name check and the GID allocation
-    // used to run on a snapshot taken beforehand, so two concurrent
-    // `groupadd -r` calls could allocate the same GID, and two `groupadd www`
-    // could both decide the name was free.
-    let group_lock = FileLock::acquire(&group_path).map_err(|e| {
-        GroupaddError::CantUpdate(format!("cannot lock {}: {e}", group_path.display()))
+    // The transaction locks *before* reading, and blocks signals for its
+    // lifetime. The name check and the GID allocation used to run on a
+    // snapshot taken beforehand, so two concurrent `groupadd -r` calls could
+    // allocate the same GID and two `groupadd www` could both decide the name
+    // was free. A group file that does not exist yet reads as empty: a fresh
+    // --prefix tree has none.
+    let mut groups = LockedFile::<GroupEntry>::open_or_empty(&group_path).map_err(|e| {
+        GroupaddError::CantUpdate(format!("cannot open {}: {e}", group_path.display()))
     })?;
-
-    let (existing_groups, group_layout) = if group_path.exists() {
-        group::read_group_with_layout(&group_path).map_err(|e| {
-            GroupaddError::CantUpdate(format!("cannot read {}: {e}", group_path.display()))
-        })?
-    } else {
-        (Vec::new(), group::Layout::default())
-    };
+    let existing_groups = groups.entries().to_vec();
 
     // Check if group name already exists.
     if existing_groups.iter().any(|g| g.name == group_name) {
@@ -214,15 +203,15 @@ fn do_groupadd(matches: &clap::ArgMatches) -> UResult<()> {
     )?;
 
     // Write to /etc/group.
-    write_group_entry(
-        &group_path,
-        existing_groups,
-        &group_layout,
-        &group_name,
+    groups.entries_mut().push(GroupEntry {
+        name: group_name.clone(),
+        passwd: "x".to_string(),
         gid,
-        &users,
-    )?;
-    drop(group_lock);
+        members: users.clone(),
+    });
+    groups.commit().map_err(|e| {
+        GroupaddError::CantUpdate(format!("cannot write {}: {e}", group_path.display()))
+    })?;
 
     // Write to /etc/gshadow.
     write_gshadow_entry(&root.gshadow_path(), &group_name, &password, &users)?;
@@ -267,32 +256,6 @@ fn determine_gid(
     }
 }
 
-/// Append a new group entry to /etc/group.
-fn write_group_entry(
-    group_path: &Path,
-    mut entries: Vec<GroupEntry>,
-    layout: &group::Layout,
-    name: &str,
-    gid: u32,
-    members: &[String],
-) -> Result<(), GroupaddError> {
-    entries.push(GroupEntry {
-        name: name.to_string(),
-        passwd: "x".to_string(),
-        gid,
-        members: members.to_vec(),
-    });
-
-    atomic::atomic_write(group_path, |f| {
-        group::write_group_with_layout(&entries, layout, f)
-    })
-    .map_err(|e| {
-        GroupaddError::CantUpdate(format!("cannot write {}: {e}", group_path.display()))
-    })?;
-
-    Ok(())
-}
-
 /// Append a new gshadow entry if /etc/gshadow exists.
 fn write_gshadow_entry(
     gshadow_path: &Path,
@@ -311,25 +274,13 @@ fn write_gshadow_entry(
         members: members.to_vec(),
     };
 
-    let gshadow_lock = FileLock::acquire(gshadow_path).map_err(|e| {
-        GroupaddError::CantUpdate(format!("cannot lock {}: {e}", gshadow_path.display()))
+    let mut gshadow = LockedFile::<GshadowEntry>::open(gshadow_path).map_err(|e| {
+        GroupaddError::CantUpdate(format!("cannot open {}: {e}", gshadow_path.display()))
     })?;
-
-    let (mut gs_entries, gshadow_layout) = gshadow::read_gshadow_with_layout(gshadow_path)
-        .map_err(|e| {
-            GroupaddError::CantUpdate(format!("cannot read {}: {e}", gshadow_path.display()))
-        })?;
-    gs_entries.push(new_gshadow);
-
-    atomic::atomic_write(gshadow_path, |f| {
-        gshadow::write_gshadow_with_layout(&gs_entries, &gshadow_layout, f)
-    })
-    .map_err(|e| {
+    gshadow.entries_mut().push(new_gshadow);
+    gshadow.commit().map_err(|e| {
         GroupaddError::CantUpdate(format!("cannot write {}: {e}", gshadow_path.display()))
-    })?;
-
-    drop(gshadow_lock);
-    Ok(())
+    })
 }
 
 /// Allocate the next available GID from login.defs ranges.

--- a/src/uu/groupdel/src/groupdel.rs
+++ b/src/uu/groupdel/src/groupdel.rs
@@ -14,14 +14,13 @@ use std::path::Path;
 use clap::{Arg, Command};
 use uucore::error::{UError, UResult};
 
-use shadow_core::atomic;
 use shadow_core::audit;
-use shadow_core::group::{self, GroupEntry};
-use shadow_core::gshadow::{self, GshadowEntry};
-use shadow_core::lock::FileLock;
+use shadow_core::group::GroupEntry;
+use shadow_core::gshadow::GshadowEntry;
 use shadow_core::nscd;
 use shadow_core::passwd;
 use shadow_core::sysroot::SysRoot;
+use shadow_core::transaction::LockedFile;
 
 mod options {
     pub const GROUP: &str = "GROUP";
@@ -108,24 +107,16 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let prefix = matches.get_one::<String>(options::PREFIX).map(Path::new);
     let root = SysRoot::new(prefix);
 
-    // Block signals for the duration of the critical section so a SIGINT
-    // between lock acquisition and atomic_write cannot leave stale lock files.
-    let _signals = shadow_core::hardening::SignalBlocker::block_critical()
-        .map_err(|e| GroupdelError::CantUpdate(format!("cannot block signals: {e}")))?;
-
-    // Read existing groups to find the target.
+    // The transaction locks, then reads, and blocks signals for its lifetime,
+    // so a SIGINT between the lock and the write cannot leave a stale lock.
     let group_path = root.group_path();
-    let group_lock = FileLock::acquire(&group_path).map_err(|e| {
-        GroupdelError::CantUpdate(format!("cannot lock {}: {e}", group_path.display()))
-    })?;
-
-    let (entries, group_layout) = group::read_group_with_layout(&group_path).map_err(|e| {
-        GroupdelError::CantUpdate(format!("cannot read {}: {e}", group_path.display()))
+    let mut groups = LockedFile::<GroupEntry>::open(&group_path).map_err(|e| {
+        GroupdelError::CantUpdate(format!("cannot open {}: {e}", group_path.display()))
     })?;
 
     let force = matches.get_flag(options::FORCE);
 
-    let Some(target) = entries.iter().find(|g| g.name == *group_name) else {
+    let Some(target) = groups.find(group_name) else {
         // groupdel(8) -f: "succeed even if the group does not exist".
         if force {
             return Ok(());
@@ -146,7 +137,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         })?;
 
         if let Some(user) = passwd_entries.iter().find(|u| u.gid == target_gid) {
-            drop(group_lock);
+            // `groups` drops here, releasing the lock with the file untouched.
             return Err(GroupdelError::PrimaryGroup(format!(
                 "cannot remove the primary group of user '{}'",
                 user.name
@@ -155,63 +146,25 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         }
     }
 
-    // Remove the group entry.
-    let new_entries: Vec<GroupEntry> = entries
-        .into_iter()
-        .filter(|g| g.name != *group_name)
-        .collect();
-
-    // Removing the last group empties the file, which the atomic writer
-    // refuses; an absent group file means the same thing and is only reached
-    // in a fully torn-down --prefix tree.
-    if new_entries.is_empty() && group_layout.is_empty() {
-        let _ = std::fs::remove_file(&group_path);
-    } else {
-        atomic::atomic_write(&group_path, |f| {
-            group::write_group_with_layout(&new_entries, &group_layout, f)
-        })
-        .map_err(|e| {
-            GroupdelError::CantUpdate(format!("cannot write {}: {e}", group_path.display()))
-        })?;
-    }
-
-    drop(group_lock);
+    // Remove the group entry. Removing the last one empties the file, and an
+    // absent group file means the same thing as an empty one, so the
+    // transaction unlinks rather than writing a zero-length file the atomic
+    // writer would refuse.
+    groups.entries_mut().retain(|g| g.name != *group_name);
+    groups.commit_or_remove().map_err(|e| {
+        GroupdelError::CantUpdate(format!("cannot write {}: {e}", group_path.display()))
+    })?;
 
     // Remove from /etc/gshadow.
     let gshadow_path = root.gshadow_path();
     if gshadow_path.exists() {
-        let gs_lock = FileLock::acquire(&gshadow_path).map_err(|e| {
-            GroupdelError::CantUpdate(format!("cannot lock {}: {e}", gshadow_path.display()))
+        let mut gshadow = LockedFile::<GshadowEntry>::open(&gshadow_path).map_err(|e| {
+            GroupdelError::CantUpdate(format!("cannot open {}: {e}", gshadow_path.display()))
         })?;
-
-        let (gs_entries, gshadow_layout) = gshadow::read_gshadow_with_layout(&gshadow_path)
-            .map_err(|e| {
-                GroupdelError::CantUpdate(format!("cannot read {}: {e}", gshadow_path.display()))
-            })?;
-
-        let before = gs_entries.len();
-        let new_gs: Vec<GshadowEntry> = gs_entries
-            .into_iter()
-            .filter(|g| g.name != *group_name)
-            .collect();
-        let changed = new_gs.len() != before;
-
-        // Write whenever the removal actually changed something. Skipping an
-        // empty result left the deleted group behind when it was the only
-        // entry; an emptied file is unlinked, since the atomic writer refuses
-        // a zero-length file and an absent gshadow means "no entries".
-        if changed && new_gs.is_empty() {
-            let _ = std::fs::remove_file(&gshadow_path);
-        } else if changed {
-            atomic::atomic_write(&gshadow_path, |f| {
-                gshadow::write_gshadow_with_layout(&new_gs, &gshadow_layout, f)
-            })
-            .map_err(|e| {
-                GroupdelError::CantUpdate(format!("cannot write {}: {e}", gshadow_path.display()))
-            })?;
-        }
-
-        drop(gs_lock);
+        gshadow.entries_mut().retain(|g| g.name != *group_name);
+        gshadow.commit_or_remove().map_err(|e| {
+            GroupdelError::CantUpdate(format!("cannot write {}: {e}", gshadow_path.display()))
+        })?;
     }
 
     nscd::invalidate_cache("group");

--- a/src/uu/passwd/src/passwd.rs
+++ b/src/uu/passwd/src/passwd.rs
@@ -15,10 +15,10 @@ use std::path::Path;
 use clap::{Arg, ArgAction, Command};
 
 use shadow_core::audit;
-use shadow_core::lock::FileLock;
+use shadow_core::nscd;
 use shadow_core::shadow::{self, ShadowEntry};
 use shadow_core::sysroot::SysRoot;
-use shadow_core::{atomic, nscd};
+use shadow_core::transaction::LockedFile;
 
 use uucore::error::{UError, UResult};
 
@@ -661,6 +661,21 @@ fn format_days_since_epoch(days: i64) -> String {
 
 /// Lock the shadow file, read entries, apply a mutation to one user's entry,
 /// write back atomically, invalidate nscd cache.
+/// Map a failure to start the transaction onto passwd(1)'s exit codes.
+///
+/// The three cases stay distinct: another process holding the file is 5, a
+/// missing shadow file is 4, and anything else is 3. Collapsing them would
+/// report transient contention as a missing file.
+fn open_error(e: shadow_core::error::ShadowError, path: &Path) -> PasswdError {
+    match e {
+        shadow_core::error::ShadowError::Lock(_) => {
+            PasswdError::FileBusy(format!("cannot lock {}: try again later", path.display()))
+        }
+        other if !path.exists() => PasswdError::FileMissing(other.to_string()),
+        other => PasswdError::UnexpectedFailure(other.to_string()),
+    }
+}
+
 fn mutate_shadow<F>(
     root: &SysRoot,
     username: &str,
@@ -671,73 +686,29 @@ fn mutate_shadow<F>(
 where
     F: FnOnce(&mut ShadowEntry) -> Result<(), String>,
 {
-    // Consolidate real + effective UID to root for file operations.
-    // Some filesystem configurations check real UID.
-    if rustix::process::geteuid().is_root() {
-        let _ = shadow_core::process::setuid(0);
-    }
-
-    // Block signals for the entire critical section (lock → write → unlock).
-    // The RAII guard restores the original signal mask when this function returns.
-    let _signals = shadow_core::hardening::SignalBlocker::block_critical()
-        .map_err(|e| PasswdError::UnexpectedFailure(e.to_string()))?;
-
+    // euid 0 is all the lock and the atomic write need; setuid(0) would also
+    // raise the real uid, after which caller_is_root() answers true for
+    // everyone for the rest of the process.
     let shadow_path = root.shadow_path();
 
-    // Acquire lock.
-    let lock = FileLock::acquire(&shadow_path).map_err(|_| {
-        PasswdError::FileBusy(format!(
-            "cannot lock {}: try again later",
-            shadow_path.display()
-        ))
-    })?;
+    // The transaction locks, then reads, and releases on every path out --
+    // including the error returns below, where the file is left untouched.
+    let mut shadow =
+        LockedFile::<ShadowEntry>::open(&shadow_path).map_err(|e| open_error(e, &shadow_path))?;
 
-    // Read current entries.
-    let (mut entries, layout) = match shadow::read_shadow_with_layout(&shadow_path) {
-        Ok(e) => e,
-        Err(e) => {
-            drop(lock);
-            return if shadow_path.exists() {
-                Err(PasswdError::UnexpectedFailure(e.to_string()).into())
-            } else {
-                Err(PasswdError::FileMissing(e.to_string()).into())
-            };
-        }
-    };
-
-    // Find the target user.
-    let Some(entry) = entries.iter_mut().find(|e| e.name == username) else {
-        drop(lock);
+    let Some(entry) = shadow.find_mut(username) else {
         return Err(PasswdError::UserNotFound(format!(
             "user '{username}' does not exist in {}",
             shadow_path.display()
         ))
         .into());
     };
+    mutate(entry).map_err(PasswdError::UnexpectedFailure)?;
 
-    // Apply the mutation.
-    if let Err(msg) = mutate(entry) {
-        drop(lock);
-        return Err(PasswdError::UnexpectedFailure(msg).into());
-    }
+    shadow.commit().map_err(|e| {
+        PasswdError::UnexpectedFailure(format!("failed to write {}: {e}", shadow_path.display()))
+    })?;
 
-    // Write back atomically.
-    let write_result = atomic::atomic_write(&shadow_path, |file| {
-        shadow::write_shadow_with_layout(&entries, &layout, file)?;
-        Ok(())
-    });
-
-    if let Err(e) = write_result {
-        drop(lock);
-        return Err(PasswdError::UnexpectedFailure(format!(
-            "failed to write {}: {e}",
-            shadow_path.display()
-        ))
-        .into());
-    }
-
-    // Release lock and invalidate caches.
-    drop(lock);
     nscd::invalidate_cache("shadow");
 
     audit::log_user_event(


### PR DESCRIPTION
Item 2 of #249, for the seven tools that write a single file.

### The problem

Every tool repeats the same five steps: take the lock, read under it, change
the entries, write atomically, release. Written out by hand at each of the
thirty-odd call sites the order is easy to get wrong, **and it was** — `pwck -s`
sorted entries it had read *before* taking the lock, so a change another
process made in between was silently reverted.

### The transaction

`LockedFile` makes the correct order the only one available. `open` locks and
then reads; `entries_mut` hands out the data; `commit` validates, writes
atomically and releases; dropping without committing releases without writing.
Reading outside the lock and writing after releasing it are not expressible.

Signals are blocked for the value's lifetime, so a `SIGINT` between the lock
and the write cannot leave a stale lock file for every later run to wait out.

Two variants earn their place rather than being conveniences:

- **`open_or_empty`** — for a tool that creates a record file where there was
  none, such as `groupadd` into a fresh `--prefix` tree. `open` stays strict,
  because for `passwd` and `chage` a missing `/etc/shadow` is its own error
  with its own exit code, and reading it as "no accounts" would report every
  login as unknown instead.
- **`commit_or_remove`** — for the files where an absent file and an empty one
  mean the same thing: group, gshadow, subid. The atomic writer refuses zero
  length, since a truncated account file is a far more common failure than a
  deliberately empty one, so deleting the last group has to unlink. Not for
  passwd or shadow.

### What changed in the tools

`chfn`, `chsh`, `chage`, `passwd`, `chpasswd`, `groupdel` and `groupadd` use
it, and lose **212 lines** between them.

The exit codes are unchanged. A locked file is still 5 and a missing shadow
file still 4; where the three cases were previously distinguished by which line
happened to fail, they are now mapped explicitly.

### What is not in this change

`groupmod`, `useradd`, `usermod`, `userdel`, `pwck` and `grpck` keep their
hand-written sequences. Each commits several files that have to agree with one
another, which needs a transaction over more than one file — the group and
gshadow pair noted in #245 is the clearest case. That is the rest of this item
and is deliberately separate.

### Verification

```
make check              exit 0
GNU comparison          38 passed, 0 unexpected
Deployment suite        198 passed, 0 failed
```
