### PR TITLE
sg: run a command with a different primary group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `sg`, the sixteenth tool: it runs a single command with a different primary
+  group. `sg` and `newgrp` decide who may enter a group by the same rules and
+  enter it the same way — on a GNU system they are one binary reached through a
+  symlink — so the shared half now lives in `shadow_core::group_switch` and both
+  tools call it. `sg` execs the command rather than forking and waiting for it,
+  which is what lets the command's own exit status reach the caller unaltered
+
+### Changed
+
+- `newgrp` no longer refuses a passwordless group before prompting. It asked
+  for a password only when the group had one, so whether a prompt appeared told
+  any caller which groups have passwords set — a list of the ones worth
+  attacking. Both tools now prompt either way
+
+### Fixed
+
+- `newgrp` dropped the caller's original primary group when it rebuilt the
+  supplementary group list. `initgroups()` builds that list from the member
+  lists in `/etc/group`, where a primary group never appears, so `newgrp staff`
+  cost the caller access to their own files until they left the new shell. The
+  group they started in is now added back, matching the GNU tools
+
 ## [0.4.0] - 2026-09-06
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -800,9 +800,7 @@ dependencies = [
  "clap",
  "rustix",
  "shadow-core",
- "tempfile",
  "uucore",
- "zeroize",
 ]
 
 [[package]]
