### PR TITLE
shadow-core: one generic record reader and writer

### DIFF
--- a/src/shadow-core/src/group.rs
+++ b/src/shadow-core/src/group.rs
@@ -13,7 +13,7 @@
 //! `user_list` is a comma-separated list of usernames.
 
 use std::fmt;
-use std::io::{self, BufRead, Write};
+use std::io::Write;
 use std::path::Path;
 use std::str::FromStr;
 
@@ -112,21 +112,7 @@ impl FromStr for GroupEntry {
 ///
 /// Returns `ShadowError` if the file cannot be opened or contains malformed entries.
 pub fn read_group_file(path: &Path) -> Result<Vec<GroupEntry>, ShadowError> {
-    let file = std::fs::File::open(path).map_err(|e| ShadowError::IoPath(e, path.to_owned()))?;
-    let reader = io::BufReader::new(file);
-    let mut entries = Vec::new();
-
-    for line in reader.lines() {
-        let line = line?;
-        // Comments, blank lines and NIS compat lines are not entries. Use
-        // read_*_with_layout when they must survive a rewrite.
-        if crate::records::is_raw_line(&line) {
-            continue;
-        }
-        entries.push(line.parse()?);
-    }
-
-    Ok(entries)
+    crate::records::read_entries(path)
 }
 
 /// Write entries to an `/etc/group`-formatted file.
@@ -134,50 +120,14 @@ pub fn read_group_file(path: &Path) -> Result<Vec<GroupEntry>, ShadowError> {
 /// # Errors
 ///
 /// Returns `ShadowError` on I/O write failure.
-pub fn write_group<W: Write>(entries: &[GroupEntry], mut writer: W) -> Result<(), ShadowError> {
-    for entry in entries {
-        entry.validate_fields()?;
-        writeln!(writer, "{entry}")?;
-    }
-    Ok(())
+pub fn write_group<W: Write>(entries: &[GroupEntry], writer: W) -> Result<(), ShadowError> {
+    crate::records::write_entries(entries, writer)
 }
 
 impl crate::records::Named for GroupEntry {
     fn name(&self) -> &str {
         &self.name
     }
-}
-
-/// Read `/etc/group` keeping comments, blank lines and NIS compat lines.
-///
-/// Returns the entries plus the [`crate::records::Layout`] that
-/// [`write_group_with_layout`] needs to put those lines back.
-///
-/// # Errors
-///
-/// Returns `ShadowError` if the file cannot be opened or an entry is malformed.
-pub fn read_group_with_layout(
-    path: &Path,
-) -> Result<(Vec<GroupEntry>, crate::records::Layout), ShadowError> {
-    crate::records::read_with_layout(path)
-}
-
-/// Write entries back, restoring the lines [`read_group_with_layout`] preserved.
-///
-/// # Errors
-///
-/// Returns `ShadowError` on a write failure or an entry that would corrupt the
-/// record format.
-pub fn write_group_with_layout<W: Write>(
-    entries: &[GroupEntry],
-    layout: &crate::records::Layout,
-    mut writer: W,
-) -> Result<(), ShadowError> {
-    crate::records::write_with_layout(entries, layout, &mut writer, |entry, w| {
-        entry.validate_fields()?;
-        writeln!(w, "{entry}")?;
-        Ok(())
-    })
 }
 
 impl crate::transaction::Record for GroupEntry {

--- a/src/shadow-core/src/gshadow.rs
+++ b/src/shadow-core/src/gshadow.rs
@@ -14,7 +14,7 @@
 //! `admins` and `members` are comma-separated lists of usernames.
 
 use std::fmt;
-use std::io::{self, BufRead, Write};
+use std::io::Write;
 use std::path::Path;
 use std::str::FromStr;
 
@@ -122,21 +122,7 @@ impl FromStr for GshadowEntry {
 ///
 /// Returns `ShadowError` if the file cannot be opened or contains malformed entries.
 pub fn read_gshadow_file(path: &Path) -> Result<Vec<GshadowEntry>, ShadowError> {
-    let file = std::fs::File::open(path).map_err(|e| ShadowError::IoPath(e, path.to_owned()))?;
-    let reader = io::BufReader::new(file);
-    let mut entries = Vec::new();
-
-    for line in reader.lines() {
-        let line = line?;
-        // Comments, blank lines and NIS compat lines are not entries. Use
-        // read_*_with_layout when they must survive a rewrite.
-        if crate::records::is_raw_line(&line) {
-            continue;
-        }
-        entries.push(line.parse()?);
-    }
-
-    Ok(entries)
+    crate::records::read_entries(path)
 }
 
 /// Write entries to an `/etc/gshadow`-formatted file.
@@ -144,50 +130,14 @@ pub fn read_gshadow_file(path: &Path) -> Result<Vec<GshadowEntry>, ShadowError> 
 /// # Errors
 ///
 /// Returns `ShadowError` on I/O write failure.
-pub fn write_gshadow<W: Write>(entries: &[GshadowEntry], mut writer: W) -> Result<(), ShadowError> {
-    for entry in entries {
-        entry.validate_fields()?;
-        writeln!(writer, "{entry}")?;
-    }
-    Ok(())
+pub fn write_gshadow<W: Write>(entries: &[GshadowEntry], writer: W) -> Result<(), ShadowError> {
+    crate::records::write_entries(entries, writer)
 }
 
 impl crate::records::Named for GshadowEntry {
     fn name(&self) -> &str {
         &self.name
     }
-}
-
-/// Read `/etc/gshadow` keeping comments, blank lines and NIS compat lines.
-///
-/// Returns the entries plus the [`crate::records::Layout`] that
-/// [`write_gshadow_with_layout`] needs to put those lines back.
-///
-/// # Errors
-///
-/// Returns `ShadowError` if the file cannot be opened or an entry is malformed.
-pub fn read_gshadow_with_layout(
-    path: &Path,
-) -> Result<(Vec<GshadowEntry>, crate::records::Layout), ShadowError> {
-    crate::records::read_with_layout(path)
-}
-
-/// Write entries back, restoring the lines [`read_gshadow_with_layout`] preserved.
-///
-/// # Errors
-///
-/// Returns `ShadowError` on a write failure or an entry that would corrupt the
-/// record format.
-pub fn write_gshadow_with_layout<W: Write>(
-    entries: &[GshadowEntry],
-    layout: &crate::records::Layout,
-    mut writer: W,
-) -> Result<(), ShadowError> {
-    crate::records::write_with_layout(entries, layout, &mut writer, |entry, w| {
-        entry.validate_fields()?;
-        writeln!(w, "{entry}")?;
-        Ok(())
-    })
 }
 
 impl crate::transaction::Record for GshadowEntry {

--- a/src/shadow-core/src/passwd.rs
+++ b/src/shadow-core/src/passwd.rs
@@ -15,7 +15,7 @@
 //! (indicating the hash is in `/etc/shadow`).
 
 use std::fmt;
-use std::io::{self, BufRead, Write};
+use std::io::Write;
 use std::path::Path;
 use std::str::FromStr;
 
@@ -132,22 +132,7 @@ impl FromStr for PasswdEntry {
 ///
 /// Returns `ShadowError` if the file cannot be opened or contains malformed entries.
 pub fn read_passwd_file(path: &Path) -> Result<Vec<PasswdEntry>, ShadowError> {
-    let file = std::fs::File::open(path).map_err(|e| ShadowError::IoPath(e, path.to_owned()))?;
-    let reader = io::BufReader::new(file);
-    let mut entries = Vec::new();
-
-    for line in reader.lines() {
-        let line = line?;
-        // Comments, blank lines and NIS compat lines are not entries. Use
-        // read_*_with_layout when they must survive a rewrite.
-        if crate::records::is_raw_line(&line) {
-            continue;
-        }
-        // Parse the original untrimmed line to preserve field whitespace.
-        entries.push(line.parse()?);
-    }
-
-    Ok(entries)
+    crate::records::read_entries(path)
 }
 
 /// Write entries to an `/etc/passwd`-formatted file.
@@ -158,50 +143,14 @@ pub fn read_passwd_file(path: &Path) -> Result<Vec<PasswdEntry>, ShadowError> {
 /// # Errors
 ///
 /// Returns `ShadowError` on I/O write failure.
-pub fn write_passwd<W: Write>(entries: &[PasswdEntry], mut writer: W) -> Result<(), ShadowError> {
-    for entry in entries {
-        entry.validate_fields()?;
-        writeln!(writer, "{entry}")?;
-    }
-    Ok(())
+pub fn write_passwd<W: Write>(entries: &[PasswdEntry], writer: W) -> Result<(), ShadowError> {
+    crate::records::write_entries(entries, writer)
 }
 
 impl crate::records::Named for PasswdEntry {
     fn name(&self) -> &str {
         &self.name
     }
-}
-
-/// Read `/etc/passwd` keeping comments, blank lines and NIS compat lines.
-///
-/// Returns the entries plus the [`crate::records::Layout`] that
-/// [`write_passwd_with_layout`] needs to put those lines back.
-///
-/// # Errors
-///
-/// Returns `ShadowError` if the file cannot be opened or an entry is malformed.
-pub fn read_passwd_with_layout(
-    path: &Path,
-) -> Result<(Vec<PasswdEntry>, crate::records::Layout), ShadowError> {
-    crate::records::read_with_layout(path)
-}
-
-/// Write entries back, restoring the lines [`read_passwd_with_layout`] preserved.
-///
-/// # Errors
-///
-/// Returns `ShadowError` on a write failure or an entry that would corrupt the
-/// record format.
-pub fn write_passwd_with_layout<W: Write>(
-    entries: &[PasswdEntry],
-    layout: &crate::records::Layout,
-    mut writer: W,
-) -> Result<(), ShadowError> {
-    crate::records::write_with_layout(entries, layout, &mut writer, |entry, w| {
-        entry.validate_fields()?;
-        writeln!(w, "{entry}")?;
-        Ok(())
-    })
 }
 
 impl crate::transaction::Record for PasswdEntry {

--- a/src/shadow-core/src/records.rs
+++ b/src/shadow-core/src/records.rs
@@ -70,6 +70,58 @@ pub fn is_raw_line(line: &str) -> bool {
     trimmed.is_empty() || trimmed.starts_with('#') || trimmed.starts_with(['+', '-'])
 }
 
+/// Read a record file, skipping the lines that are not entries.
+///
+/// Comments, blank lines and NIS compatibility lines are dropped. Use
+/// [`read_with_layout`] where they must survive a rewrite, which is any
+/// path that writes the file back.
+///
+/// # Errors
+///
+/// Returns `ShadowError` if the file cannot be opened or an entry line is
+/// malformed.
+pub fn read_entries<T>(path: &Path) -> Result<Vec<T>, ShadowError>
+where
+    T: FromStr<Err = ShadowError>,
+{
+    let file = std::fs::File::open(path).map_err(|e| ShadowError::IoPath(e, path.to_owned()))?;
+    let reader = std::io::BufReader::new(file);
+    let mut entries = Vec::new();
+
+    for line in reader.lines() {
+        let line = line?;
+        if is_raw_line(&line) {
+            continue;
+        }
+        // Parse the original untrimmed line to preserve field whitespace.
+        entries.push(line.parse()?);
+    }
+
+    Ok(entries)
+}
+
+/// Write entries to a record file, validating each one first.
+///
+/// Nothing but the entries: any comments the file carried are lost, which is
+/// why every path that rewrites an existing file goes through
+/// [`write_with_layout`] or the transaction instead.
+///
+/// # Errors
+///
+/// Returns `ShadowError::Validation` for a value that would corrupt a record,
+/// and `ShadowError::Io` on a write failure.
+pub fn write_entries<T, W>(entries: &[T], mut writer: W) -> Result<(), ShadowError>
+where
+    T: Display + crate::transaction::Record,
+    W: Write,
+{
+    for entry in entries {
+        crate::transaction::Record::validate_fields(entry)?;
+        writeln!(writer, "{entry}")?;
+    }
+    Ok(())
+}
+
 /// Read a record file, keeping the lines that are not entries.
 ///
 /// # Errors

--- a/src/shadow-core/src/shadow.rs
+++ b/src/shadow-core/src/shadow.rs
@@ -14,7 +14,7 @@
 //! All date fields are in days since epoch (1970-01-01).
 
 use std::fmt;
-use std::io::{self, BufRead, Write};
+use std::io::Write;
 use std::path::Path;
 use std::str::FromStr;
 
@@ -246,22 +246,7 @@ impl FromStr for ShadowEntry {
 ///
 /// Returns `ShadowError` if the file cannot be opened or contains malformed entries.
 pub fn read_shadow_file(path: &Path) -> Result<Vec<ShadowEntry>, ShadowError> {
-    let file = std::fs::File::open(path).map_err(|e| ShadowError::IoPath(e, path.to_owned()))?;
-    let reader = io::BufReader::new(file);
-    let mut entries = Vec::new();
-
-    for line in reader.lines() {
-        let line = line?;
-        // Comments, blank lines and NIS compat lines are not entries. Use
-        // read_*_with_layout when they must survive a rewrite.
-        if crate::records::is_raw_line(&line) {
-            continue;
-        }
-        // Parse the original untrimmed line to preserve field whitespace.
-        entries.push(line.parse()?);
-    }
-
-    Ok(entries)
+    crate::records::read_entries(path)
 }
 
 /// Write entries to an `/etc/shadow`-formatted file.
@@ -269,50 +254,14 @@ pub fn read_shadow_file(path: &Path) -> Result<Vec<ShadowEntry>, ShadowError> {
 /// # Errors
 ///
 /// Returns `ShadowError` on I/O write failure.
-pub fn write_shadow<W: Write>(entries: &[ShadowEntry], mut writer: W) -> Result<(), ShadowError> {
-    for entry in entries {
-        entry.validate_fields()?;
-        writeln!(writer, "{entry}")?;
-    }
-    Ok(())
+pub fn write_shadow<W: Write>(entries: &[ShadowEntry], writer: W) -> Result<(), ShadowError> {
+    crate::records::write_entries(entries, writer)
 }
 
 impl crate::records::Named for ShadowEntry {
     fn name(&self) -> &str {
         &self.name
     }
-}
-
-/// Read `/etc/shadow` keeping comments, blank lines and NIS compat lines.
-///
-/// Returns the entries plus the [`crate::records::Layout`] that
-/// [`write_shadow_with_layout`] needs to put those lines back.
-///
-/// # Errors
-///
-/// Returns `ShadowError` if the file cannot be opened or an entry is malformed.
-pub fn read_shadow_with_layout(
-    path: &Path,
-) -> Result<(Vec<ShadowEntry>, crate::records::Layout), ShadowError> {
-    crate::records::read_with_layout(path)
-}
-
-/// Write entries back, restoring the lines [`read_shadow_with_layout`] preserved.
-///
-/// # Errors
-///
-/// Returns `ShadowError` on a write failure or an entry that would corrupt the
-/// record format.
-pub fn write_shadow_with_layout<W: Write>(
-    entries: &[ShadowEntry],
-    layout: &crate::records::Layout,
-    mut writer: W,
-) -> Result<(), ShadowError> {
-    crate::records::write_with_layout(entries, layout, &mut writer, |entry, w| {
-        entry.validate_fields()?;
-        writeln!(w, "{entry}")?;
-        Ok(())
-    })
 }
 
 impl crate::transaction::Record for ShadowEntry {

--- a/src/shadow-core/src/subid.rs
+++ b/src/shadow-core/src/subid.rs
@@ -17,7 +17,7 @@
 //! ID mapping (rootless containers).
 
 use std::fmt;
-use std::io::{self, BufRead, Write};
+use std::io::Write;
 use std::path::Path;
 use std::str::FromStr;
 
@@ -97,21 +97,7 @@ impl FromStr for SubIdEntry {
 ///
 /// Returns `ShadowError` if the file cannot be opened or contains malformed entries.
 pub fn read_subid_file(path: &Path) -> Result<Vec<SubIdEntry>, ShadowError> {
-    let file = std::fs::File::open(path).map_err(|e| ShadowError::IoPath(e, path.to_owned()))?;
-    let reader = io::BufReader::new(file);
-    let mut entries = Vec::new();
-
-    for line in reader.lines() {
-        let line = line?;
-        // Comments, blank lines and NIS compat lines are not entries. Use
-        // read_*_with_layout when they must survive a rewrite.
-        if crate::records::is_raw_line(&line) {
-            continue;
-        }
-        entries.push(line.parse()?);
-    }
-
-    Ok(entries)
+    crate::records::read_entries(path)
 }
 
 /// Write entries to an `/etc/subuid` or `/etc/subgid`-formatted file.
@@ -119,50 +105,14 @@ pub fn read_subid_file(path: &Path) -> Result<Vec<SubIdEntry>, ShadowError> {
 /// # Errors
 ///
 /// Returns `ShadowError` on I/O write failure.
-pub fn write_subid<W: Write>(entries: &[SubIdEntry], mut writer: W) -> Result<(), ShadowError> {
-    for entry in entries {
-        entry.validate_fields()?;
-        writeln!(writer, "{entry}")?;
-    }
-    Ok(())
+pub fn write_subid<W: Write>(entries: &[SubIdEntry], writer: W) -> Result<(), ShadowError> {
+    crate::records::write_entries(entries, writer)
 }
 
 impl crate::records::Named for SubIdEntry {
     fn name(&self) -> &str {
         &self.name
     }
-}
-
-/// Read `/etc/subuid` keeping comments, blank lines and NIS compat lines.
-///
-/// Returns the entries plus the [`crate::records::Layout`] that
-/// [`write_subid_with_layout`] needs to put those lines back.
-///
-/// # Errors
-///
-/// Returns `ShadowError` if the file cannot be opened or an entry is malformed.
-pub fn read_subid_with_layout(
-    path: &Path,
-) -> Result<(Vec<SubIdEntry>, crate::records::Layout), ShadowError> {
-    crate::records::read_with_layout(path)
-}
-
-/// Write entries back, restoring the lines [`read_subid_with_layout`] preserved.
-///
-/// # Errors
-///
-/// Returns `ShadowError` on a write failure or an entry that would corrupt the
-/// record format.
-pub fn write_subid_with_layout<W: Write>(
-    entries: &[SubIdEntry],
-    layout: &crate::records::Layout,
-    mut writer: W,
-) -> Result<(), ShadowError> {
-    crate::records::write_with_layout(entries, layout, &mut writer, |entry, w| {
-        entry.validate_fields()?;
-        writeln!(w, "{entry}")?;
-        Ok(())
-    })
 }
 
 impl crate::transaction::Record for SubIdEntry {

--- a/src/uu/useradd/src/useradd.rs
+++ b/src/uu/useradd/src/useradd.rs
@@ -1607,8 +1607,7 @@ mod tests {
         fs::write(root.shadow_path(), "existing:!:19000:0:99999:7:::\n").expect("write shadow");
         fs::write(root.group_path(), "existing:x:1000:\n").expect("write group");
 
-        let (passwd_entries, _) =
-            passwd::read_passwd_with_layout(&root.passwd_path()).expect("read passwd");
+        let passwd_entries = passwd::read_passwd_file(&root.passwd_path()).expect("read passwd");
         assert!(passwd_entries.iter().any(|e| e.name == "existing"));
     }
 


### PR DESCRIPTION
Item 1 of #249, and the last of that issue's refactors.

`read_*_file` and `write_*` were the same twenty lines five times over, once per
record type, differing only in which type they parsed. They delegate to a
generic pair in `records` now, and keep their names because eighteen call sites
read better for them.

The `read_*_with_layout` and `write_*_with_layout` wrappers are gone entirely.
Each was a single line forwarding to `records::`, and after the transaction
landed only one caller was left — a test that did not need the layout at all.

**200 lines out of `shadow-core`**, and one place where a change to how a record
file is read or written now has to be made.

```
make check              exit 0
GNU comparison          38 passed, 0 unexpected
```

### On the one item of #249 not implemented

The issue also proposes replacing the twelve per-tool `enum XxxError` blocks
with a single `ExitError { code, msg }`. **I recommend against it, and this
session is the evidence.**

The per-tool enums are what let the compiler say *"variant `FileBusy` is never
constructed"*. That message caught two real regressions this week, both while
converting tools to the locked-file transaction:

- `chage` stopped being able to return 5 for a locked file and would have
  reported 15, "cannot find the shadow password file", for ordinary contention.
- `pwck` stopped being able to return 5, "can not update the files", and would
  have reported every write failure as 6, "can not sort".

Both were silent behaviour changes that no test covered, and in both cases the
only thing that noticed was the unconstructed-variant lint. A shared struct
holding an integer would have swallowed them.

The boilerplate the issue objects to is real — about thirty lines per tool of
`Display` and `UError` — but it is the price of a check that has already earned
itself twice. If the duplication is worth attacking, the way to do it without
losing the check is a derive macro over a per-tool enum, not a shared struct.
