### PR TITLE
release: give the build container the tools the workflow needs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `pidfd_spawnp` and `pidfd_getpid`, the only two symbols above 2.34 in the
   binary. The build now happens inside an `ubuntu:22.04` container on that
   runner, which puts the floor back at `GLIBC_2.34` -- what 0.2.2 required.
-  The static musl archive was never affected
+  The image is `buildpack-deps:22.04` rather than a bare `ubuntu:22.04`,
+  because the release workflow runs `git` and `curl` before installing
+  anything. The static musl archive was never affected
 
 ## [0.3.0] - 2026-09-05
 

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -46,11 +46,11 @@ features = ["pam"]
 # versioned symbols of both binaries.
 [dist.github-custom-runners.x86_64-unknown-linux-gnu]
 runner = "ubuntu-24.04"
-container = "ubuntu:22.04"
+container = "buildpack-deps:22.04"
 
 [dist.github-custom-runners.aarch64-unknown-linux-gnu]
 runner = "ubuntu-24.04-arm"
-container = "ubuntu:22.04"
+container = "buildpack-deps:22.04"
 
 # The global job only assembles artifacts and runs `make dist-musl`, whose
 # output is static and carries no glibc floor at all.


### PR DESCRIPTION
The 0.3.1 pipeline failed before it compiled anything:

```
/__w/_temp/….sh: 1: git: not found
##[error]Process completed with exit code 127
```

A bare `ubuntu:22.04` has no `git`, and the generated workflow runs `git config`
as its very first step, then installs Rust with `curl`. The apt dependencies
declared in `dist-workspace.toml` are installed later, so they cannot help.

`buildpack-deps:22.04` carries git, curl and a C toolchain, is still Ubuntu
22.04, and produces the same floor. Verified by building in it and dumping the
versioned symbols, and by running the result on a glibc 2.35 host:

```
GLIBC_2.33
GLIBC_2.34          ← highest
shadow-rs (uutils shadow-rs) 0.3.1
```

No release was published for the `0.3.1` tag — `host` and `announce` were
skipped — so the tag moves rather than the version being burned.
