### PR TITLE
release: tell dist the container is apt-based and arm64-native

### DIFF
--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -46,11 +46,14 @@ features = ["pam"]
 # versioned symbols of both binaries.
 [dist.github-custom-runners.x86_64-unknown-linux-gnu]
 runner = "ubuntu-24.04"
-container = "buildpack-deps:22.04"
+container = { image = "buildpack-deps:22.04", package-manager = "apt" }
 
+# `host` has to say arm64 here. Left at the default, dist takes the container
+# for an x86-64 one, concludes it is cross-compiling and adds a cargo-zigbuild
+# install that shells out to dnf -- which an apt image has not got.
 [dist.github-custom-runners.aarch64-unknown-linux-gnu]
 runner = "ubuntu-24.04-arm"
-container = "buildpack-deps:22.04"
+container = { image = "buildpack-deps:22.04", host = "aarch64-unknown-linux-musl", package-manager = "apt" }
 
 # The global job only assembles artifacts and runs `make dist-musl`, whose
 # output is static and carries no glibc floor at all.


### PR DESCRIPTION
Two more things the build container needed. Both are visible in `dist plan` and
neither appears in the generated workflow, which is why the previous two
attempts only failed once they were running.

**The dependency install step was emitted empty.** dist infers a package
manager only for images it recognises; for anything else it leaves
`package_manager` unset and installs nothing, so the build died on `-lpam`:

```
'container': {'image': 'buildpack-deps:22.04', 'package_manager': None}
```

The entry now says `package-manager = "apt"`.

**The arm64 entry also has to declare an arm64 host.** Left at the default it
describes an x86-64 container, so dist concluded it was cross-compiling and
added a `cargo-zigbuild` install that shells out to `dnf` — which an apt image
has not got. That job would have failed for a completely different reason.

Both checked by reading the install script dist plans for each target rather
than by tagging again:

```
aarch64-unknown-linux-gnu | ubuntu-24.04-arm | aarch64-unknown-linux-musl | zigbuild: False
x86_64-unknown-linux-gnu  | ubuntu-24.04     | x86_64-unknown-linux-musl  | zigbuild: False
```