@@ -827,6 +825,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "uu_sg"
+version = "0.4.0"
+dependencies = [
+ "clap",
+ "shadow-core",
+ "uucore",
+]
+
+[[package]]
 name = "uu_shadow"
 version = "0.4.0"
 dependencies = [
@@ -847,6 +854,7 @@ dependencies = [
  "uu_newgrp",
  "uu_passwd",
  "uu_pwck",
+ "uu_sg",
  "uu_useradd",
  "uu_userdel",
  "uu_usermod",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ members = [
     "src/uu/chpasswd",
     "src/uu/chage",
     "src/uu/gpasswd",
+    "src/uu/sg",
 ]
 
 [workspace.package]
@@ -92,10 +93,12 @@ chfn = { optional = true, version = "0.4.0", package = "uu_chfn", path = "src/uu
 chsh = { optional = true, version = "0.4.0", package = "uu_chsh", path = "src/uu/chsh" }
 newgrp = { optional = true, version = "0.4.0", package = "uu_newgrp", path = "src/uu/newgrp" }
 gpasswd = { optional = true, version = "0.4.0", package = "uu_gpasswd", path = "src/uu/gpasswd" }
+sg = { optional = true, version = "0.4.0", package = "uu_sg", path = "src/uu/sg" }
 
 [features]
 default = ["passwd", "pwck", "useradd", "userdel", "usermod", "chpasswd", "chage",
-           "groupadd", "groupdel", "groupmod", "grpck", "chfn", "chsh", "newgrp", "gpasswd"]
+           "groupadd", "groupdel", "groupmod", "grpck", "chfn", "chsh", "newgrp", "gpasswd",
+           "sg"]
 
 # PAM authentication (requires libpam-dev). The `?` matters: without it,
 # asking for PAM would drag in the three applets that can use it even when the
@@ -130,6 +133,7 @@ groupadd = { version = "0.4.0", package = "uu_groupadd", path = "src/uu/groupadd
 groupdel = { version = "0.4.0", package = "uu_groupdel", path = "src/uu/groupdel" }
 groupmod = { version = "0.4.0", package = "uu_groupmod", path = "src/uu/groupmod" }
 newgrp = { version = "0.4.0", package = "uu_newgrp", path = "src/uu/newgrp" }
+sg = { version = "0.4.0", package = "uu_sg", path = "src/uu/sg" }
 passwd = { version = "0.4.0", package = "uu_passwd", path = "src/uu/passwd" }
 useradd = { version = "0.4.0", package = "uu_useradd", path = "src/uu/useradd" }
 userdel = { version = "0.4.0", package = "uu_userdel", path = "src/uu/userdel" }

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ SBINDIR ?= $(PREFIX)/sbin
 
 # Tools that need setuid-root to allow non-root callers (change own password,
 # GECOS, shell, effective group, or administer a group as a group admin).
-SETUID_TOOLS = passwd chfn chsh newgrp gpasswd
+SETUID_TOOLS = passwd chfn chsh newgrp gpasswd sg
 
 # Root-only tools (no setuid; fail at getuid() check for non-root callers).
 ROOT_TOOLS = useradd userdel usermod chpasswd \
@@ -107,9 +107,8 @@ test-arm64: build-arm64
 test-gnu-compat:
 	bash tests/gnu-compat.sh
 
-# Default install: 15 standalone per-tool binaries, with the setuid layout and
-# the bin/sbin split GNU shadow-utils uses. Only passwd/chfn/chsh/newgrp are
-# setuid.
+# Default install: 16 standalone per-tool binaries, with the setuid layout and
+# the bin/sbin split GNU shadow-utils uses. Only $(SETUID_TOOLS) are setuid.
 install: build
 	@for tool in $(SETUID_TOOLS); do \
 		install -Dm4755 target/release/$$tool $(DESTDIR)$(BINDIR)/$$tool || exit 1; \
@@ -124,9 +123,9 @@ install: build
 	@echo "  $(DESTDIR)$(SBINDIR)/ root (0755):   $(ROOT_TOOLS)"
 
 # Opt-in install: single multicall binary with symlinks. Smaller footprint.
-# The binary is installed setuid-root for passwd/chfn/chsh/newgrp/gpasswd; the
-# other applets drop back to the caller's uid before running, so the privilege
-# model matches the per-tool layout. Intended for container/embedded use.
+# The binary is installed setuid-root for $(SETUID_TOOLS); the other applets
+# drop back to the caller's uid before running, so the privilege model matches
+# the per-tool layout. Intended for container/embedded use.
 install-multicall: build-multicall
 	install -Dm4755 target/release/shadow-rs $(DESTDIR)$(SBINDIR)/shadow-rs
 	@install -d $(DESTDIR)$(BINDIR)

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ default-in-Ubuntu in under 3 years. This project follows that playbook.
 | `chsh` | **Implemented.** Shell change with /etc/shells validation. |
 | `newgrp` | **Implemented.** Effective group change with crypt verification. |
 | `gpasswd` | **Implemented.** Group membership, administrators, and group password. |
+| `sg` | **Implemented.** Runs one command in another group; shares `newgrp`'s authorization. |
 
 ## Building
 
@@ -88,9 +89,9 @@ docker compose run --rm debian cargo build --release
 
 ### Install
 
-Default install: 15 standalone per-tool binaries with least-privilege setuid
+Default install: 16 standalone per-tool binaries with least-privilege setuid
 layout matching GNU shadow-utils. Only `passwd`, `chfn`, `chsh`, `newgrp`,
-`gpasswd` are installed setuid-root; the other 10 are plain `0755`.
+`gpasswd` and `sg` are installed setuid-root; the other 10 are plain `0755`.
 
 ```shell
 sudo make install PREFIX=/usr/local
@@ -98,7 +99,7 @@ sudo make install PREFIX=/usr/local
 
 Alternative: single multicall binary with symlinks. Smaller footprint (~15×
 disk savings). The binary is installed setuid-root so that `passwd`, `chfn`,
-`chsh`, `newgrp` and `gpasswd` can serve unprivileged callers; every other
+`chsh`, `newgrp`, `gpasswd` and `sg` can serve unprivileged callers; every other
 applet drops back to the caller's uid before it runs, so the privilege model
 is the same as the per-tool layout. Intended for container/embedded use cases.
 
@@ -141,7 +142,7 @@ would:
 tar xzf uu_shadow-x86_64-unknown-linux-gnu.tar.gz   # or the -musl-static one
 sudo install -o root -g root -m 4755 \
     uu_shadow-*/shadow-rs /usr/local/bin/shadow-rs
-for tool in passwd chfn chsh newgrp gpasswd chage chpasswd groupadd groupdel \
+for tool in passwd chfn chsh newgrp gpasswd sg chage chpasswd groupadd groupdel \
             groupmod grpck pwck useradd userdel usermod; do
     sudo ln -sf shadow-rs "/usr/local/bin/$tool"
 done

--- a/docs/PLATFORM-SUPPORT.md
+++ b/docs/PLATFORM-SUPPORT.md
@@ -86,19 +86,19 @@ Effect, and this is the heaviest of the three gaps:
   than apply an unverified one, so without PAM they refuse every non-root
   invocation outright.
 
-Unaffected: `passwd -S/-l/-u/-d/-e/-n/-x/-w/-i`, and `newgrp` and `gpasswd`,
-which authenticate against the group password through crypt(3) rather than
-PAM -- so a group administrator can still use them. The other ten tools are
-root-only anyway and reach the account files directly.
+Unaffected: `passwd -S/-l/-u/-d/-e/-n/-x/-w/-i`, and `newgrp`, `sg` and
+`gpasswd`, which authenticate against the group password through crypt(3)
+rather than PAM -- so a group administrator can still use them. The other ten
+tools are root-only anyway and reach the account files directly.
 
 ### 2. No NSS
 
 `shadow_core::process` resolves the calling user through `getpwuid_r`, used by
-`passwd`, `chfn`, `chsh`, `chage`, `newgrp` and `gpasswd`.
+`passwd`, `chfn`, `chsh`, `chage`, `newgrp`, `sg` and `gpasswd`.
 
 glibc answers such lookups through its NSS module system, so it sees users from
 LDAP, SSSD, Active Directory or systemd-userdb. musl has no NSS module system
-and reads `/etc/passwd` directly. On a directory-joined host those six tools
+and reads `/etc/passwd` directly. On a directory-joined host those seven tools
 do not see network users at all.
 
 ### 3. No yescrypt (`$y$`)
@@ -109,7 +109,7 @@ yescrypt.
 
 This is not a marginal format: **Debian 12+ and Ubuntu 24.04 use yescrypt as
 the default password hash.** A musl build can neither verify nor produce `$y$`
-hashes, so `newgrp` and `gpasswd` fail against a `$y$` group password,
+hashes, so `newgrp`, `sg` and `gpasswd` fail against a `$y$` group password,
 `gpasswd` cannot set one on a host configured for yescrypt, and `chpasswd -c
 YESCRYPT` is rejected. The prefix guard in `shadow_core::crypt` reports the
 unsupported method explicitly; it never falls back to a weaker hash silently.

--- a/docs/SECURITY-HARDENING.md
+++ b/docs/SECURITY-HARDENING.md
@@ -7,7 +7,8 @@ Techniques adopted from OpenBSD and best practices for setuid-root tools.
 ### Privilege model
 
 - [x] `caller_is_root()` uses `getuid()` not `geteuid()` for authorization
-- [x] In the multicall layout, an applet outside `passwd`/`chfn`/`chsh`/`newgrp`
+- [x] In the multicall layout, an applet outside
+      `passwd`/`chfn`/`chsh`/`newgrp`/`gpasswd`/`sg`
       drops to the caller's uid before running, so the single setuid binary has
       the same privilege model as the per-tool install — and fails closed if the
       kernel will not take the privilege away
@@ -34,7 +35,9 @@ Techniques adopted from OpenBSD and best practices for setuid-root tools.
       (`PrivDrop` RAII, #39). `passwd` keeps euid 0 across `pam_chauthtok`:
       `pam_unix` needs it to run its helper and rewrite `/etc/shadow`, and keys
       the current-password prompt on the *real* uid, which stays the caller's
-- [x] `initgroups()` in `newgrp` (prevent supplementary group leak across exec)
+- [x] `initgroups()` in `newgrp` and `sg` (prevent supplementary group leak
+      across exec), with the caller's original primary group added back so the
+      switch does not cost them access to their own files
 
 ### File integrity
 

--- a/docs/man/newgrp.1.md
+++ b/docs/man/newgrp.1.md
@@ -20,8 +20,11 @@ With no *group*, the shell is started with the user's own primary group from
 The shell comes from the user's /etc/passwd record, never from **$SHELL**:
 **newgrp** is installed setuid-root, and an environment variable is the
 caller's to choose. Privileges are dropped to the caller's own user before the
-shell is started, and the supplementary group list is rebuilt from scratch so
-no membership leaks across the change.
+shell is started.
+
+The supplementary group list is rebuilt from the caller's own memberships, with
+the group they started in added to it. Keeping that group is what stops the
+switch from costing them access to their own files.
 
 **newgrp** replaces the current shell rather than nesting one inside it. Leave
 the new group by exiting that shell.
@@ -50,8 +53,13 @@ A user may enter a group without a password if it is their primary group in
 
 Otherwise the group's password from /etc/gshadow is required, and the user is
 prompted for it. A group whose password field is empty, `!`, `!!` or `*` has no
-usable password, so a non-member is refused outright: those values mean "no
-password access", not "no password needed".
+usable password, and a non-member is refused: those values mean "no password
+access", not "no password needed".
+
+The prompt appears either way. Refusing such a group without asking would be
+quicker, but the presence or absence of a prompt would then tell any caller
+which groups have passwords set, and that is a list of the ones worth
+attacking.
 
 Membership is read from /etc/group and the password from /etc/gshadow. The
 member list in /etc/gshadow does not by itself grant access, matching the

--- a/docs/man/sg.1.md
+++ b/docs/man/sg.1.md
@@ -1,0 +1,129 @@
+# sg(1) - execute a command as a different group
+
+## NAME
+
+sg - execute a command as a different group
+
+## SYNOPSIS
+
+**sg** *group* [[**-c**] *command*]
+
+## DESCRIPTION
+
+The **sg** command runs *command* with *group* as the primary group. Files the
+command creates belong to *group* without any need to change permissions
+afterwards, which is the usual reason to run it.
+
+**sg** is **newgrp**(1) for a single command. The two decide who may enter a
+group by the same rules, move the process into it the same way, and differ only
+in what follows: **newgrp** replaces the caller's shell and leaves them in the
+new group until they exit it, while **sg** runs one command and is done. On
+systems shipping the GNU shadow suite the two are the same binary, reached
+through a symlink.
+
+With no *command*, **sg** starts a shell, behaving as **newgrp** does.
+
+The command is run by the shell named in the caller's /etc/passwd record, never
+by **$SHELL**: **sg** is installed setuid-root, and an environment variable is
+the caller's to choose. Privileges are dropped to the caller's own user before
+the command is started.
+
+The supplementary group list is rebuilt from the caller's own memberships, with
+the group they started in added to it. Keeping that group is what stops the
+switch from costing them access to their own files.
+
+**sg** changes the group and nothing else. The user, the environment and the
+working directory are the caller's throughout; it is not **su**(1).
+
+## THE -c OPERAND
+
+**-c** is optional and has no effect: `sg staff -c 'id -gn'` and
+`sg staff 'id -gn'` are the same request. It is accepted because the GNU tool
+accepts it, and scripts written against that tool pass it.
+
+*command* is a single operand, so a command of more than one word must be
+quoted. It is handed to the shell, which means shell syntax — pipes,
+redirections, `&&` — works inside it. Operands after *command* are ignored.
+
+## PERMISSIONS
+
+A user may enter a group without a password if it is their primary group in
+/etc/passwd, or if they are listed as a member of it in /etc/group.
+
+Otherwise the group's password from /etc/gshadow is required, and the user is
+prompted for it. A group whose password field is empty, `!`, `!!` or `*` has no
+usable password, and a non-member is refused: those values mean "no password
+access", not "no password needed".
+
+The prompt appears either way. Refusing such a group without asking would be
+quicker, but the presence or absence of a prompt would then tell any caller
+which groups have passwords set, and that is a list of the ones worth
+attacking.
+
+Being named an administrator of a group in /etc/gshadow does not by itself
+grant entry. An administrator may add themselves to the group with
+**gpasswd**(1), and is then a member like any other.
+
+The superuser may enter any group without a password.
+
+## OPERANDS
+
+*group*
+:   The group to run the command in. Defaults to the caller's primary group.
+
+**-c**
+:   Optional, and ignored. Accepted for compatibility.
+
+*command*
+:   The command to run, as a single operand. Defaults to starting a shell.
+
+## EXIT STATUS
+
+**sg** replaces itself with the shell that runs *command*, so the status the
+caller sees is the command's own — including the shell's **127** for a command
+that could not be run. A script may test it exactly as if it had run the
+command directly.
+
+**1**
+:   Unknown group, permission denied, wrong password, or the shell could not be
+    started.
+
+## FILES
+
+/etc/passwd
+:   User account information, including the shell and primary group.
+
+/etc/group
+:   Group membership.
+
+/etc/gshadow
+:   Group passwords.
+
+## EXAMPLES
+
+Create a file owned by the `staff` group:
+
+```
+$ sg staff -c 'touch report.txt'
+$ ls -l report.txt
+-rw-r--r-- 1 alice staff 0 Sep  6 11:04 report.txt
+```
+
+Check which group a command would run in:
+
+```
+$ sg docker 'id -gn'
+docker
+```
+
+The command's exit status is the caller's:
+
+```
+$ sg staff -c 'test -w /srv/shared'
+$ echo $?
+0
+```
+
+## SEE ALSO
+
+group(5), gshadow(5), gpasswd(1), newgrp(1)

--- a/src/bin/completions.rs
+++ b/src/bin/completions.rs
@@ -47,6 +47,8 @@ fn get_tool_app(name: &str) -> Option<Command> {
         "passwd" => Some(passwd::uu_app()),
         #[cfg(feature = "pwck")]
         "pwck" => Some(pwck::uu_app()),
+        #[cfg(feature = "sg")]
+        "sg" => Some(sg::uu_app()),
         #[cfg(feature = "useradd")]
         "useradd" => Some(useradd::uu_app()),
         #[cfg(feature = "userdel")]
@@ -84,6 +86,8 @@ fn all_tool_names() -> Vec<&'static str> {
     names.push("passwd");
     #[cfg(feature = "pwck")]
     names.push("pwck");
+    #[cfg(feature = "sg")]
+    names.push("sg");
     #[cfg(feature = "useradd")]
     names.push("useradd");
     #[cfg(feature = "userdel")]

--- a/src/bin/shadow-rs.rs
+++ b/src/bin/shadow-rs.rs
@@ -10,8 +10,9 @@
 //!
 //! # Privileges
 //!
-//! The per-tool install makes only `passwd`, `chfn`, `chsh` and `newgrp`
-//! setuid-root. A multicall install has to make the one binary setuid, which
+//! The per-tool install makes only `passwd`, `chfn`, `chsh`, `newgrp`,
+//! `gpasswd` and `sg` setuid-root.
+//! A multicall install has to make the one binary setuid, which
 //! would hand euid 0 to every applet — an unprivileged `pwck -s` rewriting
 //! `/etc/passwd`. So before an applet outside that set runs, the binary drops
 //! back to the caller's uid, and the two layouts have the same privilege
@@ -24,9 +25,11 @@ use std::process::ExitCode;
 
 type Applet = fn(&[OsString]) -> i32;
 
-/// Applets that keep euid 0 for an unprivileged caller: the same five that
-/// `make install` marks setuid.
-const SETUID_APPLETS: [&str; 5] = ["passwd", "chfn", "chsh", "newgrp", "gpasswd"];
+/// Applets that keep euid 0 for an unprivileged caller: the same six that
+/// `make install` marks setuid. `sg` is here for the reason `newgrp` is --
+/// it has to read `/etc/gshadow` to check a group password, and the GNU suite
+/// ships it as a symlink to the setuid `newgrp` for exactly that.
+const SETUID_APPLETS: [&str; 6] = ["passwd", "chfn", "chsh", "newgrp", "gpasswd", "sg"];
 
 /// Every applet compiled into this binary, by name, in `--list` order.
 // `#[cfg]` is not accepted on the elements of a `vec![]` literal, so the
@@ -36,7 +39,7 @@ const SETUID_APPLETS: [&str; 5] = ["passwd", "chfn", "chsh", "newgrp", "gpasswd"
 // nothing, and the binding is then not mutated.
 #[allow(unused_mut)]
 fn applets() -> Vec<(&'static str, Applet)> {
-    let mut table: Vec<(&'static str, Applet)> = Vec::with_capacity(14);
+    let mut table: Vec<(&'static str, Applet)> = Vec::with_capacity(16);
     #[cfg(feature = "chage")]
     table.push(("chage", |a| chage::uumain(a.iter().cloned())));
     #[cfg(feature = "chfn")]
@@ -61,6 +64,8 @@ fn applets() -> Vec<(&'static str, Applet)> {
     table.push(("passwd", |a| passwd::uumain(a.iter().cloned())));
     #[cfg(feature = "pwck")]
     table.push(("pwck", |a| pwck::uumain(a.iter().cloned())));
+    #[cfg(feature = "sg")]
+    table.push(("sg", |a| sg::uumain(a.iter().cloned())));
     #[cfg(feature = "useradd")]
     table.push(("useradd", |a| useradd::uumain(a.iter().cloned())));
     #[cfg(feature = "userdel")]
@@ -225,9 +230,9 @@ fn print_available_utils() {
 mod tests {
     use super::*;
 
-    const ALL_TOOLS: [&str; 15] = [
+    const ALL_TOOLS: [&str; 16] = [
         "chage", "chfn", "chpasswd", "chsh", "gpasswd", "groupadd", "groupdel", "groupmod",
-        "grpck", "newgrp", "passwd", "pwck", "useradd", "userdel", "usermod",
+        "grpck", "newgrp", "passwd", "pwck", "sg", "useradd", "userdel", "usermod",
     ];
 
     // The table drives both dispatch and `--list`, so it must contain only
@@ -242,14 +247,17 @@ mod tests {
         assert!(names.iter().all(|n| ALL_TOOLS.contains(n)));
     }
 
-    // Exactly the four tools that the per-tool install marks setuid keep the
+    // Exactly the tools that the per-tool install marks setuid keep the
     // privilege; every other applet gives it up before running.
     #[test]
     fn only_self_service_tools_keep_privilege() {
         for tool in ALL_TOOLS {
             assert_eq!(
                 keeps_privilege(tool),
-                matches!(tool, "passwd" | "chfn" | "chsh" | "newgrp" | "gpasswd"),
+                matches!(
+                    tool,
+                    "passwd" | "chfn" | "chsh" | "newgrp" | "gpasswd" | "sg"
+                ),
                 "{tool}"
             );
         }

--- a/src/shadow-core/src/group_switch.rs
+++ b/src/shadow-core/src/group_switch.rs
@@ -1,0 +1,235 @@
+// This file is part of the shadow-rs package.
+//
+// For the full copyright and license information, please view the LICENSE
+// file that was distributed with this source code.
+// spell-checker:ignore gshadow initgroups setgid newgrp
+
+//! Entering a group — the half `newgrp(1)` and `sg(1)` share.
+//!
+//! Both tools do the same three things before they diverge: work out which
+//! group the caller asked for, decide whether the caller is entitled to it,
+//! and move the process into it. Only what follows differs — `newgrp` replaces
+//! the caller's shell, `sg` runs a single command — so everything up to that
+//! point lives here.
+//!
+//! Distributions that ship the GNU suite make `sg` a symlink to `newgrp`, so
+//! the two cannot disagree there. Keeping the shared half in one module is
+//! what buys us the same guarantee.
+
+use std::ffi::CString;
+
+use crate::error::ShadowError;
+use crate::sysroot::SysRoot;
+
+/// The caller, resolved once, so the tool can exec their shell afterwards.
+#[derive(Debug, Clone)]
+pub struct Session {
+    /// The caller's login name.
+    pub username: String,
+    /// The login shell from the caller's passwd entry — never `$SHELL`, which
+    /// is attacker-controlled in a setuid-root process.
+    pub shell: String,
+    /// The home directory from the passwd entry. May be empty.
+    pub home: String,
+}
+
+/// The shell to fall back to when the passwd entry names none.
+const DEFAULT_SHELL: &str = "/bin/sh";
+
+/// Whether `username` may enter the group without knowing its password.
+///
+/// Membership is either holding the group as one's primary GID or appearing in
+/// its member list. Being listed as a group *administrator* in `/etc/gshadow`
+/// is deliberately not enough: an administrator may change the membership, and
+/// can therefore add themselves, but until they do they are not a member.
+fn is_member(username: &str, user_gid: u32, target_gid: u32, members: &[String]) -> bool {
+    user_gid == target_gid || members.iter().any(|m| m == username)
+}
+
+/// The group's password hash, or `None` when it has no usable one.
+///
+/// `!`, `*`, `!!` and the empty string all mean "no password will ever match".
+fn group_password(root: &SysRoot, group_name: &str) -> Option<String> {
+    let entries = crate::gshadow::read_gshadow_file(&root.gshadow_path()).ok()?;
+    let entry = entries.iter().find(|e| e.name == group_name)?;
+    if matches!(entry.passwd.as_str(), "" | "!" | "*" | "!!") {
+        return None;
+    }
+    Some(entry.passwd.clone())
+}
+
+/// Prompt for the group password and check it.
+///
+/// The prompt is unconditional. A group with no password could be refused
+/// outright without ever asking, but then the presence of a prompt would tell
+/// any caller which groups have passwords set and which do not, and that is a
+/// map of the ones worth attacking. Asking either way costs one wasted prompt
+/// and answers nothing.
+fn authenticate(root: &SysRoot, group_name: &str) -> Result<(), ShadowError> {
+    let hash = group_password(root, group_name);
+
+    let password = crate::tty::read_password("Password: ")
+        .map_err(|e| ShadowError::Auth(format!("cannot read the password: {e}").into()))?;
+
+    let Some(hash) = hash else {
+        return Err(ShadowError::Auth(
+            format!("permission denied for group '{group_name}'").into(),
+        ));
+    };
+
+    if crate::crypt::verify_password(&password, &hash)? {
+        Ok(())
+    } else {
+        Err(ShadowError::Auth("incorrect password".into()))
+    }
+}
+
+/// Resolve `group`, authorize the caller, and move the process into it.
+///
+/// `group` is `None` when the caller named no group, which both tools take to
+/// mean their own primary group. That leaves the group ID where it was, but it
+/// still reinitializes the supplementary set, which is what POSIX asks for.
+///
+/// On return the process holds the target group, the caller's full
+/// supplementary set, and the caller's own real UID — so a setuid-root caller
+/// has already given the privilege back before the shell is reached.
+pub fn enter(root: &SysRoot, group: Option<&str>) -> Result<Session, ShadowError> {
+    let real_uid = rustix::process::getuid().as_raw();
+    let entry = crate::hardening::lookup_passwd_entry_by_uid(real_uid)?;
+
+    let target_gid = match group {
+        None => entry.gid,
+        Some(name) => {
+            let group_path = root.group_path();
+            let groups = crate::group::read_group_file(&group_path).map_err(|e| {
+                ShadowError::Other(format!("cannot read {}: {e}", group_path.display()).into())
+            })?;
+            let Some(target) = groups.iter().find(|g| g.name == name) else {
+                // GNU's wording, which scripts match on.
+                return Err(ShadowError::Validation("no such group".into()));
+            };
+
+            if !crate::hardening::caller_is_root()
+                && !is_member(&entry.name, entry.gid, target.gid, &target.members)
+            {
+                authenticate(root, name)?;
+            }
+            target.gid
+        }
+    };
+
+    crate::process::setgid(target_gid).map_err(|e| {
+        ShadowError::Other(format!("cannot set group ID to {target_gid}: {e}").into())
+    })?;
+
+    // POSIX has newgrp reinitialize the group list; without this the new shell
+    // would carry the supplementary groups of the old one.
+    let username_c = CString::new(entry.name.as_str())
+        .map_err(|_| ShadowError::Validation("invalid username".into()))?;
+    crate::process::initgroups(&username_c, target_gid)
+        .map_err(|e| ShadowError::Other(format!("cannot initialize groups: {e}").into()))?;
+
+    // The group the caller started in has to survive the switch. `initgroups`
+    // rebuilds the list from the member lists in `/etc/group`, and a primary
+    // group is never named there, so on its own it drops the caller's original
+    // group -- `sg staff` would cost them access to their own files. Adding it
+    // back is what the GNU tools do, and it has to happen while the privilege
+    // to call setgroups(2) is still in hand.
+    if entry.gid != target_gid {
+        let mut groups = crate::process::getgroups()
+            .map_err(|e| ShadowError::Other(format!("cannot read the group list: {e}").into()))?;
+        if !groups.contains(&entry.gid) {
+            groups.push(entry.gid);
+            crate::process::setgroups(&groups).map_err(|e| {
+                ShadowError::Other(format!("cannot set the group list: {e}").into())
+            })?;
+        }
+    }
+
+    // Give the setuid privilege back before anything the caller chose runs.
+    if rustix::process::geteuid().as_raw() != real_uid {
+        crate::process::setuid(real_uid)
+            .map_err(|e| ShadowError::Other(format!("cannot drop privileges: {e}").into()))?;
+    }
+
+    Ok(Session {
+        username: entry.name,
+        shell: if entry.shell.is_empty() {
+            DEFAULT_SHELL.to_string()
+        } else {
+            entry.shell
+        },
+        home: entry.home,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_member_by_primary_gid() {
+        assert!(is_member("alice", 1000, 1000, &[]));
+    }
+
+    #[test]
+    fn test_is_member_by_group_list() {
+        let members = vec!["alice".to_string(), "bob".to_string()];
+        assert!(is_member("alice", 1000, 27, &members));
+    }
+
+    #[test]
+    fn test_is_not_member() {
+        let members = vec!["bob".to_string()];
+        assert!(!is_member("alice", 1000, 27, &members));
+    }
+
+    /// A locked, disabled, or absent group password is never a usable hash,
+    /// however it is spelled.
+    #[test]
+    fn test_group_password_recognizes_no_password() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        for locked in ["!", "*", "!!", ""] {
+            std::fs::create_dir_all(dir.path().join("etc")).expect("mkdir");
+            std::fs::write(
+                dir.path().join("etc/gshadow"),
+                format!("staff:{locked}::\n"),
+            )
+            .expect("write");
+            let root = SysRoot::new(Some(dir.path()));
+            assert!(
+                group_password(&root, "staff").is_none(),
+                "{locked:?} should not be a usable password"
+            );
+        }
+    }
+
+    #[test]
+    fn test_group_password_returns_the_hash() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::create_dir_all(dir.path().join("etc")).expect("mkdir");
+        std::fs::write(
+            dir.path().join("etc/gshadow"),
+            "staff:$6$saltsalt$hashhere::\n",
+        )
+        .expect("write");
+        let root = SysRoot::new(Some(dir.path()));
+        assert_eq!(
+            group_password(&root, "staff").as_deref(),
+            Some("$6$saltsalt$hashhere")
+        );
+    }
+
+    #[test]
+    fn test_group_password_missing_group_and_missing_file() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::create_dir_all(dir.path().join("etc")).expect("mkdir");
+        std::fs::write(dir.path().join("etc/gshadow"), "other:!::\n").expect("write");
+        let root = SysRoot::new(Some(dir.path()));
+        assert!(group_password(&root, "staff").is_none());
+
+        let empty = tempfile::tempdir().expect("tempdir");
+        let root = SysRoot::new(Some(empty.path()));
+        assert!(group_password(&root, "staff").is_none());
+    }
+}

--- a/src/shadow-core/src/lib.rs
+++ b/src/shadow-core/src/lib.rs
@@ -45,6 +45,11 @@ pub mod pam;
 #[allow(unsafe_code)]
 pub mod crypt;
 
+// Entering a group has to check the group password, so it follows the gate of
+// the module that checks it.
+#[cfg(feature = "crypt")]
+pub mod group_switch;
+
 // Process-level POSIX wrappers (setuid, sigprocmask, etc.) — FFI requires unsafe.
 #[allow(unsafe_code)]
 pub mod process;

--- a/src/shadow-core/src/process.rs
+++ b/src/shadow-core/src/process.rs
@@ -76,6 +76,40 @@ pub fn initgroups(user: &CStr, gid: u32) -> io::Result<()> {
     }
 }
 
+/// `getgroups()` — the process's current supplementary group list.
+pub fn getgroups() -> io::Result<Vec<u32>> {
+    // SAFETY: a null buffer with size 0 asks getgroups for the count only,
+    // which is the documented way to size the real call.
+    let count = unsafe { libc::getgroups(0, std::ptr::null_mut()) };
+    if count < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    let len = usize::try_from(count).unwrap_or(0);
+    let mut groups: Vec<libc::gid_t> = vec![0; len];
+    // SAFETY: the buffer holds exactly `count` gid_t, which is the size passed.
+    let filled = unsafe { libc::getgroups(count, groups.as_mut_ptr()) };
+    if filled < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    groups.truncate(usize::try_from(filled).unwrap_or(0));
+    Ok(groups)
+}
+
+/// `setgroups(groups)` — replace the process's supplementary group list.
+///
+/// Requires `CAP_SETGID`, so a setuid-root tool must call this before it gives
+/// the privilege back.
+pub fn setgroups(groups: &[u32]) -> io::Result<()> {
+    // SAFETY: the pointer and length describe `groups` exactly, and setgroups
+    // only reads from it.
+    let ret = unsafe { libc::setgroups(groups.len(), groups.as_ptr()) };
+    if ret == 0 {
+        Ok(())
+    } else {
+        Err(io::Error::last_os_error())
+    }
+}
+
 // ---------------------------------------------------------------------------
 // exec
 // ---------------------------------------------------------------------------

--- a/src/uu/newgrp/src/newgrp.rs
+++ b/src/uu/newgrp/src/newgrp.rs
@@ -15,9 +15,7 @@ use std::path::Path;
 
 use clap::{Arg, Command};
 
-use shadow_core::crypt;
-use shadow_core::group;
-use shadow_core::gshadow;
+use shadow_core::group_switch::{self, Session};
 use shadow_core::sysroot::SysRoot;
 
 use uucore::error::{UError, UResult};
@@ -92,85 +90,10 @@ impl UError for NewgrpError {
     }
 }
 
-// ---------------------------------------------------------------------------
-// Security hardening
-// ---------------------------------------------------------------------------
-
-// Hardening functions are now centralized in shadow_core::hardening.
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-/// Get the current user's primary GID from the real UID.
-fn get_current_gid() -> Result<u32, NewgrpError> {
-    let uid = rustix::process::getuid().as_raw();
-    match shadow_core::hardening::lookup_passwd_entry_by_uid(uid) {
-        Ok(entry) => Ok(entry.gid),
-        Err(e) => Err(NewgrpError::Error(format!(
-            "cannot determine current user for uid {uid}: {e}"
-        ))),
+impl From<shadow_core::error::ShadowError> for NewgrpError {
+    fn from(e: shadow_core::error::ShadowError) -> Self {
+        Self::Error(e.to_string())
     }
-}
-
-/// Determine the shell to exec from the user's passwd entry.
-///
-/// Reads the shell field from `/etc/passwd` for the given UID rather
-/// than trusting `$SHELL`, which is attacker-controlled in a
-/// setuid-root context.
-fn get_shell(uid: u32) -> String {
-    match shadow_core::hardening::lookup_passwd_entry_by_uid(uid) {
-        Ok(entry) => {
-            if entry.shell.is_empty() {
-                "/bin/sh".to_string()
-            } else {
-                entry.shell
-            }
-        }
-        _ => "/bin/sh".to_string(),
-    }
-}
-
-/// Check if the user is a member of the group (either as primary GID
-/// in /etc/passwd or in the group's member list in /etc/group).
-fn is_member(username: &str, user_gid: u32, target_gid: u32, group_members: &[String]) -> bool {
-    if user_gid == target_gid {
-        return true;
-    }
-    group_members.iter().any(|m| m == username)
-}
-
-/// Check if the group has a usable password in /etc/gshadow.
-/// A password of `!`, `*`, `!!`, or empty means no password access.
-fn group_has_password(gshadow_path: &Path, group_name: &str) -> Option<String> {
-    let entries = gshadow::read_gshadow_file(gshadow_path).ok()?;
-    let entry = entries.iter().find(|e| e.name == group_name)?;
-
-    if entry.passwd.is_empty() || entry.passwd == "!" || entry.passwd == "*" || entry.passwd == "!!"
-    {
-        return None;
-    }
-
-    Some(entry.passwd.clone())
-}
-
-/// Read the group password, with echo off and interrupts blocked.
-///
-/// The shared helper is what keeps Ctrl-C at this prompt from leaving the
-/// terminal with echo disabled, and it falls back to stderr/stdin where there
-/// is no controlling terminal.
-fn read_password(prompt: &str) -> Result<zeroize::Zeroizing<String>, NewgrpError> {
-    shadow_core::tty::read_password(prompt)
-        .map_err(|e| NewgrpError::Error(format!("cannot read the password: {e}")))
-}
-
-/// Verify a password against a crypt(3) hash.
-///
-/// Delegates to `shadow_core::crypt::verify_password` which wraps
-/// the POSIX `crypt(3)` function.
-fn verify_password(password: &str, hash: &str) -> Result<bool, NewgrpError> {
-    crypt::verify_password(password, hash)
-        .map_err(|e| NewgrpError::Error(format!("password verification failed: {e}")))
 }
 
 // ---------------------------------------------------------------------------
@@ -190,11 +113,6 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         return Ok(());
     };
 
-    let root = SysRoot::default();
-    let username = shadow_core::hardening::current_username()
-        .map_err(|e| NewgrpError::Error(e.to_string()))?;
-    let user_gid = get_current_gid()?;
-
     let operands: Vec<String> = matches
         .get_many::<String>(options::OPERANDS)
         .map(|v| v.cloned().collect())
@@ -204,74 +122,12 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         group: group_name,
     } = parse_operands(&operands)?;
 
-    // Resolve the target GID.
-    let target_gid = if let Some(gname) = group_name {
-        let gname = &gname.to_string();
-        // Look up the group in /etc/group.
-        let group_path = root.group_path();
-        let groups = group::read_group_file(&group_path).map_err(|e| {
-            NewgrpError::Error(format!("cannot read {}: {e}", group_path.display()))
-        })?;
+    let session =
+        group_switch::enter(&SysRoot::default(), group_name).map_err(NewgrpError::from)?;
 
-        let Some(group_entry) = groups.iter().find(|g| g.name == *gname) else {
-            return Err(NewgrpError::Error(format!("group '{gname}' does not exist")).into());
-        };
-
-        let gid = group_entry.gid;
-
-        // Check membership: if the user is not a member, they need the
-        // group password. Root always gets in.
-        if !shadow_core::hardening::caller_is_root()
-            && !is_member(&username, user_gid, gid, &group_entry.members)
-        {
-            // Check if the group has a password in /etc/gshadow.
-            let gshadow_path = root.gshadow_path();
-            match group_has_password(&gshadow_path, gname) {
-                Some(hash) => {
-                    let password = read_password("Password: ")?;
-                    if !verify_password(&password, &hash)? {
-                        return Err(NewgrpError::Error("incorrect password".into()).into());
-                    }
-                }
-                None => {
-                    return Err(NewgrpError::Error(format!(
-                        "permission denied for group '{gname}'"
-                    ))
-                    .into());
-                }
-            }
-        }
-
-        gid
-    } else {
-        // No group specified — change to user's primary group.
-        user_gid
-    };
-
-    // Set the new GID.
-    shadow_core::process::setgid(target_gid)
-        .map_err(|e| NewgrpError::Error(format!("cannot set group ID to {target_gid}: {e}")))?;
-
-    // Reset supplementary groups. POSIX requires newgrp to reinitialize
-    // the group list. Without this, the new shell inherits stale groups.
-    let username_cstr = std::ffi::CString::new(username.as_str())
-        .map_err(|_| NewgrpError::Error("invalid username".into()))?;
-    shadow_core::process::initgroups(&username_cstr, target_gid)
-        .map_err(|e| NewgrpError::Error(format!("cannot initialize groups: {e}")))?;
-
-    // Drop back to the real UID (in case we are setuid-root).
-    let real_uid = rustix::process::getuid().as_raw();
-    if rustix::process::geteuid().as_raw() != real_uid {
-        shadow_core::process::setuid(real_uid)
-            .map_err(|e| NewgrpError::Error(format!("cannot drop privileges: {e}")))?;
-    }
-
-    // Exec the user's shell (from passwd entry, not $SHELL).
-    let shell = get_shell(real_uid);
-    let shell_cstr = CString::new(shell.as_str())
+    let shell_cstr = CString::new(session.shell.as_str())
         .map_err(|_| NewgrpError::Error("invalid shell path".into()))?;
-
-    let basename = Path::new(&shell)
+    let basename = Path::new(&session.shell)
         .file_name()
         .map_or_else(|| "sh".to_string(), |n| n.to_string_lossy().to_string());
 
@@ -283,7 +139,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         let argv0 = CString::new(basename.as_str())
             .map_err(|_| NewgrpError::Error("invalid shell name".into()))?;
         let err = shadow_core::process::execv(&shell_cstr, &[&argv0]);
-        return Err(NewgrpError::Error(format!("cannot exec {shell}: {err}")).into());
+        return Err(NewgrpError::Error(format!("cannot exec {}: {err}", session.shell)).into());
     }
 
     // newgrp(1) with `-`: "the user's environment will be reinitialized as
@@ -293,15 +149,12 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let argv0 = CString::new(format!("-{basename}"))
         .map_err(|_| NewgrpError::Error("invalid shell name".into()))?;
 
-    let home = shadow_core::hardening::lookup_passwd_entry_by_uid(real_uid)
-        .map(|e| e.home)
-        .unwrap_or_default();
-    if !home.is_empty() {
+    if !session.home.is_empty() {
         // A missing or unreadable home is not fatal; login(1) falls back to /.
-        let _ = rustix::process::chdir(Path::new(&home));
+        let _ = rustix::process::chdir(Path::new(&session.home));
     }
 
-    let env = login_environment(&username, &home, &shell);
+    let env = login_environment(&session);
     let env_cstrings: Vec<CString> = env
         .into_iter()
         .map(|kv| CString::new(kv).map_err(|_| NewgrpError::Error("invalid environment".into())))
@@ -309,7 +162,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let env_refs: Vec<&std::ffi::CStr> = env_cstrings.iter().map(CString::as_c_str).collect();
 
     let err = shadow_core::process::execve(&shell_cstr, &[&argv0], &env_refs);
-    Err(NewgrpError::Error(format!("cannot exec {shell}: {err}")).into())
+    Err(NewgrpError::Error(format!("cannot exec {}: {err}", session.shell)).into())
 }
 
 /// The environment a login shell is entitled to expect.
@@ -317,12 +170,17 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 /// Everything else the caller was carrying is dropped, which is the whole
 /// point of `newgrp -`. `TERM` and the locale variables are kept because a
 /// login session inherits them from the terminal, not from the profile.
-fn login_environment(user: &str, home: &str, shell: &str) -> Vec<String> {
+fn login_environment(session: &Session) -> Vec<String> {
+    let Session {
+        username,
+        shell,
+        home,
+    } = session;
     let mut env = vec![
         format!("HOME={home}"),
         format!("SHELL={shell}"),
-        format!("USER={user}"),
-        format!("LOGNAME={user}"),
+        format!("USER={username}"),
+        format!("LOGNAME={username}"),
         "PATH=/usr/local/bin:/usr/bin:/bin".to_string(),
     ];
     for (k, v) in std::env::vars() {
@@ -359,80 +217,6 @@ mod tests {
     #[test]
     fn test_app_builds() {
         uu_app().debug_assert();
-    }
-
-    // -----------------------------------------------------------------------
-    // Membership tests
-    // -----------------------------------------------------------------------
-
-    #[test]
-    fn test_is_member_by_primary_gid() {
-        assert!(is_member("alice", 1000, 1000, &[]));
-    }
-
-    #[test]
-    fn test_is_member_by_group_list() {
-        let members = vec!["alice".to_string(), "bob".to_string()];
-        assert!(is_member("alice", 1000, 27, &members));
-    }
-
-    #[test]
-    fn test_is_not_member() {
-        let members = vec!["bob".to_string()];
-        assert!(!is_member("alice", 1000, 27, &members));
-    }
-
-    // -----------------------------------------------------------------------
-    // Group password tests
-    // -----------------------------------------------------------------------
-
-    #[test]
-    fn test_group_has_password_locked() {
-        let dir = tempfile::tempdir().expect("tempdir");
-        let path = dir.path().join("gshadow");
-        std::fs::write(&path, "testgroup:!::\n").expect("write");
-        assert!(group_has_password(&path, "testgroup").is_none());
-    }
-
-    #[test]
-    fn test_group_has_password_star() {
-        let dir = tempfile::tempdir().expect("tempdir");
-        let path = dir.path().join("gshadow");
-        std::fs::write(&path, "testgroup:*::\n").expect("write");
-        assert!(group_has_password(&path, "testgroup").is_none());
-    }
-
-    #[test]
-    fn test_group_has_password_empty() {
-        let dir = tempfile::tempdir().expect("tempdir");
-        let path = dir.path().join("gshadow");
-        std::fs::write(&path, "testgroup:::\n").expect("write");
-        assert!(group_has_password(&path, "testgroup").is_none());
-    }
-
-    #[test]
-    fn test_group_has_password_with_hash() {
-        let dir = tempfile::tempdir().expect("tempdir");
-        let path = dir.path().join("gshadow");
-        std::fs::write(&path, "testgroup:$6$saltsalt$hashhere::\n").expect("write");
-        let pw = group_has_password(&path, "testgroup");
-        assert!(pw.is_some());
-        assert_eq!(pw.expect("should have password"), "$6$saltsalt$hashhere");
-    }
-
-    #[test]
-    fn test_group_has_password_nonexistent_group() {
-        let dir = tempfile::tempdir().expect("tempdir");
-        let path = dir.path().join("gshadow");
-        std::fs::write(&path, "other:!::\n").expect("write");
-        assert!(group_has_password(&path, "testgroup").is_none());
-    }
-
-    #[test]
-    fn test_group_has_password_missing_file() {
-        let dir = tempfile::tempdir().expect("tempdir");
-        let path = dir.path().join("nonexistent");
-        assert!(group_has_password(&path, "testgroup").is_none());
     }
 
     // -----------------------------------------------------------------------
@@ -514,7 +298,11 @@ mod tests {
     /// carrying.
     #[test]
     fn test_login_environment_is_a_login_session() {
-        let env = login_environment("alice", "/home/alice", "/bin/bash");
+        let env = login_environment(&Session {
+            username: "alice".to_string(),
+            shell: "/bin/bash".to_string(),
+            home: "/home/alice".to_string(),
+        });
         for expected in [
             "HOME=/home/alice",
             "SHELL=/bin/bash",
@@ -531,17 +319,5 @@ mod tests {
             !env.iter().any(|e| e.starts_with("LD_PRELOAD=")),
             "the caller's environment must not be carried over"
         );
-    }
-
-    // -----------------------------------------------------------------------
-    // get_shell tests
-    // -----------------------------------------------------------------------
-
-    #[test]
-    fn test_get_shell_default() {
-        // This test is environment-dependent but should at least not panic.
-        let uid = rustix::process::getuid().as_raw();
-        let shell = get_shell(uid);
-        assert!(!shell.is_empty());
     }
 }

--- a/src/uu/sg/Cargo.toml
+++ b/src/uu/sg/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "uu_newgrp"
+name = "uu_sg"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
@@ -8,18 +8,17 @@ homepage.workspace = true
 keywords.workspace = true
 categories.workspace = true
 rust-version.workspace = true
-description = "newgrp ~ (shadow-rs) change effective group ID"
+description = "sg ~ (shadow-rs) run a command with a different primary group"
 
 [lib]
-path = "src/newgrp.rs"
+path = "src/sg.rs"
 
 [[bin]]
-name = "newgrp"
+name = "sg"
 path = "src/main.rs"
 
 [dependencies]
 clap = { workspace = true }
-rustix = { workspace = true }
 shadow-core = { workspace = true, features = ["crypt"] }
 uucore = { workspace = true }
 

--- a/src/uu/sg/locales/en-US.ftl
+++ b/src/uu/sg/locales/en-US.ftl
@@ -1,0 +1,2 @@
+sg-about = Run a command with a different primary group
+sg-usage = sg <group> [[-c] <command>]

--- a/src/uu/sg/src/main.rs
+++ b/src/uu/sg/src/main.rs
@@ -1,0 +1,6 @@
+// This file is part of the shadow-rs package.
+//
+// For the full copyright and license information, please view the LICENSE
+// file that was distributed with this source code.
+
+uucore::bin!(uu_sg);

--- a/src/uu/sg/src/sg.rs
+++ b/src/uu/sg/src/sg.rs
@@ -1,0 +1,241 @@
+// This file is part of the shadow-rs package.
+//
+// For the full copyright and license information, please view the LICENSE
+// file that was distributed with this source code.
+// spell-checker:ignore setgid setuid gshadow newgrp
+
+//! `sg` — run a command with a different primary group.
+//!
+//! Drop-in replacement for GNU shadow-utils `sg(1)`. `sg` is `newgrp(1)` for a
+//! single command: it authorizes the caller into the group the same way, then
+//! runs one command in it instead of replacing the caller's shell. On a
+//! distribution shipping the GNU suite the two are literally the same binary,
+//! and here they are the same [`shadow_core::group_switch`] call.
+
+use std::ffi::CString;
+use std::fmt;
+use std::path::Path;
+
+use clap::{Arg, Command};
+
+use shadow_core::group_switch;
+use shadow_core::sysroot::SysRoot;
+
+use uucore::error::{UError, UResult};
+
+mod options {
+    /// `group [[-c] command]`, taken together: `-c` is optional, so the
+    /// command has to be recognized positionally as well.
+    pub const OPERANDS: &str = "operands";
+}
+
+/// What the command line asked for.
+struct Operands<'a> {
+    /// The target group, or `None` for the caller's primary group.
+    group: Option<&'a str>,
+    /// The command to run, or `None` to start a shell.
+    command: Option<&'a str>,
+}
+
+/// Split `sg [group [[-c] command]]` into its parts.
+///
+/// `-c` is optional -- `sg staff 'id -gn'` and `sg staff -c 'id -gn'` are the
+/// same request -- and anything after the command is ignored, both of which
+/// match what the GNU tool accepts.
+fn parse_operands(operands: &[String]) -> Operands<'_> {
+    let command = match operands {
+        [_, flag, command, ..] if flag == "-c" => Some(command.as_str()),
+        // A trailing `-c` names no command. Falling through to the arm below
+        // would take the flag itself as the command and hand `-c` to the
+        // shell to run.
+        [_, flag] if flag == "-c" => None,
+        [_, command, ..] => Some(command.as_str()),
+        _ => None,
+    };
+    Operands {
+        group: operands.first().map(String::as_str),
+        command,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Error type
+// ---------------------------------------------------------------------------
+
+#[derive(Debug)]
+enum SgError {
+    /// Exit 1 — general error.
+    Error(String),
+}
+
+impl fmt::Display for SgError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Error(msg) => f.write_str(msg),
+        }
+    }
+}
+
+impl std::error::Error for SgError {}
+
+impl UError for SgError {
+    fn code(&self) -> i32 {
+        match self {
+            Self::Error(_) => 1,
+        }
+    }
+}
+
+impl From<shadow_core::error::ShadowError> for SgError {
+    fn from(e: shadow_core::error::ShadowError) -> Self {
+        Self::Error(e.to_string())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Entry point
+// ---------------------------------------------------------------------------
+
+#[uucore::main]
+pub fn uumain(args: impl uucore::Args) -> UResult<()> {
+    // Like newgrp, sg hands control to a shell running as the caller, so only
+    // core dumps are suppressed; raising RLIMIT_FSIZE would leak into the
+    // command the caller asked for.
+    shadow_core::hardening::suppress_core_dumps();
+
+    let Some(matches) = shadow_core::cli::parse_args(uu_app(), args, |_| 1)? else {
+        return Ok(());
+    };
+
+    let operands: Vec<String> = matches
+        .get_many::<String>(options::OPERANDS)
+        .map(|v| v.cloned().collect())
+        .unwrap_or_default();
+    let Operands { group, command } = parse_operands(&operands);
+
+    let session = group_switch::enter(&SysRoot::default(), group).map_err(SgError::from)?;
+
+    let shell_cstr = CString::new(session.shell.as_str())
+        .map_err(|_| SgError::Error("invalid shell path".into()))?;
+    let basename = Path::new(&session.shell)
+        .file_name()
+        .map_or_else(|| "sh".to_string(), |n| n.to_string_lossy().to_string());
+    let argv0 =
+        CString::new(basename.as_str()).map_err(|_| SgError::Error("invalid shell name".into()))?;
+
+    // Exec rather than fork and wait: the shell then *is* this process, so the
+    // command's exit status reaches the caller unaltered -- `sg staff -c 'exit
+    // 7'` exits 7, and a command that cannot be run exits 127 -- without sg
+    // having to reconstruct a wait status.
+    let err = match command {
+        None => shadow_core::process::execv(&shell_cstr, &[&argv0]),
+        Some(command) => {
+            let dash_c = c"-c";
+            let command =
+                CString::new(command).map_err(|_| SgError::Error("invalid command".into()))?;
+            shadow_core::process::execv(&shell_cstr, &[&argv0, dash_c, &command])
+        }
+    };
+    Err(SgError::Error(format!("cannot exec {}: {err}", session.shell)).into())
+}
+
+/// Build the clap `Command` for `sg`.
+#[must_use]
+pub fn uu_app() -> Command {
+    Command::new("sg")
+        .about("Run a command with a different primary group")
+        .override_usage("sg <group> [[-c] <command>]")
+        .version(shadow_core::cli::VERSION)
+        .after_help(shadow_core::cli::AFTER_HELP)
+        .arg(
+            Arg::new(options::OPERANDS)
+                .help("the target group, then the command to run in it")
+                .value_name("group [[-c] command]")
+                .num_args(0..)
+                // `-c` is an operand here, matched positionally, not an option.
+                .allow_hyphen_values(true)
+                .index(1),
+        )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_app_builds() {
+        uu_app().debug_assert();
+    }
+
+    #[test]
+    fn test_help_does_not_error() {
+        let result = uu_app().try_get_matches_from(["sg", "--help"]);
+        assert!(result.is_err());
+        let err = result.expect_err("expected error");
+        assert!(!err.use_stderr());
+    }
+
+    fn operands(cli: &[&str]) -> Vec<String> {
+        let mut full = vec!["sg".to_string()];
+        full.extend(cli.iter().map(|s| (*s).to_string()));
+        uu_app()
+            .try_get_matches_from(full)
+            .expect("should parse")
+            .get_many::<String>(options::OPERANDS)
+            .map(|v| v.cloned().collect())
+            .unwrap_or_default()
+    }
+
+    /// No operands at all is a shell in the caller's own primary group, the
+    /// same as bare `newgrp`.
+    #[test]
+    fn test_no_operands_is_a_shell_in_the_primary_group() {
+        let ops = operands(&[]);
+        let parsed = parse_operands(&ops);
+        assert_eq!(parsed.group, None);
+        assert_eq!(parsed.command, None);
+    }
+
+    #[test]
+    fn test_group_alone_is_a_shell() {
+        let ops = operands(&["staff"]);
+        let parsed = parse_operands(&ops);
+        assert_eq!(parsed.group, Some("staff"));
+        assert_eq!(parsed.command, None);
+    }
+
+    /// `-c` is optional: both spellings name the same command.
+    #[test]
+    fn test_command_with_and_without_dash_c() {
+        for cli in [vec!["staff", "-c", "id -gn"], vec!["staff", "id -gn"]] {
+            let ops = operands(&cli);
+            let parsed = parse_operands(&ops);
+            assert_eq!(parsed.group, Some("staff"), "{cli:?}");
+            assert_eq!(parsed.command, Some("id -gn"), "{cli:?}");
+        }
+    }
+
+    /// The command is one operand, however many words it holds, and trailing
+    /// operands after it are ignored -- as they are by the GNU tool.
+    #[test]
+    fn test_command_is_one_operand_and_extras_are_ignored() {
+        for cli in [
+            vec!["staff", "-c", "echo a b c", "ignored"],
+            vec!["staff", "echo a b c", "ignored"],
+        ] {
+            let ops = operands(&cli);
+            let parsed = parse_operands(&ops);
+            assert_eq!(parsed.command, Some("echo a b c"), "{cli:?}");
+        }
+    }
+
+    /// A trailing `-c` names no command, so it must not become one: handing
+    /// the flag to the shell would run `-c` as if the caller had asked for it.
+    #[test]
+    fn test_trailing_dash_c_is_not_itself_the_command() {
+        let ops = operands(&["staff", "-c"]);
+        let parsed = parse_operands(&ops);
+        assert_eq!(parsed.group, Some("staff"));
+        assert_eq!(parsed.command, None);
+    }
+}

--- a/tests/arm64-smoke.sh
+++ b/tests/arm64-smoke.sh
@@ -64,10 +64,10 @@ version=$("${QEMU[@]}" "$BIN" --version 2>&1)
 if [ -n "$version" ]; then ok "runs: $version"; else bad "would not run"; exit 1; fi
 
 applets=$("${QEMU[@]}" "$BIN" --list 2>/dev/null | tail -n +2 | wc -l)
-if [ "$applets" -ge 15 ]; then
+if [ "$applets" -ge 16 ]; then
     ok "carries $applets applets"
 else
-    bad "expected at least 15 applets, found $applets"
+    bad "expected at least 16 applets, found $applets"
 fi
 
 # ── A prefix tree, so nothing here touches the container's own accounts ──
@@ -117,6 +117,12 @@ if grep -q '^ada:' "$T/etc/passwd"; then
 else
     ok "the account is gone from passwd"
 fi
+
+# sg cannot be driven against a prefix tree -- it switches the running
+# process's groups and execs -- so this only checks that the applet links and
+# starts under emulation. It is the only caller of getgroups/setgroups, and a
+# wrong struct width there would show up as a failure to run at all.
+check "sg starts" "${QEMU[@]}" "$BIN" sg --help
 
 # pwck exits 2 for warnings, which a synthetic tree produces (no real shells),
 # so anything up to 2 means it read and checked the files rather than failing.

--- a/tests/by-util/test_multicall.rs
+++ b/tests/by-util/test_multicall.rs
@@ -16,9 +16,9 @@ use std::process::Command;
 use crate::common::{run, run_cmd};
 
 /// Every applet this build is expected to carry, in `--list` order.
-const TOOLS: [&str; 15] = [
+const TOOLS: [&str; 16] = [
     "chage", "chfn", "chpasswd", "chsh", "gpasswd", "groupadd", "groupdel", "groupmod", "grpck",
-    "newgrp", "passwd", "pwck", "useradd", "userdel", "usermod",
+    "newgrp", "passwd", "pwck", "sg", "useradd", "userdel", "usermod",
 ];
 
 /// The binary with no applet argument.

--- a/tests/by-util/test_sg.rs
+++ b/tests/by-util/test_sg.rs
@@ -1,0 +1,140 @@
+// This file is part of the shadow-rs package.
+//
+// For the full copyright and license information, please view the LICENSE
+// file that was distributed with this source code.
+// spell-checker:ignore newgrp
+
+//! Integration tests for the `sg` utility.
+//!
+//! `sg` execs the command it was given, so a successful run never returns.
+//! In-process tests therefore only exercise the paths that fail before the
+//! exec; everything that has to observe a *successful* switch runs the real
+//! binary as a child, which is also the only way to see the exit status the
+//! command left behind.
+
+use std::ffi::OsString;
+
+use crate::common::{run, skip_unless_root};
+
+/// Run `uumain` in-process, returning the exit code.
+///
+/// Only ever called with input that fails before the exec: a successful `sg`
+/// would replace this test binary with a shell.
+fn run_in_process(args: &[&str]) -> i32 {
+    let os_args: Vec<OsString> = args.iter().map(|s| (*s).into()).collect();
+    sg::uumain(os_args.into_iter())
+}
+
+// ---------------------------------------------------------------------------
+// Non-root tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_help_exits_zero() {
+    assert_eq!(run_in_process(&["sg", "--help"]), 0, "--help should exit 0");
+}
+
+/// GNU's wording, which scripts match on.
+#[test]
+fn test_unknown_group_is_refused() {
+    run("sg", &["nonexistent_group_99999", "-c", "true"])
+        .assert_code(1)
+        .assert_stderr_contains("no such group");
+}
+
+// ---------------------------------------------------------------------------
+// Root tests — a real group switch
+// ---------------------------------------------------------------------------
+
+/// Create a group to switch into, ignoring the error if a previous run left
+/// it behind.
+fn ensure_group(name: &str) {
+    let _ = run("groupadd", &[name]);
+}
+
+#[test]
+fn test_runs_the_command_in_the_target_group() {
+    if skip_unless_root() {
+        return;
+    }
+    ensure_group("sgtest");
+
+    run("sg", &["sgtest", "-c", "id -gn"])
+        .assert_code(0)
+        .assert_stdout_contains("sgtest");
+}
+
+/// `-c` is optional: `sg staff 'id -gn'` is the same request as
+/// `sg staff -c 'id -gn'`, and the GNU tool accepts both.
+#[test]
+fn test_dash_c_is_optional() {
+    if skip_unless_root() {
+        return;
+    }
+    ensure_group("sgtest2");
+
+    run("sg", &["sgtest2", "id -gn"])
+        .assert_code(0)
+        .assert_stdout_contains("sgtest2");
+}
+
+/// The reason `sg` execs instead of forking and waiting: whatever the command
+/// exits with is what the caller sees. A wrapper that returned 0 here, or that
+/// collapsed every failure to 1, would break any script testing `sg`'s status.
+#[test]
+fn test_the_commands_exit_status_reaches_the_caller() {
+    if skip_unless_root() {
+        return;
+    }
+    ensure_group("sgtest3");
+
+    run("sg", &["sgtest3", "-c", "exit 7"]).assert_code(7);
+    run("sg", &["sgtest3", "-c", "false"]).assert_code(1);
+    // A command the shell cannot run is 127 by convention, and that too has to
+    // survive the trip.
+    run("sg", &["sgtest3", "-c", "/nonexistent/command"]).assert_code(127);
+}
+
+/// The switch changes the primary group and keeps the caller's identity: `sg`
+/// is not `su`.
+#[test]
+fn test_the_uid_is_unchanged() {
+    if skip_unless_root() {
+        return;
+    }
+    ensure_group("sgtest4");
+
+    run("sg", &["sgtest4", "-c", "id -u"])
+        .assert_code(0)
+        .assert_stdout_contains("0");
+}
+
+/// Supplementary groups are reinitialized from the caller's own membership
+/// rather than dropped, so the target group is added to what the caller had.
+#[test]
+fn test_supplementary_groups_are_kept() {
+    if skip_unless_root() {
+        return;
+    }
+    ensure_group("sgtest5");
+
+    let out = run("sg", &["sgtest5", "-c", "id -Gn"]);
+    out.assert_code(0).assert_stdout_contains("root");
+}
+
+/// `sg` and `newgrp` are one implementation on a GNU system, where `sg` is a
+/// symlink. Both must reach the same code here too.
+#[test]
+fn test_sg_and_newgrp_agree_on_an_unknown_group() {
+    let sg = run("sg", &["nonexistent_group_99999", "-c", "true"]);
+    let newgrp = run("newgrp", &["nonexistent_group_99999"]);
+    assert_eq!(
+        sg.code, newgrp.code,
+        "sg and newgrp disagree on an unknown group"
+    );
+    assert_eq!(
+        sg.stderr.trim_start_matches("sg:"),
+        newgrp.stderr.trim_start_matches("newgrp:"),
+        "sg and newgrp report an unknown group differently"
+    );
+}

--- a/tests/e2e/deploy-test.sh
+++ b/tests/e2e/deploy-test.sh
@@ -100,8 +100,8 @@ hash_password() {
 
 # ── TOOLS list ──────────────────────────────────────────────────────
 
-TOOLS="passwd pwck useradd userdel usermod chpasswd chage groupadd groupdel groupmod gpasswd grpck chfn chsh newgrp"
-SETUID_TOOLS="passwd chfn chsh newgrp gpasswd"
+TOOLS="passwd pwck useradd userdel usermod chpasswd chage groupadd groupdel groupmod gpasswd grpck chfn chsh newgrp sg"
+SETUID_TOOLS="passwd chfn chsh newgrp gpasswd sg"
 
 # The tools an unprivileged user runs are installed in bin, the rest in sbin,
 # which is the split the GNU package uses: sbin is not on a normal user's
@@ -869,6 +869,65 @@ test_gpasswd_group_admin() {
     userdel -r gp_member 2>/dev/null || true
 }
 
+# ── sg: running one command in another group ───────────────────────
+
+test_sg_group_switch() {
+    section "sg — running one command in another group"
+
+    # sg is setuid for the same reason newgrp is: a caller who is not a member
+    # of the target group has to be checked against the group password in
+    # /etc/gshadow, which is root-only. Nothing else in this suite runs sg as
+    # an unprivileged user, so dropping sg from the setuid list fails here and
+    # nowhere else.
+    userdel -r sg_member 2>/dev/null || true
+    userdel -r sg_outsider 2>/dev/null || true
+    groupdel sg_team 2>/dev/null || true
+    groupdel sg_locked 2>/dev/null || true
+
+    assert_ok "useradd -m sg_member" useradd -m sg_member
+    assert_ok "useradd -m sg_outsider" useradd -m sg_outsider
+    assert_ok "groupadd sg_team" groupadd sg_team
+    assert_ok "groupadd sg_locked" groupadd sg_locked
+    assert_ok "gpasswd -a sg_member sg_team" gpasswd -a sg_member sg_team
+
+    assert_contains "a member runs a command in the group" "sg_team" \
+        su -s /bin/bash sg_member -c "sg sg_team -c 'id -gn'"
+    assert_contains "-c is optional" "sg_team" \
+        su -s /bin/bash sg_member -c "sg sg_team 'id -gn'"
+
+    # sg changes the group, not the user: anything else would make it su.
+    assert_contains "the caller keeps their own identity" "sg_member" \
+        su -s /bin/bash sg_member -c "sg sg_team -c 'id -un'"
+
+    # The group the caller started in must still be reachable afterwards, or
+    # the switch would cost them access to their own files.
+    assert_contains "the original primary group survives the switch" "sg_member" \
+        su -s /bin/bash sg_member -c "sg sg_team -c 'id -Gn'"
+
+    # sg execs the command, so its status is the caller's status.
+    assert_ok "the command's exit status reaches the caller" \
+        bash -c "su -s /bin/bash sg_member -c \"sg sg_team -c 'exit 7'\"; test \$? -eq 7"
+
+    # The setuid path: a non-member authenticating against the group password.
+    printf 'teampw\nteampw\n' | gpasswd sg_team >/dev/null 2>&1
+    assert_contains "a non-member with the group password gets in" "sg_team" \
+        bash -c "echo teampw | su -s /bin/bash sg_outsider -c \"sg sg_team -c 'id -gn'\""
+    assert_fail "a wrong group password is refused" \
+        bash -c "echo wrong | su -s /bin/bash sg_outsider -c \"sg sg_team -c 'id -gn'\""
+
+    # A group with no password admits nobody who is not already a member.
+    assert_fail "a non-member is refused a group with no password" \
+        bash -c "echo anything | su -s /bin/bash sg_outsider -c \"sg sg_locked -c 'id -gn'\""
+
+    assert_fail "an unknown group is refused" \
+        su -s /bin/bash sg_member -c "sg no_such_group_at_all -c true"
+
+    groupdel sg_team 2>/dev/null || true
+    groupdel sg_locked 2>/dev/null || true
+    userdel -r sg_member 2>/dev/null || true
+    userdel -r sg_outsider 2>/dev/null || true
+}
+
 # ── nscd cache invalidation ────────────────────────────────────────
 
 test_nscd() {
@@ -979,6 +1038,7 @@ main() {
     test_pam_auth
     test_self_service
     test_gpasswd_group_admin
+    test_sg_group_switch
     test_aging_and_input
     test_audit_logging
     test_root_option

--- a/tests/gnu-compat.sh
+++ b/tests/gnu-compat.sh
@@ -216,6 +216,7 @@ for pair in \
     "chfn:/usr/bin/chfn" \
     "chsh:/usr/bin/chsh" \
     "newgrp:/usr/bin/newgrp" \
+    "sg:/usr/bin/sg" \
     "useradd:/usr/sbin/useradd" \
     "userdel:/usr/sbin/userdel" \
     "usermod:/usr/sbin/usermod" \

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -46,6 +46,8 @@ mod test_newgrp;
 mod test_passwd;
 #[path = "by-util/test_pwck.rs"]
 mod test_pwck;
+#[path = "by-util/test_sg.rs"]
+mod test_sg;
 #[path = "by-util/test_useradd.rs"]
 mod test_useradd;
 #[path = "by-util/test_userdel.rs"]


### PR DESCRIPTION
Adds `sg`, the sixteenth tool: it runs a single command with a different primary group.

`sg` is the first of the nine tools that both Debian and Fedora ship and we did not. It was picked first because it is the one that proves the scaffolding: it shares nearly all its behaviour with a tool we already have.

## sg and newgrp are one implementation

They decide who may enter a group by the same rules and enter it the same way, and the distributions ship `sg` as a symlink to the setuid `newgrp` binary — one implementation dispatched on `argv[0]`:

```
$ ls -l /usr/bin/sg
lrwxrwxrwx 1 root root 6 Jul 31 15:34 /usr/bin/sg -> newgrp
```

So the shared half moves into `shadow_core::group_switch` and both tools call it. That is what keeps them from drifting apart. Our multicall binary already dispatches on `argv[0]`, so it needs only the new applet.

`sg` execs the command instead of forking and waiting for it. The shell then *is* the process, so the command's exit status reaches the caller unaltered — `sg staff -c 'exit 7'` exits 7, and a command that cannot be run exits 127 — without `sg` having to reconstruct a wait status. Same observable behaviour as the GNU tool, one fewer process.

## Two bugs in newgrp that writing the shared module exposed

**It leaked which groups have passwords.** `newgrp` refused a group with no password without prompting, and prompted when the group had one. Whether a prompt appeared therefore told any caller which groups have a password set — a list of the ones worth attacking. Both tools now prompt either way and refuse afterwards. The GNU tools do the same:

```
$ newgrp nomember          # caller is not a member, group has no password
Password:
newgrp: getline() failed: Success
```

**It dropped the caller's own primary group.** The supplementary list was rebuilt with `initgroups()` alone, which builds it from the member lists in `/etc/group` — where a primary group never appears. So `newgrp staff` cost the caller access to their own files until they left the shell. Confirmed against the GNU tool, which keeps it:

```
before      : groups=pri target
sg target   : groups=target pri
```

The original group is added back, which needs `setgroups(2)` and so has to happen before the setuid privilege is given up.

Both were established by running the GNU tools, not by reading them.

## Privilege

`sg` is setuid for the reason `newgrp` is: a caller who is not a member has to be checked against the group password in `/etc/gshadow`, which is root-only. Removing `sg` from the setuid list fails six assertions in the e2e suite — including for a plain member, since `initgroups()` itself needs the privilege — and nothing else in the suite covers it.

## Verification

| | |
|---|---|
| `cargo test --workspace` | 763 passed on debian, alpine and fedora |
| `make check` | fmt, clippy ×3, tests with and without `pam` — exit 0 |
| e2e deployment suite | 255 assertions against a real setuid install |
| `make test-gnu-compat` | 43 comparisons against the GNU binaries |
| `make test-arm64` | 19 assertions under emulation |

The e2e section covers a member, a non-member with the correct group password, a wrong password, a group with no password, an unknown group, `-c` being optional, exit-status propagation, and that the caller's uid and original primary group both survive.
