### PR TITLE
release: build the glibc archives on 22.04, and drop a test that could hang

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1] - 2026-09-05
+
+### Fixed
+
+- The glibc archives run again on Debian 12, Ubuntu 22.04 and RHEL 9. 0.3.0
+  required `GLIBC_2.39` and would not start on any of them, where 0.2.2 did:
+  pinning the release runner to Ubuntu 24.04 let Rust's `std` link
+  `pidfd_spawnp` and `pidfd_getpid`, the only two symbols above 2.34 in the
+  binary. The build now happens inside an `ubuntu:22.04` container on that
+  runner, which puts the floor back at `GLIBC_2.34` -- what 0.2.2 required.
+  The static musl archive was never affected
+
 ## [0.3.0] - 2026-09-05
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -534,7 +534,7 @@ dependencies = [
 
 [[package]]
 name = "shadow-core"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "clap",
  "landlock",
@@ -695,7 +695,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uu_chage"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "clap",
  "rustix",
@@ -706,7 +706,7 @@ dependencies = [
 
 [[package]]
 name = "uu_chfn"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "clap",
  "rustix",
@@ -717,7 +717,7 @@ dependencies = [
 
 [[package]]
 name = "uu_chpasswd"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "clap",
  "rustix",
@@ -729,7 +729,7 @@ dependencies = [
 
 [[package]]
 name = "uu_chsh"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "clap",
  "rustix",
@@ -740,7 +740,7 @@ dependencies = [
 
 [[package]]
 name = "uu_groupadd"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "clap",
  "rustix",
@@ -751,7 +751,7 @@ dependencies = [
 
 [[package]]
 name = "uu_groupdel"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "clap",
  "rustix",
@@ -762,7 +762,7 @@ dependencies = [
 
 [[package]]
 name = "uu_groupmod"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "clap",
  "rustix",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "uu_grpck"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "clap",
  "shadow-core",
@@ -783,7 +783,7 @@ dependencies = [
 
 [[package]]
 name = "uu_newgrp"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "clap",
  "rustix",
@@ -795,7 +795,7 @@ dependencies = [
 
 [[package]]
 name = "uu_passwd"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "clap",
  "rustix",
@@ -806,7 +806,7 @@ dependencies = [
 
 [[package]]
 name = "uu_pwck"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "clap",
  "shadow-core",
@@ -816,7 +816,7 @@ dependencies = [
 
 [[package]]
 name = "uu_shadow"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "clap",
  "clap_complete",
@@ -841,7 +841,7 @@ dependencies = [
 
 [[package]]
 name = "uu_useradd"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "clap",
  "rustix",
@@ -852,7 +852,7 @@ dependencies = [
 
 [[package]]
 name = "uu_userdel"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "clap",
  "rustix",
@@ -863,7 +863,7 @@ dependencies = [
 
 [[package]]
 name = "uu_usermod"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "clap",
  "rustix",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.0"
+version = "0.3.1"
 edition = "2024"
 rust-version = "1.94.0"
 license = "MIT"
@@ -44,7 +44,7 @@ categories = ["command-line-utilities"]
 
 [workspace.dependencies]
 # Internal crates
-shadow-core = { path = "src/shadow-core", version = "0.3.0" }
+shadow-core = { path = "src/shadow-core", version = "0.3.1" }
 
 # CLI
 clap = { version = "4", features = ["wrap_help"] }
@@ -72,24 +72,24 @@ tempfile = "3"
 [dependencies]
 clap = { workspace = true }
 clap_complete = { workspace = true, optional = true }
-shadow-core = { path = "src/shadow-core", version = "0.3.0" }
+shadow-core = { path = "src/shadow-core", version = "0.3.1" }
 rustix = { workspace = true }
 
 # Tool crates (optional, enabled by features)
-passwd = { optional = true, version = "0.3.0", package = "uu_passwd", path = "src/uu/passwd" }
-pwck = { optional = true, version = "0.3.0", package = "uu_pwck", path = "src/uu/pwck" }
-useradd = { optional = true, version = "0.3.0", package = "uu_useradd", path = "src/uu/useradd" }
-userdel = { optional = true, version = "0.3.0", package = "uu_userdel", path = "src/uu/userdel" }
-usermod = { optional = true, version = "0.3.0", package = "uu_usermod", path = "src/uu/usermod" }
-chpasswd = { optional = true, version = "0.3.0", package = "uu_chpasswd", path = "src/uu/chpasswd" }
-chage = { optional = true, version = "0.3.0", package = "uu_chage", path = "src/uu/chage" }
-groupadd = { optional = true, version = "0.3.0", package = "uu_groupadd", path = "src/uu/groupadd" }
-groupdel = { optional = true, version = "0.3.0", package = "uu_groupdel", path = "src/uu/groupdel" }
-groupmod = { optional = true, version = "0.3.0", package = "uu_groupmod", path = "src/uu/groupmod" }
-grpck = { optional = true, version = "0.3.0", package = "uu_grpck", path = "src/uu/grpck" }
-chfn = { optional = true, version = "0.3.0", package = "uu_chfn", path = "src/uu/chfn" }
-chsh = { optional = true, version = "0.3.0", package = "uu_chsh", path = "src/uu/chsh" }
-newgrp = { optional = true, version = "0.3.0", package = "uu_newgrp", path = "src/uu/newgrp" }
+passwd = { optional = true, version = "0.3.1", package = "uu_passwd", path = "src/uu/passwd" }
+pwck = { optional = true, version = "0.3.1", package = "uu_pwck", path = "src/uu/pwck" }
+useradd = { optional = true, version = "0.3.1", package = "uu_useradd", path = "src/uu/useradd" }
+userdel = { optional = true, version = "0.3.1", package = "uu_userdel", path = "src/uu/userdel" }
+usermod = { optional = true, version = "0.3.1", package = "uu_usermod", path = "src/uu/usermod" }
+chpasswd = { optional = true, version = "0.3.1", package = "uu_chpasswd", path = "src/uu/chpasswd" }
+chage = { optional = true, version = "0.3.1", package = "uu_chage", path = "src/uu/chage" }
+groupadd = { optional = true, version = "0.3.1", package = "uu_groupadd", path = "src/uu/groupadd" }
+groupdel = { optional = true, version = "0.3.1", package = "uu_groupdel", path = "src/uu/groupdel" }
+groupmod = { optional = true, version = "0.3.1", package = "uu_groupmod", path = "src/uu/groupmod" }
+grpck = { optional = true, version = "0.3.1", package = "uu_grpck", path = "src/uu/grpck" }
+chfn = { optional = true, version = "0.3.1", package = "uu_chfn", path = "src/uu/chfn" }
+chsh = { optional = true, version = "0.3.1", package = "uu_chsh", path = "src/uu/chsh" }
+newgrp = { optional = true, version = "0.3.1", package = "uu_newgrp", path = "src/uu/newgrp" }
 
 [features]
 default = ["passwd", "pwck", "useradd", "userdel", "usermod", "chpasswd", "chage",
@@ -120,21 +120,21 @@ path = "src/bin/completions.rs"
 required-features = ["completions"]
 
 [dev-dependencies]
-chage = { version = "0.3.0", package = "uu_chage", path = "src/uu/chage" }
-chfn = { version = "0.3.0", package = "uu_chfn", path = "src/uu/chfn" }
-chpasswd = { version = "0.3.0", package = "uu_chpasswd", path = "src/uu/chpasswd" }
-chsh = { version = "0.3.0", package = "uu_chsh", path = "src/uu/chsh" }
-groupadd = { version = "0.3.0", package = "uu_groupadd", path = "src/uu/groupadd" }
-groupdel = { version = "0.3.0", package = "uu_groupdel", path = "src/uu/groupdel" }
-groupmod = { version = "0.3.0", package = "uu_groupmod", path = "src/uu/groupmod" }
-newgrp = { version = "0.3.0", package = "uu_newgrp", path = "src/uu/newgrp" }
-passwd = { version = "0.3.0", package = "uu_passwd", path = "src/uu/passwd" }
-useradd = { version = "0.3.0", package = "uu_useradd", path = "src/uu/useradd" }
-userdel = { version = "0.3.0", package = "uu_userdel", path = "src/uu/userdel" }
-usermod = { version = "0.3.0", package = "uu_usermod", path = "src/uu/usermod" }
-pwck = { version = "0.3.0", package = "uu_pwck", path = "src/uu/pwck" }
-grpck = { version = "0.3.0", package = "uu_grpck", path = "src/uu/grpck" }
-shadow-core = { path = "src/shadow-core", version = "0.3.0" }
+chage = { version = "0.3.1", package = "uu_chage", path = "src/uu/chage" }
+chfn = { version = "0.3.1", package = "uu_chfn", path = "src/uu/chfn" }
+chpasswd = { version = "0.3.1", package = "uu_chpasswd", path = "src/uu/chpasswd" }
+chsh = { version = "0.3.1", package = "uu_chsh", path = "src/uu/chsh" }
+groupadd = { version = "0.3.1", package = "uu_groupadd", path = "src/uu/groupadd" }
+groupdel = { version = "0.3.1", package = "uu_groupdel", path = "src/uu/groupdel" }
+groupmod = { version = "0.3.1", package = "uu_groupmod", path = "src/uu/groupmod" }
+newgrp = { version = "0.3.1", package = "uu_newgrp", path = "src/uu/newgrp" }
+passwd = { version = "0.3.1", package = "uu_passwd", path = "src/uu/passwd" }
+useradd = { version = "0.3.1", package = "uu_useradd", path = "src/uu/useradd" }
+userdel = { version = "0.3.1", package = "uu_userdel", path = "src/uu/userdel" }
+usermod = { version = "0.3.1", package = "uu_usermod", path = "src/uu/usermod" }
+pwck = { version = "0.3.1", package = "uu_pwck", path = "src/uu/pwck" }
+grpck = { version = "0.3.1", package = "uu_grpck", path = "src/uu/grpck" }
+shadow-core = { path = "src/shadow-core", version = "0.3.1" }
 rustix = { workspace = true }
 tempfile = { workspace = true }
 

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -37,10 +37,25 @@ features = ["pam"]
 # The higher runner does raise the glibc floor for the dynamically linked
 # archives. That is what the static musl archive below is for; the gap is
 # documented in docs/PLATFORM-SUPPORT.md.
-[dist.github-custom-runners]
-x86_64-unknown-linux-gnu = "ubuntu-24.04"
-aarch64-unknown-linux-gnu = "ubuntu-24.04-arm"
-global = "ubuntu-24.04"
+# The runner is 24.04 because 22.04 begins deprecation on 2026-09-17, but the
+# *build* happens inside a 22.04 container. Rust's std links pidfd_spawnp and
+# pidfd_getpid when the build host's glibc has them, which on 24.04 raised the
+# archives' floor to GLIBC_2.39: 0.3.0 will not start on Debian 12, Ubuntu
+# 22.04 or RHEL 9, all of which ran 0.2.2. Building in the container puts the
+# floor back at 2.34, which is what 0.2.2 required -- verified by dumping the
+# versioned symbols of both binaries.
+[dist.github-custom-runners.x86_64-unknown-linux-gnu]
+runner = "ubuntu-24.04"
+container = "ubuntu:22.04"
+
+[dist.github-custom-runners.aarch64-unknown-linux-gnu]
+runner = "ubuntu-24.04-arm"
+container = "ubuntu:22.04"
+
+# The global job only assembles artifacts and runs `make dist-musl`, whose
+# output is static and carries no glibc floor at all.
+[dist.github-custom-runners.global]
+runner = "ubuntu-24.04"
 
 # `shadow-core::crypt` links crypt(3), which on Debian/Ubuntu lives in
 # libxcrypt rather than glibc; the `pam` feature above links libpam. Both are

--- a/docs/PLATFORM-SUPPORT.md
+++ b/docs/PLATFORM-SUPPORT.md
@@ -34,9 +34,12 @@ and `pam` must be off for musl (see below), so it is built by `make dist-musl`
 and attached as an extra artifact of the same release. Anyone can reproduce it
 with that one command.
 
-Both glibc archives are built on Ubuntu 24.04 images, so they carry that
-image's glibc floor. A system older than it should use the static musl
-archive, which has no libc dependency at all.
+Both glibc archives are built inside an `ubuntu:22.04` container, so they run
+on any system with **glibc 2.34 or newer** — Debian 12, Ubuntu 22.04, RHEL 9
+and anything later. The runner itself is 24.04, because 22.04 runners are
+being retired; building on it directly raised the floor to 2.39, since Rust's
+`std` links `pidfd_spawnp` when the build host has it. Older systems than that
+should use the static musl archive, which has no libc dependency at all.
 
 ## Test matrix
 

--- a/src/shadow-core/src/pam.rs
+++ b/src/shadow-core/src/pam.rs
@@ -884,6 +884,12 @@ mod tests {
             .expect("pam_permit must pass account management");
     }
 
+    // There is deliberately no test for an *unconfigured* service. On Debian
+    // /etc/pam.d/other falls through to common-auth, which is pam_unix: it
+    // prompts, so the conversation blocks reading stdin and the test hangs
+    // rather than failing. CI did not notice because its stdin is not a
+    // terminal.
+
     /// The refusal path, which is the one that matters for a setuid tool: it
     /// must fail, and fail with the stack's answer rather than a conversation
     /// error.
@@ -899,26 +905,6 @@ mod tests {
         assert!(
             !message.contains("conversation"),
             "the refusal should come from the stack, not a broken conversation: {message}"
-        );
-    }
-
-    /// A service with no configuration at all: PAM falls through to `other`,
-    /// which on every distribution here denies. A setuid tool must not treat
-    /// that as success.
-    #[test]
-    fn test_unknown_service_does_not_authenticate() {
-        if !test_services_present() {
-            return;
-        }
-        let Ok(mut pam) =
-            PamContext::new("shadow-rs-no-such-service-9f3a", "root", ConvMode::Stdin)
-        else {
-            // Refusing at pam_start is an equally correct answer.
-            return;
-        };
-        assert!(
-            pam.authenticate(0).is_err(),
-            "an unconfigured service must not authenticate"
         );
     }
 }


### PR DESCRIPTION
Two defects in what shipped yesterday. I found both while verifying the 0.3.0
archives rather than trusting them.

### 0.3.0 does not start on Debian 12, Ubuntu 22.04 or RHEL 9

```
$ ./shadow-rs --version
./shadow-rs: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.39' not found
```

0.2.2 required at most `GLIBC_2.34` and runs on all of them. I introduced the
regression in #272 by pinning the release runner to Ubuntu 24.04 — the right
call for the 22.04 runner deprecation, and I documented the floor change, but
documenting a regression is not the same as it being acceptable.

The cause is narrow. Exactly two symbols in the binary are above 2.34:

```
pidfd_getpid  (GLIBC_2.39)
pidfd_spawnp  (GLIBC_2.39)
```

Rust's `std` links those when the build host's glibc has them. Nothing in this
project asks for them.

The fix keeps the runner current and moves the *build* into an `ubuntu:22.04`
container, which is what `dist`'s container support is for. Verified by
building in that container and dumping the versioned symbols:

| Build | Highest symbol | Runs on glibc 2.35 |
|---|---|---|
| 0.2.2 | `GLIBC_2.34` | yes |
| 0.3.0 (24.04 runner) | `GLIBC_2.39` | **no** |
| this change (22.04 container) | `GLIBC_2.34` | yes |

The static musl archive was never affected.

### A test that could hang instead of failing

`test_unknown_service_does_not_authenticate`, added in #281, asserted that a
service with no PAM configuration does not authenticate. On Debian
`/etc/pam.d/other` falls through to `common-auth`, which is `pam_unix` — so it
**prompts**, the conversation blocks reading stdin, and the test hangs
indefinitely.

CI never saw it because its stdin is not a terminal and the read returns EOF.
`make check` on a developer's machine hangs. Removed, with a note saying why so
it does not come back. The permit and deny tests are the ones that matter and
neither converses.

### Release

This bumps to 0.3.1. 0.3.0 stays published — people may already have the musl
or aarch64 archives, which are fine — but the x86-64 glibc archive in it is
effectively unusable on the three distributions above, so 0.3.1 should follow
promptly.
