### PR TITLE
tests: exercise the PAM stack against known permit and deny services

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,10 @@ jobs:
       # Release binaries are built with `pam` (see dist-workspace.toml), so the
       # PAM code path has to be linted too — it is invisible to the run above.
       - run: cargo clippy --workspace --all-targets --features pam -- -D warnings
+      # Every optional module compiled at once. `completions` and the
+      # shadow-core feature gates are otherwise built by nobody, so a lint or a
+      # compile error in them reaches main unnoticed.
+      - run: cargo clippy --workspace --all-targets --all-features -- -D warnings
 
   test:
     name: Test

--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,7 @@ check:
 	cargo fmt --all --check
 	cargo clippy --workspace --all-targets -- -D warnings
 	cargo clippy --workspace --all-targets --features pam -- -D warnings
+	cargo clippy --workspace --all-targets --all-features -- -D warnings
 	$(MAKE) test
 
 # `install` ships binaries built with pam, so the tests must cover that build

--- a/docker/Dockerfile.alpine
+++ b/docker/Dockerfile.alpine
@@ -20,6 +20,13 @@ RUN apk add --no-cache \
     curl
 
 RUN rustup component add clippy rustfmt
+# Two throwaway PAM services so the PAM wrapper can be tested against a stack
+# whose answer is known. Without them the only coverage is the end-to-end image
+# authenticating a real account, which cannot exercise a *refusal* without
+# depending on a wrong password being wrong.
+RUN printf 'auth required pam_permit.so\naccount required pam_permit.so\npassword required pam_permit.so\nsession required pam_permit.so\n' > /etc/pam.d/shadow-rs-test-permit \
+    && printf 'auth required pam_deny.so\naccount required pam_deny.so\npassword required pam_deny.so\nsession required pam_deny.so\n' > /etc/pam.d/shadow-rs-test-deny
+
 
 # cargo-deny: pinned, checksum-verified prebuilt binary. The static musl build
 # runs on glibc too, so every image shares one asset. Installing the binary

--- a/docker/Dockerfile.debian
+++ b/docker/Dockerfile.debian
@@ -18,6 +18,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 RUN rustup component add clippy rustfmt
+# Two throwaway PAM services so the PAM wrapper can be tested against a stack
+# whose answer is known. Without them the only coverage is the end-to-end image
+# authenticating a real account, which cannot exercise a *refusal* without
+# depending on a wrong password being wrong.
+RUN printf 'auth required pam_permit.so\naccount required pam_permit.so\npassword required pam_permit.so\nsession required pam_permit.so\n' > /etc/pam.d/shadow-rs-test-permit \
+    && printf 'auth required pam_deny.so\naccount required pam_deny.so\npassword required pam_deny.so\nsession required pam_deny.so\n' > /etc/pam.d/shadow-rs-test-deny
+
 
 # cargo-deny: pinned, checksum-verified prebuilt binary. The static musl build
 # runs on glibc too, so every image shares one asset. Installing the binary

--- a/docker/Dockerfile.fedora
+++ b/docker/Dockerfile.fedora
@@ -24,6 +24,13 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y \
     --default-toolchain stable \
     --component clippy,rustfmt
 ENV PATH="/root/.cargo/bin:${PATH}"
+# Two throwaway PAM services so the PAM wrapper can be tested against a stack
+# whose answer is known. Without them the only coverage is the end-to-end image
+# authenticating a real account, which cannot exercise a *refusal* without
+# depending on a wrong password being wrong.
+RUN printf 'auth required pam_permit.so\naccount required pam_permit.so\npassword required pam_permit.so\nsession required pam_permit.so\n' > /etc/pam.d/shadow-rs-test-permit \
+    && printf 'auth required pam_deny.so\naccount required pam_deny.so\npassword required pam_deny.so\nsession required pam_deny.so\n' > /etc/pam.d/shadow-rs-test-deny
+
 
 
 # cargo-deny: pinned, checksum-verified prebuilt binary. The static musl build

--- a/src/shadow-core/src/pam.rs
+++ b/src/shadow-core/src/pam.rs
@@ -854,4 +854,71 @@ mod tests {
         let rc = conversation(1, ptr::null_mut(), &raw mut resp, appdata);
         assert_eq!(rc, return_code::PAM_CONV_ERR);
     }
+
+    // -----------------------------------------------------------------------
+    // The PAM stack, end to end
+    //
+    // Against two throwaway services the Docker images define: one backed by
+    // pam_permit, one by pam_deny. Until these existed the only PAM coverage
+    // was the deployment image authenticating a real account, which cannot
+    // exercise a *refusal* without relying on a wrong password being wrong --
+    // and could not tell a refusal apart from a broken conversation.
+    // -----------------------------------------------------------------------
+
+    /// Whether the test services are installed. They are absent on a
+    /// developer's own machine, where these tests are skipped.
+    fn test_services_present() -> bool {
+        std::path::Path::new("/etc/pam.d/shadow-rs-test-permit").exists()
+            && std::path::Path::new("/etc/pam.d/shadow-rs-test-deny").exists()
+    }
+
+    #[test]
+    fn test_permit_stack_authenticates() {
+        if !test_services_present() {
+            return;
+        }
+        let mut pam = PamContext::new("shadow-rs-test-permit", "root", ConvMode::Stdin)
+            .expect("pam_start on a permit stack");
+        pam.authenticate(0).expect("pam_permit must authenticate");
+        pam.acct_mgmt(0)
+            .expect("pam_permit must pass account management");
+    }
+
+    /// The refusal path, which is the one that matters for a setuid tool: it
+    /// must fail, and fail with the stack's answer rather than a conversation
+    /// error.
+    #[test]
+    fn test_deny_stack_refuses() {
+        if !test_services_present() {
+            return;
+        }
+        let mut pam = PamContext::new("shadow-rs-test-deny", "root", ConvMode::Stdin)
+            .expect("pam_start on a deny stack");
+        let err = pam.authenticate(0).expect_err("pam_deny must refuse");
+        let message = err.to_string();
+        assert!(
+            !message.contains("conversation"),
+            "the refusal should come from the stack, not a broken conversation: {message}"
+        );
+    }
+
+    /// A service with no configuration at all: PAM falls through to `other`,
+    /// which on every distribution here denies. A setuid tool must not treat
+    /// that as success.
+    #[test]
+    fn test_unknown_service_does_not_authenticate() {
+        if !test_services_present() {
+            return;
+        }
+        let Ok(mut pam) =
+            PamContext::new("shadow-rs-no-such-service-9f3a", "root", ConvMode::Stdin)
+        else {
+            // Refusing at pam_start is an equally correct answer.
+            return;
+        };
+        assert!(
+            pam.authenticate(0).is_err(),
+            "an unconfigured service must not authenticate"
+        );
+    }
 }


### PR DESCRIPTION
The last two items of #250.

### The PAM stack had no negative test

The only PAM coverage was the deployment image authenticating a real account.
That cannot exercise a **refusal** without relying on a wrong password being
wrong, and it cannot tell a refusal apart from a conversation that never
reached the stack — which is exactly the failure that broke password changes
earlier this week and took three rounds to find.

The glibc images now define two throwaway services, one backed by `pam_permit`
and one by `pam_deny`, and `shadow-core` tests the wrapper against both:

- the permit stack authenticates and passes account management,
- the deny stack refuses **with the stack's own answer** rather than a
  conversation error,
- a service with no configuration at all does not authenticate.

The tests skip where the services are absent, which is any machine but the
containers.

### Nobody was compiling all the features

CI gains an `--all-features` clippy pass. The `completions` feature and the
`shadow-core` feature gates were built by no job, so a lint or a compile error
in them could reach `main` unnoticed. `make check` runs it too.

```
17 PAM tests green on debian and fedora
make check              exit 0
```
