### PR TITLE
vipw, vigr: edit the account files under the suite's lock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `vipw` and `vigr`, the nineteenth and twentieth tools: they hand
+  `/etc/passwd`, `/etc/shadow`, `/etc/group` or `/etc/gshadow` to the
+  administrator's editor under the same lock every other tool takes, so a hand
+  edit cannot interleave with a `useradd` running at the same moment, and they
+  install the result atomically. Two deliberate departures from GNU: the edited
+  file is parsed before it is installed — GNU installs whatever was saved, a
+  line with no colons included — and when it is refused the edit is kept
+  beside the file rather than thrown away; and changes are detected by content,
+  where GNU compares timestamps in whole seconds and discards an edit saved
+  within the same second. `vigr` is `vipw` with the group file as its default,
+  which is how the GNU suite ships it, as a symlink
+
 - `newusers`, the eighteenth tool: it creates or updates accounts in batch
   from stdin, writing the passwd record, the hashed shadow record, a group and
   the home directory for each line. Every line is parsed, every group resolved
@@ -37,6 +49,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   which is what lets the command's own exit status reach the caller unaltered
 
 ### Changed
+
+- `shadow_core::process::spawn_with_signals_unblocked` starts a child with a
+  clean signal mask. A tool that blocks `SIGINT` while it holds a lock passes
+  that mask to every child, and an editor started under it could not be
+  interrupted at all
 
 - Home directory creation moved to `shadow_core::home`, shared by `useradd`
   and `newusers`. The care it takes -- forcing the umask so the mode is exact,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -882,6 +882,8 @@ dependencies = [
  "uu_useradd",
  "uu_userdel",
  "uu_usermod",
+ "uu_vigr",
+ "uu_vipw",
 ]
 
 [[package]]
@@ -908,6 +910,26 @@ dependencies = [
 
 [[package]]
 name = "uu_usermod"
+version = "0.4.0"
+dependencies = [
+ "clap",
+ "rustix",
+ "shadow-core",
+ "tempfile",
+ "uucore",
+]
+
+[[package]]
+name = "uu_vigr"
+version = "0.4.0"
+dependencies = [
+ "clap",
+ "uu_vipw",
+ "uucore",
+]
+
+[[package]]
+name = "uu_vipw"
 version = "0.4.0"
 dependencies = [
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,8 @@ members = [
     "src/uu/sg",
     "src/uu/chgpasswd",
     "src/uu/newusers",
+    "src/uu/vipw",
+    "src/uu/vigr",
 ]
 
 [workspace.package]
@@ -98,11 +100,13 @@ gpasswd = { optional = true, version = "0.4.0", package = "uu_gpasswd", path = "
 sg = { optional = true, version = "0.4.0", package = "uu_sg", path = "src/uu/sg" }
 chgpasswd = { optional = true, version = "0.4.0", package = "uu_chgpasswd", path = "src/uu/chgpasswd" }
 newusers = { optional = true, version = "0.4.0", package = "uu_newusers", path = "src/uu/newusers" }
+vipw = { optional = true, version = "0.4.0", package = "uu_vipw", path = "src/uu/vipw" }
+vigr = { optional = true, version = "0.4.0", package = "uu_vigr", path = "src/uu/vigr" }
 
 [features]
 default = ["passwd", "pwck", "useradd", "userdel", "usermod", "chpasswd", "chage",
            "groupadd", "groupdel", "groupmod", "grpck", "chfn", "chsh", "newgrp", "gpasswd",
-           "sg", "chgpasswd", "newusers"]
+           "sg", "chgpasswd", "newusers", "vipw", "vigr"]
 
 # PAM authentication (requires libpam-dev). The `?` matters: without it,
 # asking for PAM would drag in the three applets that can use it even when the
@@ -140,6 +144,8 @@ newgrp = { version = "0.4.0", package = "uu_newgrp", path = "src/uu/newgrp" }
 sg = { version = "0.4.0", package = "uu_sg", path = "src/uu/sg" }
 chgpasswd = { version = "0.4.0", package = "uu_chgpasswd", path = "src/uu/chgpasswd" }
 newusers = { version = "0.4.0", package = "uu_newusers", path = "src/uu/newusers" }
+vipw = { version = "0.4.0", package = "uu_vipw", path = "src/uu/vipw" }
+vigr = { version = "0.4.0", package = "uu_vigr", path = "src/uu/vigr" }
 passwd = { version = "0.4.0", package = "uu_passwd", path = "src/uu/passwd" }
 useradd = { version = "0.4.0", package = "uu_useradd", path = "src/uu/useradd" }
 userdel = { version = "0.4.0", package = "uu_userdel", path = "src/uu/userdel" }

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ SETUID_TOOLS = passwd chfn chsh newgrp gpasswd sg
 
 # Root-only tools (no setuid; fail at getuid() check for non-root callers).
 ROOT_TOOLS = useradd userdel usermod chpasswd chgpasswd newusers \
-             groupadd groupdel groupmod pwck grpck
+             groupadd groupdel groupmod pwck grpck vipw vigr
 
 # Tools an ordinary user runs, and which therefore go in bin rather than sbin:
 # sbin is not on a normal user's PATH, so `passwd` there is `command not
@@ -133,7 +133,7 @@ test-unprivileged:
 test-gnu-compat:
 	bash tests/gnu-compat.sh
 
-# Default install: 18 standalone per-tool binaries, with the setuid layout and
+# Default install: 20 standalone per-tool binaries, with the setuid layout and
 # the bin/sbin split GNU shadow-utils uses. Only $(SETUID_TOOLS) are setuid.
 install: build
 	@for tool in $(SETUID_TOOLS); do \

--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ default-in-Ubuntu in under 3 years. This project follows that playbook.
 | `sg` | **Implemented.** Runs one command in another group; shares `newgrp`'s authorization. |
 | `chgpasswd` | **Implemented.** Batch group passwords, applied all-or-nothing. |
 | `newusers` | **Implemented.** Batch account creation: passwd, shadow, group and home. |
+| `vipw` | **Implemented.** Edit passwd or shadow under the suite's lock; the result is checked before it is installed. |
+| `vigr` | **Implemented.** `vipw` for group and gshadow. |
 
 ## Building
 
@@ -91,9 +93,9 @@ docker compose run --rm debian cargo build --release
 
 ### Install
 
-Default install: 18 standalone per-tool binaries with least-privilege setuid
+Default install: 20 standalone per-tool binaries with least-privilege setuid
 layout matching GNU shadow-utils. Only `passwd`, `chfn`, `chsh`, `newgrp`,
-`gpasswd` and `sg` are installed setuid-root; the other 12 are plain `0755`.
+`gpasswd` and `sg` are installed setuid-root; the other 14 are plain `0755`.
 
 ```shell
 sudo make install PREFIX=/usr/local
@@ -145,7 +147,7 @@ tar xzf uu_shadow-x86_64-unknown-linux-gnu.tar.gz   # or the -musl-static one
 sudo install -o root -g root -m 4755 \
     uu_shadow-*/shadow-rs /usr/local/bin/shadow-rs
 for tool in passwd chfn chsh newgrp gpasswd sg chage chpasswd chgpasswd newusers \
-            groupadd groupdel groupmod grpck pwck useradd userdel usermod; do
+            groupadd groupdel groupmod grpck pwck useradd userdel usermod vipw vigr; do
     sudo ln -sf shadow-rs "/usr/local/bin/$tool"
 done
 ```

--- a/docs/man/vigr.8.md
+++ b/docs/man/vigr.8.md
@@ -1,0 +1,19 @@
+# vigr(8) - edit the group or gshadow file
+
+## NAME
+
+vigr - edit the group or gshadow file
+
+## SYNOPSIS
+
+**vigr** [*options*]
+
+## DESCRIPTION
+
+**vigr** is **vipw**(8) with /etc/group as its default file; **vigr -s** edits
+/etc/gshadow. Everything else — the lock, the working copy, the editor, the
+check before installing, the options — is described in **vipw**(8).
+
+## SEE ALSO
+
+vipw(8), group(5), gshadow(5), grpck(8)

--- a/docs/man/vipw.8.md
+++ b/docs/man/vipw.8.md
@@ -1,0 +1,115 @@
+# vipw(8) - edit the password, group, shadow or gshadow file
+
+## NAME
+
+vipw, vigr - edit the password, group, shadow or gshadow file
+
+## SYNOPSIS
+
+**vipw** [*options*]
+
+**vigr** [*options*]
+
+## DESCRIPTION
+
+The **vipw** and **vigr** commands edit /etc/passwd and /etc/group
+respectively. With the **-s** flag they edit the shadow versions of those
+files, /etc/shadow and /etc/gshadow. The two are one program: **vigr** is
+**vipw** with the group file as its default.
+
+The point of using them rather than an editor directly is the lock. **vipw**
+takes the same lock every other tool in the suite takes, so a hand edit
+cannot interleave with a **useradd**(8) running at the same moment — the other
+tool waits — and the result is installed atomically, so a crash mid-write
+cannot leave a half-written /etc/passwd.
+
+The editor is taken from **VISUAL**, then **EDITOR**, then **vi**. The string
+goes through the shell, so `EDITOR="emacs -nw"` works. Signals such as Ctrl-C
+reach the editor normally; they do not reach **vipw**, which would otherwise
+die holding the lock.
+
+## HOW AN EDIT PROCEEDS
+
+1. The lock is taken and the file copied to a working copy beside it,
+   `/etc/passwd.edit`, with the same mode and ownership. A stale copy from a
+   crashed run is replaced.
+2. The editor runs on the working copy.
+3. If the editor exits with an error, the working copy is removed and nothing
+   is installed.
+4. If the working copy is identical to the original, nothing is installed and
+   *file is unchanged* is reported.
+5. The working copy is parsed as the file it is meant to be. If it does not
+   parse, it is **kept**, its location is printed, and the live file is left
+   alone.
+6. Otherwise the working copy's bytes are installed as they are — comments and
+   blank lines included — and the companion file that usually has to change
+   alongside is named.
+
+## OPTIONS
+
+**-g**, **--group**
+:   Edit the group database.
+
+**-p**, **--passwd**
+:   Edit the passwd database.
+
+**-s**, **--shadow**
+:   Edit the shadow counterpart of the selected database.
+
+**-q**, **--quiet**
+:   Do not report an unchanged file or suggest the companion edit.
+
+**-R**, **--root** *CHROOT_DIR*
+:   Apply changes in *CHROOT_DIR* and use its configuration files.
+
+**-P**, **--prefix** *PREFIX_DIR*
+:   Edit the account files under *PREFIX_DIR* without chrooting.
+
+## DIFFERENCES FROM GNU SHADOW
+
+**The result is checked before it is installed.** GNU **vipw** installs
+whatever the editor saved — a line with no colons, or a UID 0 account with an
+empty password field — and leaves **pwck**(8) to find it later. Here a file the
+rest of the suite could not parse is refused. The check is structural: it does
+not judge the contents, and **pwck**(8) and **grpck**(8) remain the tools for
+that. When it refuses, the edited copy is kept rather than discarded: an
+administrator whose ten minutes of work vanished would use a raw editor next
+time, which is the outcome this tool exists to prevent.
+
+**Changes are detected by content, not by timestamp.** GNU compares
+modification times in whole seconds, so an edit saved within the same second
+as the copy was made is silently thrown away. Any edit that changes a byte is
+installed here.
+
+## EXIT STATUS
+
+**0**
+:   The file was installed, or was unchanged.
+
+**1**
+:   The editor failed, the result did not parse, the lock could not be taken,
+    or the caller is not root. Nothing was installed.
+
+**2**
+:   Invalid command syntax.
+
+**3**
+:   The **--root** directory could not be entered.
+
+## ENVIRONMENT
+
+**VISUAL**, **EDITOR**
+:   The editor, in that order of preference. An empty value counts as unset.
+
+## FILES
+
+/etc/passwd, /etc/shadow, /etc/group, /etc/gshadow
+:   The files edited.
+
+/etc/passwd.edit *and so on*
+:   The working copy, beside the file it copies. Left in place only when the
+    edit was refused.
+
+## SEE ALSO
+
+group(5), grpck(8), passwd(5), pwck(8), shadow(5), useradd(8)

--- a/src/bin/completions.rs
+++ b/src/bin/completions.rs
@@ -59,6 +59,10 @@ fn get_tool_app(name: &str) -> Option<Command> {
         "userdel" => Some(userdel::uu_app()),
         #[cfg(feature = "usermod")]
         "usermod" => Some(usermod::uu_app()),
+        #[cfg(feature = "vigr")]
+        "vigr" => Some(vigr::uu_app()),
+        #[cfg(feature = "vipw")]
+        "vipw" => Some(vipw::uu_app()),
         _ => None,
     }
 }
@@ -102,6 +106,10 @@ fn all_tool_names() -> Vec<&'static str> {
     names.push("userdel");
     #[cfg(feature = "usermod")]
     names.push("usermod");
+    #[cfg(feature = "vigr")]
+    names.push("vigr");
+    #[cfg(feature = "vipw")]
+    names.push("vipw");
     names
 }
 

--- a/src/bin/shadow-rs.rs
+++ b/src/bin/shadow-rs.rs
@@ -39,7 +39,7 @@ const SETUID_APPLETS: [&str; 6] = ["passwd", "chfn", "chsh", "newgrp", "gpasswd"
 // nothing, and the binding is then not mutated.
 #[allow(unused_mut)]
 fn applets() -> Vec<(&'static str, Applet)> {
-    let mut table: Vec<(&'static str, Applet)> = Vec::with_capacity(18);
+    let mut table: Vec<(&'static str, Applet)> = Vec::with_capacity(20);
     #[cfg(feature = "chage")]
     table.push(("chage", |a| chage::uumain(a.iter().cloned())));
     #[cfg(feature = "chfn")]
@@ -76,6 +76,10 @@ fn applets() -> Vec<(&'static str, Applet)> {
     table.push(("userdel", |a| userdel::uumain(a.iter().cloned())));
     #[cfg(feature = "usermod")]
     table.push(("usermod", |a| usermod::uumain(a.iter().cloned())));
+    #[cfg(feature = "vigr")]
+    table.push(("vigr", |a| vigr::uumain(a.iter().cloned())));
+    #[cfg(feature = "vipw")]
+    table.push(("vipw", |a| vipw::uumain(a.iter().cloned())));
     table
 }
 
@@ -234,7 +238,7 @@ fn print_available_utils() {
 mod tests {
     use super::*;
 
-    const ALL_TOOLS: [&str; 18] = [
+    const ALL_TOOLS: [&str; 20] = [
         "chage",
         "chfn",
         "chgpasswd",
@@ -253,6 +257,8 @@ mod tests {
         "useradd",
         "userdel",
         "usermod",
+        "vigr",
+        "vipw",
     ];
 
     // The table drives both dispatch and `--list`, so it must contain only

--- a/src/shadow-core/src/process.rs
+++ b/src/shadow-core/src/process.rs
@@ -207,6 +207,36 @@ pub fn block_critical_signals() -> io::Result<SavedSigSet> {
     }
 }
 
+/// Spawn `cmd` with an empty signal mask in the child.
+///
+/// A tool that blocks `SIGINT` and friends while it holds a lock -- so that a
+/// Ctrl-C cannot leave the lock behind -- passes that mask on to every child
+/// it starts, and an interactive program started under it, an editor say,
+/// then cannot be interrupted at all. The child gets a clean mask; the parent
+/// keeps its own.
+pub fn spawn_with_signals_unblocked(
+    cmd: &mut std::process::Command,
+) -> io::Result<std::process::Child> {
+    use std::os::unix::process::CommandExt as _;
+
+    // SAFETY: the closure runs in the forked child before exec. It calls only
+    // sigemptyset and sigprocmask, both async-signal-safe, and touches nothing
+    // else: no allocation, no locks, no Rust state shared with the parent.
+    unsafe {
+        cmd.pre_exec(|| {
+            let mut empty: libc::sigset_t = std::mem::zeroed();
+            if libc::sigemptyset(&raw mut empty) != 0 {
+                return Err(io::Error::last_os_error());
+            }
+            if libc::sigprocmask(libc::SIG_SETMASK, &raw const empty, std::ptr::null_mut()) != 0 {
+                return Err(io::Error::last_os_error());
+            }
+            Ok(())
+        });
+    }
+    cmd.spawn()
+}
+
 /// Restore a previously saved signal mask.
 pub fn restore_signals(saved: &SavedSigSet) -> io::Result<()> {
     // SAFETY: sigprocmask with SIG_SETMASK restores a previously captured mask.

--- a/src/uu/vigr/Cargo.toml
+++ b/src/uu/vigr/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "uu_vigr"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+categories.workspace = true
+rust-version.workspace = true
+description = "vigr ~ (shadow-rs) edit the group file under a lock"
+
+[lib]
+path = "src/vigr.rs"
+
+[[bin]]
+name = "vigr"
+path = "src/main.rs"
+
+[dependencies]
+clap = { workspace = true }
+uucore = { workspace = true }
+# vigr is vipw with a different default; the GNU suite ships it as a symlink.
+uu_vipw = { path = "../vipw", version = "0.4.0" }
+
+[lints]
+workspace = true
+
+# Distributed via the `shadow-rs` multicall binary in the workspace root
+# package, not as a standalone archive (see dist-workspace.toml, issue #207).
+[package.metadata.dist]
+dist = false

--- a/src/uu/vigr/locales/en-US.ftl
+++ b/src/uu/vigr/locales/en-US.ftl
@@ -1,0 +1,2 @@
+vigr-about = Edit the group or gshadow file under a lock
+vigr-usage = vigr [options]

--- a/src/uu/vigr/src/main.rs
+++ b/src/uu/vigr/src/main.rs
@@ -1,0 +1,6 @@
+// This file is part of the shadow-rs package.
+//
+// For the full copyright and license information, please view the LICENSE
+// file that was distributed with this source code.
+
+uucore::bin!(uu_vigr);

--- a/src/uu/vigr/src/vigr.rs
+++ b/src/uu/vigr/src/vigr.rs
@@ -1,0 +1,43 @@
+// This file is part of the shadow-rs package.
+//
+// For the full copyright and license information, please view the LICENSE
+// file that was distributed with this source code.
+// spell-checker:ignore vigr vipw gshadow
+
+//! `vigr` — edit the group file under a lock.
+//!
+//! `vigr` is `vipw(8)` with `/etc/group` as the default target instead of
+//! `/etc/passwd`; the GNU suite ships it as a symlink to `vipw`. Everything it
+//! does lives in `uu_vipw`, and this crate only names the default.
+
+use clap::Command;
+use uucore::error::UResult;
+
+/// Entry point for the `vigr` utility.
+#[uucore::main]
+pub fn uumain(args: impl uucore::Args) -> UResult<()> {
+    uu_vipw::run(uu_vipw::Tool::Vigr, args)
+}
+
+/// Build the clap `Command` for `vigr`.
+#[must_use]
+pub fn uu_app() -> Command {
+    uu_vipw::app(uu_vipw::Tool::Vigr)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_app_builds() {
+        uu_app().debug_assert();
+    }
+
+    /// The only thing vigr adds over vipw is the default, so that is what
+    /// is worth pinning.
+    #[test]
+    fn test_defaults_to_the_group_file() {
+        assert_eq!(uu_app().get_name(), "vigr");
+    }
+}

--- a/src/uu/vipw/Cargo.toml
+++ b/src/uu/vipw/Cargo.toml
@@ -1,0 +1,35 @@
+[package]
+name = "uu_vipw"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+categories.workspace = true
+rust-version.workspace = true
+description = "vipw ~ (shadow-rs) edit the password or group file under a lock"
+
+[lib]
+path = "src/vipw.rs"
+
+[[bin]]
+name = "vipw"
+path = "src/main.rs"
+
+[dependencies]
+clap = { workspace = true }
+rustix = { workspace = true }
+shadow-core = { workspace = true }
+uucore = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }
+
+[lints]
+workspace = true
+
+# Distributed via the `shadow-rs` multicall binary in the workspace root
+# package, not as a standalone archive (see dist-workspace.toml, issue #207).
+[package.metadata.dist]
+dist = false

--- a/src/uu/vipw/locales/en-US.ftl
+++ b/src/uu/vipw/locales/en-US.ftl
@@ -1,0 +1,2 @@
+vipw-about = Edit the password, group, shadow or gshadow file under a lock
+vipw-usage = vipw [options]

--- a/src/uu/vipw/src/main.rs
+++ b/src/uu/vipw/src/main.rs
@@ -1,0 +1,6 @@
+// This file is part of the shadow-rs package.
+//
+// For the full copyright and license information, please view the LICENSE
+// file that was distributed with this source code.
+
+uucore::bin!(uu_vipw);

--- a/src/uu/vipw/src/vipw.rs
+++ b/src/uu/vipw/src/vipw.rs
@@ -1,0 +1,580 @@
+// This file is part of the shadow-rs package.
+//
+// For the full copyright and license information, please view the LICENSE
+// file that was distributed with this source code.
+// spell-checker:ignore vipw vigr gshadow chroot pwck grpck fchown sysroot
+
+//! `vipw` — edit the password, group, shadow or gshadow file under a lock.
+//!
+//! Drop-in replacement for GNU shadow-utils `vipw(8)` and `vigr(8)`. It takes
+//! the same lock every other tool in the suite takes, hands the administrator
+//! a copy of the file in their editor, and installs the result atomically --
+//! so a hand edit cannot interleave with a `useradd` running at the same time,
+//! and a crash mid-write cannot leave a half-written `/etc/passwd`.
+//!
+//! `vigr` is this tool with `/etc/group` as its default; the GNU suite ships
+//! it as a symlink. It lives in its own crate, which calls [`run`].
+
+use std::fmt;
+use std::io::Write as _;
+use std::os::unix::fs::{MetadataExt as _, OpenOptionsExt as _};
+use std::path::{Path, PathBuf};
+
+use clap::{Arg, ArgAction, Command};
+
+use shadow_core::error::ShadowError;
+use shadow_core::group::GroupEntry;
+use shadow_core::gshadow::GshadowEntry;
+use shadow_core::passwd::PasswdEntry;
+use shadow_core::shadow::ShadowEntry;
+use shadow_core::sysroot::SysRoot;
+use shadow_core::transaction::Record;
+
+use uucore::error::{UError, UResult};
+
+mod options {
+    pub const GROUP: &str = "group";
+    pub const PASSWD: &str = "passwd";
+    pub const SHADOW: &str = "shadow";
+    pub const QUIET: &str = "quiet";
+    pub const ROOT: &str = "root";
+    pub const PREFIX: &str = "prefix";
+}
+
+/// The editor when neither `VISUAL` nor `EDITOR` names one.
+const DEFAULT_EDITOR: &str = "vi";
+
+/// Which of the two entry points was invoked. The only difference is the
+/// file edited when neither `-p` nor `-g` is given.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Tool {
+    /// Defaults to `/etc/passwd`.
+    Vipw,
+    /// Defaults to `/etc/group`.
+    Vigr,
+}
+
+impl Tool {
+    fn name(self) -> &'static str {
+        match self {
+            Self::Vipw => "vipw",
+            Self::Vigr => "vigr",
+        }
+    }
+}
+
+/// Which file is being edited.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Database {
+    Passwd,
+    Shadow,
+    Group,
+    Gshadow,
+}
+
+impl Database {
+    fn select(tool: Tool, group: bool, passwd: bool, shadow: bool) -> Self {
+        let group_db = group || (tool == Tool::Vigr && !passwd);
+        match (group_db, shadow) {
+            (false, false) => Self::Passwd,
+            (false, true) => Self::Shadow,
+            (true, false) => Self::Group,
+            (true, true) => Self::Gshadow,
+        }
+    }
+
+    fn path(self, root: &SysRoot) -> PathBuf {
+        match self {
+            Self::Passwd => root.passwd_path(),
+            Self::Shadow => root.shadow_path(),
+            Self::Group => root.group_path(),
+            Self::Gshadow => root.gshadow_path(),
+        }
+    }
+
+    /// The file that usually has to change alongside this one, and the
+    /// command that edits it. Printed after a successful edit, as the GNU
+    /// tool does, because a passwd line without its shadow line is an account
+    /// nobody can log into.
+    fn companion(self) -> (&'static str, &'static str) {
+        match self {
+            Self::Passwd => ("/etc/shadow", "vipw -s"),
+            Self::Shadow => ("/etc/passwd", "vipw"),
+            Self::Group => ("/etc/gshadow", "vigr -s"),
+            Self::Gshadow => ("/etc/group", "vigr"),
+        }
+    }
+
+    /// Parse the edited file as this database, refusing anything the rest of
+    /// the suite could not read back.
+    fn check(self, path: &Path) -> Result<(), ShadowError> {
+        match self {
+            Self::Passwd => check_as::<PasswdEntry>(path),
+            Self::Shadow => check_as::<ShadowEntry>(path),
+            Self::Group => check_as::<GroupEntry>(path),
+            Self::Gshadow => check_as::<GshadowEntry>(path),
+        }
+    }
+}
+
+/// Every entry has to parse, and every parsed entry has to pass the same
+/// field checks the other tools apply before they write.
+fn check_as<T: Record>(path: &Path) -> Result<(), ShadowError> {
+    let (entries, _layout) = shadow_core::records::read_with_layout::<T>(path)?;
+    for entry in &entries {
+        entry.validate_fields()?;
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Error type
+// ---------------------------------------------------------------------------
+
+/// Errors that `vipw` and `vigr` can produce.
+#[derive(Debug)]
+enum VipwError {
+    /// Exit 1 — insufficient privileges.
+    PermissionDenied(String),
+    /// Exit 1 — an unexpected runtime failure.
+    UnexpectedFailure(String),
+    /// Exit 1 — could not acquire the lock.
+    FileBusy(String),
+    /// Exit 1 — the editor did not exit successfully; nothing was installed.
+    EditorFailed(String),
+    /// Exit 1 — the edited file does not parse; it is kept for the caller.
+    InvalidResult(String),
+    /// Exit 3 — the `--root` directory could not be entered.
+    CantChroot(String),
+}
+
+impl fmt::Display for VipwError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::PermissionDenied(msg)
+            | Self::UnexpectedFailure(msg)
+            | Self::FileBusy(msg)
+            | Self::EditorFailed(msg)
+            | Self::InvalidResult(msg)
+            | Self::CantChroot(msg) => f.write_str(msg),
+        }
+    }
+}
+
+impl std::error::Error for VipwError {}
+
+impl UError for VipwError {
+    fn code(&self) -> i32 {
+        match self {
+            Self::PermissionDenied(_)
+            | Self::UnexpectedFailure(_)
+            | Self::FileBusy(_)
+            | Self::EditorFailed(_)
+            | Self::InvalidResult(_) => 1,
+            Self::CantChroot(_) => 3,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Entry points
+// ---------------------------------------------------------------------------
+
+/// Entry point for the `vipw` utility.
+#[uucore::main]
+pub fn uumain(args: impl uucore::Args) -> UResult<()> {
+    run(Tool::Vipw, args)
+}
+
+/// Build the clap `Command` for `vipw`.
+#[must_use]
+pub fn uu_app() -> Command {
+    app(Tool::Vipw)
+}
+
+/// Run either tool.
+pub fn run(tool: Tool, args: impl uucore::Args) -> UResult<()> {
+    // The editor is an interactive child that inherits this process's
+    // limits and environment, so only core dumps are suppressed: a raised
+    // RLIMIT_FSIZE would follow the editor, and a sanitized environment would
+    // take TERM and the editor's own configuration away from it.
+    shadow_core::hardening::suppress_core_dumps();
+
+    let Some(matches) = shadow_core::cli::parse_args(app(tool), args, |_| 2)? else {
+        return Ok(());
+    };
+
+    if let Some(chroot_dir) = matches.get_one::<String>(options::ROOT) {
+        shadow_core::hardening::chroot_into(Path::new(chroot_dir))
+            .map_err(|e| VipwError::CantChroot(e.to_string()))?;
+    }
+    let prefix = matches.get_one::<String>(options::PREFIX).map(Path::new);
+    let root = SysRoot::new(prefix);
+
+    if !shadow_core::hardening::caller_is_root() {
+        return Err(VipwError::PermissionDenied(shadow_core::os_error::permission_denied()).into());
+    }
+
+    let database = Database::select(
+        tool,
+        matches.get_flag(options::GROUP),
+        matches.get_flag(options::PASSWD),
+        matches.get_flag(options::SHADOW),
+    );
+    let quiet = matches.get_flag(options::QUIET);
+
+    edit(tool, database, &root, quiet)
+}
+
+/// Build the clap `Command` for either tool.
+#[must_use]
+pub fn app(tool: Tool) -> Command {
+    let (about, default) = match tool {
+        Tool::Vipw => ("Edit the password file under a lock", "passwd"),
+        Tool::Vigr => ("Edit the group file under a lock", "group"),
+    };
+    Command::new(tool.name())
+        .about(about)
+        .override_usage(format!("{} [options]", tool.name()))
+        .version(shadow_core::cli::VERSION)
+        .after_help(shadow_core::cli::AFTER_HELP)
+        .arg(
+            Arg::new(options::GROUP)
+                .short('g')
+                .long("group")
+                .help("edit the group database")
+                .conflicts_with(options::PASSWD)
+                .action(ArgAction::SetTrue),
+        )
+        .arg(
+            Arg::new(options::PASSWD)
+                .short('p')
+                .long("passwd")
+                .help("edit the passwd database")
+                .action(ArgAction::SetTrue),
+        )
+        .arg(
+            Arg::new(options::SHADOW)
+                .short('s')
+                .long("shadow")
+                .help(format!(
+                    "edit the shadow counterpart of the {default} database"
+                ))
+                .action(ArgAction::SetTrue),
+        )
+        .arg(
+            Arg::new(options::QUIET)
+                .short('q')
+                .long("quiet")
+                .help("do not report an unchanged file or suggest the companion edit")
+                .action(ArgAction::SetTrue),
+        )
+        .arg(
+            Arg::new(options::ROOT)
+                .short('R')
+                .long("root")
+                .help("chroot into CHROOT_DIR before editing")
+                .value_name("CHROOT_DIR"),
+        )
+        .arg(
+            Arg::new(options::PREFIX)
+                .short('P')
+                .long("prefix")
+                .help("directory prefix")
+                .value_name("PREFIX_DIR"),
+        )
+}
+
+// ---------------------------------------------------------------------------
+// The edit
+// ---------------------------------------------------------------------------
+
+/// Lock, copy, edit, check, install.
+fn edit(tool: Tool, database: Database, root: &SysRoot, quiet: bool) -> UResult<()> {
+    let target = database.path(root);
+    let shown = target.display();
+
+    // Held for the whole edit. A Ctrl-C aimed at the editor must not kill
+    // this process and leave the lock file and the working copy behind; the
+    // editor itself gets a clean mask when it is spawned.
+    let _signals = shadow_core::hardening::SignalBlocker::block_critical()
+        .map_err(|e| VipwError::UnexpectedFailure(e.to_string()))?;
+
+    let _lock = shadow_core::lock::FileLock::acquire(&target).map_err(|e| match e {
+        ShadowError::Lock(_) => {
+            VipwError::FileBusy(format!("cannot lock {shown}: try again later"))
+        }
+        other => VipwError::UnexpectedFailure(format!("cannot lock {shown}: {other}")),
+    })?;
+
+    let original = std::fs::read(&target)
+        .map_err(|e| VipwError::UnexpectedFailure(format!("cannot open {shown}: {e}")))?;
+    let meta = std::fs::metadata(&target)
+        .map_err(|e| VipwError::UnexpectedFailure(format!("cannot stat {shown}: {e}")))?;
+
+    let edit_path = edit_path_for(&target);
+    write_working_copy(&edit_path, &original, &meta)
+        .map_err(|e| VipwError::UnexpectedFailure(e.to_string()))?;
+
+    let editor = choose_editor(
+        std::env::var("VISUAL").ok().as_deref(),
+        std::env::var("EDITOR").ok().as_deref(),
+    );
+    let status = run_editor(&editor, &edit_path);
+
+    let status = match status {
+        Ok(status) if status.success() => status,
+        Ok(status) => {
+            let _ = std::fs::remove_file(&edit_path);
+            let code = status
+                .code()
+                .map_or_else(|| "a signal".to_string(), |c| c.to_string());
+            uucore::show_error!("{editor} returned with status {code}");
+            return Err(VipwError::EditorFailed(format!("{shown} is unchanged")).into());
+        }
+        Err(e) => {
+            let _ = std::fs::remove_file(&edit_path);
+            return Err(VipwError::EditorFailed(format!(
+                "cannot run {editor}: {e}; {shown} is unchanged"
+            ))
+            .into());
+        }
+    };
+    debug_assert!(status.success());
+
+    let edited = std::fs::read(&edit_path).map_err(|e| {
+        VipwError::UnexpectedFailure(format!("cannot read {}: {e}", edit_path.display()))
+    })?;
+
+    // Compared by content, not by timestamp. The GNU tool compares
+    // modification times in whole seconds, so an edit saved within the same
+    // second as the copy was made is silently thrown away.
+    if edited == original {
+        let _ = std::fs::remove_file(&edit_path);
+        if !quiet {
+            let _ = writeln!(std::io::stderr(), "{}: {shown} is unchanged", tool.name());
+        }
+        return Ok(());
+    }
+
+    // The working copy is kept on failure: the administrator's edit may be
+    // ten minutes of work, and losing it teaches them to use a raw editor
+    // next time, which is the outcome this tool exists to prevent.
+    if let Err(e) = database.check(&edit_path) {
+        uucore::show_error!("{}: {e}", edit_path.display());
+        return Err(VipwError::InvalidResult(format!(
+            "the edited copy is kept at {}; {shown} is unchanged",
+            edit_path.display()
+        ))
+        .into());
+    }
+
+    shadow_core::atomic::atomic_write(&target, |w| w.write_all(&edited).map_err(ShadowError::Io))
+        .map_err(|e| VipwError::UnexpectedFailure(format!("cannot write {shown}: {e}")))?;
+    let _ = std::fs::remove_file(&edit_path);
+
+    if !quiet {
+        let (companion, command) = database.companion();
+        let mut out = std::io::stdout().lock();
+        let _ = writeln!(out, "You have modified {shown}.");
+        let _ = writeln!(out, "You may need to modify {companion} for consistency.");
+        let _ = writeln!(out, "Please use the command '{command}' to do so.");
+    }
+    Ok(())
+}
+
+/// The working copy sits next to the file it copies, as `passwd.edit`, so it
+/// is on the same filesystem and under the same directory permissions.
+fn edit_path_for(target: &Path) -> PathBuf {
+    let mut name = target.file_name().unwrap_or_default().to_os_string();
+    name.push(".edit");
+    target.with_file_name(name)
+}
+
+/// Write the working copy with the original's mode and ownership.
+///
+/// The mode is applied at creation under a zeroed umask, so there is no moment
+/// at which a copy of `/etc/shadow` is more readable than `/etc/shadow`. A
+/// stale copy left by a crashed run is replaced.
+fn write_working_copy(
+    edit_path: &Path,
+    contents: &[u8],
+    meta: &std::fs::Metadata,
+) -> Result<(), ShadowError> {
+    let _umask = shadow_core::atomic::UmaskGuard::zero();
+    let mode = meta.mode() & 0o7777;
+    let open = || {
+        std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .mode(mode)
+            .open(edit_path)
+    };
+    let mut file = match open() {
+        Ok(file) => file,
+        Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
+            std::fs::remove_file(edit_path)
+                .map_err(|e| ShadowError::IoPath(e, edit_path.to_owned()))?;
+            open().map_err(|e| ShadowError::IoPath(e, edit_path.to_owned()))?
+        }
+        Err(e) => return Err(ShadowError::IoPath(e, edit_path.to_owned())),
+    };
+    rustix::fs::fchown(
+        &file,
+        Some(rustix::fs::Uid::from_raw(meta.uid())),
+        Some(rustix::fs::Gid::from_raw(meta.gid())),
+    )
+    .map_err(|e| ShadowError::IoPath(e.into(), edit_path.to_owned()))?;
+    file.write_all(contents)
+        .map_err(|e| ShadowError::IoPath(e, edit_path.to_owned()))?;
+    file.sync_all()
+        .map_err(|e| ShadowError::IoPath(e, edit_path.to_owned()))
+}
+
+/// `VISUAL`, then `EDITOR`, then `vi`; an empty value counts as unset.
+fn choose_editor(visual: Option<&str>, editor: Option<&str>) -> String {
+    [visual, editor]
+        .into_iter()
+        .flatten()
+        .map(str::trim)
+        .find(|s| !s.is_empty())
+        .unwrap_or(DEFAULT_EDITOR)
+        .to_string()
+}
+
+/// Run the editor on the working copy and wait for it.
+///
+/// The editor string goes through the shell so `EDITOR="emacs -nw"` works, as
+/// it does everywhere else; the path is passed as a positional argument rather
+/// than spliced into the command line.
+fn run_editor(editor: &str, path: &Path) -> std::io::Result<std::process::ExitStatus> {
+    let mut cmd = std::process::Command::new("/bin/sh");
+    cmd.arg("-c")
+        .arg(format!("{editor} \"$1\""))
+        .arg(editor)
+        .arg(path);
+    shadow_core::process::spawn_with_signals_unblocked(&mut cmd)?.wait()
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_apps_build() {
+        app(Tool::Vipw).debug_assert();
+        app(Tool::Vigr).debug_assert();
+    }
+
+    /// vigr is vipw with the group file as the default; the flags then select
+    /// the same four files from either.
+    #[test]
+    fn test_database_selection() {
+        use Database::{Group, Gshadow, Passwd, Shadow};
+        assert_eq!(Database::select(Tool::Vipw, false, false, false), Passwd);
+        assert_eq!(Database::select(Tool::Vipw, false, false, true), Shadow);
+        assert_eq!(Database::select(Tool::Vigr, false, false, false), Group);
+        assert_eq!(Database::select(Tool::Vigr, false, false, true), Gshadow);
+        assert_eq!(Database::select(Tool::Vipw, true, false, false), Group);
+        assert_eq!(Database::select(Tool::Vipw, true, false, true), Gshadow);
+        assert_eq!(Database::select(Tool::Vigr, false, true, false), Passwd);
+        assert_eq!(Database::select(Tool::Vigr, false, true, true), Shadow);
+    }
+
+    #[test]
+    fn test_group_and_passwd_conflict() {
+        assert!(
+            app(Tool::Vipw)
+                .try_get_matches_from(["vipw", "-g", "-p"])
+                .is_err()
+        );
+        assert!(
+            app(Tool::Vipw)
+                .try_get_matches_from(["vipw", "-g", "-s"])
+                .is_ok()
+        );
+    }
+
+    /// The hint names the file that has to change alongside, and the command
+    /// for it is by database, not by which name this tool was invoked under.
+    #[test]
+    fn test_companion_hints() {
+        assert_eq!(Database::Passwd.companion(), ("/etc/shadow", "vipw -s"));
+        assert_eq!(Database::Shadow.companion(), ("/etc/passwd", "vipw"));
+        assert_eq!(Database::Group.companion(), ("/etc/gshadow", "vigr -s"));
+        assert_eq!(Database::Gshadow.companion(), ("/etc/group", "vigr"));
+    }
+
+    #[test]
+    fn test_editor_preference() {
+        assert_eq!(choose_editor(Some("code -w"), Some("nano")), "code -w");
+        assert_eq!(choose_editor(None, Some("nano")), "nano");
+        assert_eq!(choose_editor(None, None), "vi");
+        // Empty and blank values are unset, not editors called "".
+        assert_eq!(choose_editor(Some(""), Some("nano")), "nano");
+        assert_eq!(choose_editor(Some("  "), Some("")), "vi");
+    }
+
+    #[test]
+    fn test_edit_path_sits_beside_the_target() {
+        assert_eq!(
+            edit_path_for(Path::new("/etc/passwd")),
+            PathBuf::from("/etc/passwd.edit")
+        );
+        assert_eq!(
+            edit_path_for(Path::new("/mnt/root/etc/gshadow")),
+            PathBuf::from("/mnt/root/etc/gshadow.edit")
+        );
+    }
+
+    /// The working copy takes the original's mode and replaces a stale one.
+    #[test]
+    fn test_working_copy_mode_and_stale_replacement() {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let target = dir.path().join("shadow");
+        std::fs::write(&target, "root:!:1::::::\n").expect("write");
+        std::fs::set_permissions(&target, std::fs::Permissions::from_mode(0o640)).expect("chmod");
+        let meta = std::fs::metadata(&target).expect("stat");
+
+        let edit = edit_path_for(&target);
+        std::fs::write(&edit, "stale junk\n").expect("stale");
+
+        write_working_copy(&edit, b"root:!:1::::::\n", &meta).expect("copy");
+        assert_eq!(std::fs::read(&edit).expect("read"), b"root:!:1::::::\n");
+        let mode = std::fs::metadata(&edit).expect("stat").permissions().mode() & 0o777;
+        assert_eq!(
+            mode, 0o640,
+            "the copy must not be more readable than the original"
+        );
+    }
+
+    /// The check is the same one every other tool applies before writing:
+    /// a line that does not parse is refused, a line that does is accepted.
+    #[test]
+    fn test_check_accepts_valid_and_refuses_broken_files() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let good = dir.path().join("passwd");
+        std::fs::write(&good, "# comment\nroot:x:0:0:root:/root:/bin/sh\n").expect("write");
+        assert!(Database::Passwd.check(&good).is_ok());
+
+        let bad = dir.path().join("passwd.bad");
+        std::fs::write(&bad, "root:x:0:0:root:/root:/bin/sh\nbroken line\n").expect("write");
+        assert!(Database::Passwd.check(&bad).is_err());
+    }
+
+    #[test]
+    fn test_exit_codes() {
+        assert_eq!(VipwError::PermissionDenied("x".into()).code(), 1);
+        assert_eq!(VipwError::UnexpectedFailure("x".into()).code(), 1);
+        assert_eq!(VipwError::FileBusy("x".into()).code(), 1);
+        assert_eq!(VipwError::EditorFailed("x".into()).code(), 1);
+        assert_eq!(VipwError::InvalidResult("x".into()).code(), 1);
+        assert_eq!(VipwError::CantChroot("x".into()).code(), 3);
+    }
+}

--- a/tests/arm64-smoke.sh
+++ b/tests/arm64-smoke.sh
@@ -64,10 +64,10 @@ version=$("${QEMU[@]}" "$BIN" --version 2>&1)
 if [ -n "$version" ]; then ok "runs: $version"; else bad "would not run"; exit 1; fi
 
 applets=$("${QEMU[@]}" "$BIN" --list 2>/dev/null | tail -n +2 | wc -l)
-if [ "$applets" -ge 18 ]; then
+if [ "$applets" -ge 20 ]; then
     ok "carries $applets applets"
 else
-    bad "expected at least 18 applets, found $applets"
+    bad "expected at least 20 applets, found $applets"
 fi
 
 # ── A prefix tree, so nothing here touches the container's own accounts ──
@@ -123,6 +123,8 @@ fi
 # starts under emulation. It is the only caller of getgroups/setgroups, and a
 # wrong struct width there would show up as a failure to run at all.
 check "sg starts" "${QEMU[@]}" "$BIN" sg --help
+check "vipw starts" "${QEMU[@]}" "$BIN" vipw --help
+check "vigr starts" "${QEMU[@]}" "$BIN" vigr --help
 
 # newusers writes three files and a home directory from one line, so it
 # exercises the allocator, crypt(3) and the fchown in shadow_core::home

--- a/tests/by-util/test_multicall.rs
+++ b/tests/by-util/test_multicall.rs
@@ -16,7 +16,7 @@ use std::process::Command;
 use crate::common::{run, run_cmd};
 
 /// Every applet this build is expected to carry, in `--list` order.
-const TOOLS: [&str; 18] = [
+const TOOLS: [&str; 20] = [
     "chage",
     "chfn",
     "chgpasswd",
@@ -35,6 +35,8 @@ const TOOLS: [&str; 18] = [
     "useradd",
     "userdel",
     "usermod",
+    "vigr",
+    "vipw",
 ];
 
 /// The binary with no applet argument.

--- a/tests/by-util/test_vipw.rs
+++ b/tests/by-util/test_vipw.rs
@@ -1,0 +1,341 @@
+// This file is part of the shadow-rs package.
+//
+// For the full copyright and license information, please view the LICENSE
+// file that was distributed with this source code.
+// spell-checker:ignore vipw vigr gshadow
+
+//! Integration tests for `vipw` and `vigr`.
+//!
+//! The editor is a shell script written into the prefix tree and named
+//! through `EDITOR`, so each test decides what "the administrator typed".
+//! Everything is asserted on the files afterwards: what was installed, what
+//! was left alone, and whether the working copy was kept or cleaned up.
+
+use std::os::unix::fs::PermissionsExt as _;
+
+use crate::common::{Output, run_cmd, skip_unless_root, tool};
+
+const PASSWD: &str = "root:x:0:0:root:/root:/bin/sh\nalice:x:1000:1000::/home/alice:/bin/sh\n";
+const SHADOW: &str = "root:!:19000:0:99999:7:::\nalice:!:19000:0:99999:7:::\n";
+const GROUP: &str = "root:x:0:\nalice:x:1000:\n";
+const GSHADOW: &str = "root:!::\nalice:!::\n";
+
+/// A prefix tree with all four files at their conventional modes.
+fn prefix() -> tempfile::TempDir {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let etc = dir.path().join("etc");
+    std::fs::create_dir_all(&etc).expect("etc");
+    for (name, body, mode) in [
+        ("passwd", PASSWD, 0o644),
+        ("shadow", SHADOW, 0o640),
+        ("group", GROUP, 0o644),
+        ("gshadow", GSHADOW, 0o640),
+    ] {
+        let path = etc.join(name);
+        std::fs::write(&path, body).expect(name);
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(mode)).expect("chmod");
+    }
+    dir
+}
+
+/// An "editor": a script that runs `body` with the file to edit in `$1`.
+fn editor(dir: &tempfile::TempDir, name: &str, body: &str) -> String {
+    let path = dir.path().join(name);
+    std::fs::write(&path, format!("#!/bin/sh\n{body}\n")).expect("editor");
+    std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755)).expect("chmod");
+    path.to_string_lossy().into_owned()
+}
+
+fn read(dir: &tempfile::TempDir, name: &str) -> String {
+    std::fs::read_to_string(dir.path().join("etc").join(name))
+        .unwrap_or_else(|e| panic!("cannot read {name}: {e}"))
+}
+
+fn mode_of(dir: &tempfile::TempDir, name: &str) -> u32 {
+    std::fs::metadata(dir.path().join("etc").join(name))
+        .expect("stat")
+        .permissions()
+        .mode()
+        & 0o777
+}
+
+fn edit_copy_exists(dir: &tempfile::TempDir, name: &str) -> bool {
+    dir.path().join("etc").join(format!("{name}.edit")).exists()
+}
+
+/// Run `<tool> --prefix <dir> <args...>` with the given editor.
+fn edit_with(which: &str, dir: &tempfile::TempDir, args: &[&str], env: &[(&str, &str)]) -> Output {
+    let mut cmd = tool(which);
+    cmd.arg("--prefix").arg(dir.path()).args(args);
+    for (k, v) in env {
+        cmd.env(k, v);
+    }
+    run_cmd(&mut cmd)
+}
+
+// ---------------------------------------------------------------------------
+// The edit lands
+// ---------------------------------------------------------------------------
+
+/// The core promise: what the editor saved is what is installed, with the
+/// file's mode intact and the working copy gone. The editor here returns
+/// within the second the copy was made -- the GNU tool would discard this
+/// edit, because it compares timestamps in whole seconds.
+#[test]
+fn test_an_edit_is_installed_and_the_mode_kept() {
+    if skip_unless_root() {
+        return;
+    }
+    let dir = prefix();
+    let ed = editor(
+        &dir,
+        "ed",
+        r#"printf 'bob:x:1001:1001::/home/bob:/bin/sh\n' >> "$1""#,
+    );
+
+    edit_with("vipw", &dir, &[], &[("EDITOR", &ed)])
+        .assert_code(0)
+        .assert_stdout_contains("You have modified")
+        .assert_stdout_contains("vipw -s");
+
+    assert!(read(&dir, "passwd").contains("bob:x:1001:1001"));
+    assert_eq!(mode_of(&dir, "passwd"), 0o644, "the mode changed");
+    assert!(
+        !edit_copy_exists(&dir, "passwd"),
+        "the working copy was left behind"
+    );
+}
+
+/// Comments and blank lines the administrator writes survive verbatim: the
+/// edited bytes are installed as they are, not re-rendered.
+#[test]
+fn test_the_bytes_are_installed_verbatim() {
+    if skip_unless_root() {
+        return;
+    }
+    let dir = prefix();
+    let ed = editor(
+        &dir,
+        "ed",
+        r#"printf '# added by hand\n\ncarol:x:1002:1002::/home/carol:/bin/sh\n' >> "$1""#,
+    );
+    edit_with("vipw", &dir, &[], &[("EDITOR", &ed)]).assert_code(0);
+    let after = read(&dir, "passwd");
+    assert!(
+        after.contains("# added by hand\n\ncarol:"),
+        "layout was not preserved: {after:?}"
+    );
+}
+
+#[test]
+fn test_shadow_flag_edits_the_shadow_file() {
+    if skip_unless_root() {
+        return;
+    }
+    let dir = prefix();
+    let ed = editor(&dir, "ed", r#"printf 'bob:!:19000:0:99999:7:::\n' >> "$1""#);
+    edit_with("vipw", &dir, &["-s"], &[("EDITOR", &ed)])
+        .assert_code(0)
+        .assert_stdout_contains("Please use the command 'vipw'");
+    assert!(read(&dir, "shadow").contains("bob:!:19000"));
+    assert_eq!(read(&dir, "passwd"), PASSWD, "passwd must be untouched");
+    assert_eq!(mode_of(&dir, "shadow"), 0o640);
+}
+
+/// vigr is vipw with the group file as its default, and `-s` then means
+/// gshadow. `vipw -g` reaches the same file.
+#[test]
+fn test_vigr_and_group_flags() {
+    if skip_unless_root() {
+        return;
+    }
+    let dir = prefix();
+    let ed = editor(&dir, "ed", r#"printf 'team:x:5000:alice\n' >> "$1""#);
+    edit_with("vigr", &dir, &[], &[("EDITOR", &ed)])
+        .assert_code(0)
+        .assert_stdout_contains("vigr -s");
+    assert!(read(&dir, "group").contains("team:x:5000:alice"));
+
+    let ed = editor(&dir, "ed2", r#"printf 'team:!::alice\n' >> "$1""#);
+    edit_with("vigr", &dir, &["-s"], &[("EDITOR", &ed)]).assert_code(0);
+    assert!(read(&dir, "gshadow").contains("team:!::alice"));
+
+    let ed = editor(&dir, "ed3", r#"printf 'other:x:5001:\n' >> "$1""#);
+    edit_with("vipw", &dir, &["-g"], &[("EDITOR", &ed)]).assert_code(0);
+    assert!(read(&dir, "group").contains("other:x:5001:"));
+    assert_eq!(read(&dir, "passwd"), PASSWD);
+}
+
+// ---------------------------------------------------------------------------
+// Nothing lands
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_no_change_is_reported_and_nothing_is_written() {
+    if skip_unless_root() {
+        return;
+    }
+    let dir = prefix();
+    let ed = editor(&dir, "ed", "true");
+    edit_with("vipw", &dir, &[], &[("EDITOR", &ed)])
+        .assert_code(0)
+        .assert_stderr_contains("is unchanged");
+    assert_eq!(read(&dir, "passwd"), PASSWD);
+    assert!(!edit_copy_exists(&dir, "passwd"));
+
+    // -q silences the report; the result is the same.
+    let out = edit_with("vipw", &dir, &["-q"], &[("EDITOR", &ed)]);
+    out.assert_code(0);
+    assert!(
+        out.stderr.is_empty(),
+        "-q should print nothing: {:?}",
+        out.stderr
+    );
+}
+
+/// An editor that fails has not finished the job, whatever it wrote.
+#[test]
+fn test_a_failing_editor_installs_nothing() {
+    if skip_unless_root() {
+        return;
+    }
+    let dir = prefix();
+    let ed = editor(
+        &dir,
+        "ed",
+        r#"printf 'zed:x:6000:6000:::/bin/sh\n' >> "$1"; exit 1"#,
+    );
+    edit_with("vipw", &dir, &[], &[("EDITOR", &ed)])
+        .assert_code(1)
+        .assert_stderr_contains("returned with status 1")
+        .assert_stderr_contains("is unchanged");
+    assert_eq!(read(&dir, "passwd"), PASSWD);
+    assert!(!edit_copy_exists(&dir, "passwd"));
+}
+
+/// The deliberate divergence from GNU, which installs whatever the editor
+/// saved: a file the suite cannot parse is refused -- and the edit is kept,
+/// so the refusal costs the administrator nothing but a second look.
+#[test]
+fn test_an_unparseable_result_is_refused_and_kept() {
+    if skip_unless_root() {
+        return;
+    }
+    let dir = prefix();
+    let ed = editor(&dir, "ed", r#"printf 'this line has no colons\n' >> "$1""#);
+    edit_with("vipw", &dir, &[], &[("EDITOR", &ed)])
+        .assert_code(1)
+        .assert_stderr_contains("kept at")
+        .assert_stderr_contains("is unchanged");
+
+    assert_eq!(
+        read(&dir, "passwd"),
+        PASSWD,
+        "the live file must be untouched"
+    );
+    assert!(
+        edit_copy_exists(&dir, "passwd"),
+        "the edit must be kept for the caller"
+    );
+    assert!(
+        read(&dir, "passwd.edit").contains("this line has no colons"),
+        "the kept copy must be the administrator's edit"
+    );
+}
+
+/// A field the other tools would refuse to write is refused here too: the
+/// working copy is not a way around the checks.
+#[test]
+fn test_a_field_that_would_corrupt_the_file_is_refused() {
+    if skip_unless_root() {
+        return;
+    }
+    let dir = prefix();
+    // A group line with too many fields.
+    let ed = editor(&dir, "ed", r#"printf 'team:x:5000:alice:extra\n' >> "$1""#);
+    edit_with("vigr", &dir, &[], &[("EDITOR", &ed)]).assert_code(1);
+    assert_eq!(read(&dir, "group"), GROUP);
+}
+
+/// A stale working copy from a crashed run is not offered as the file to
+/// edit; the administrator sees the live contents.
+#[test]
+fn test_a_stale_working_copy_is_replaced() {
+    if skip_unless_root() {
+        return;
+    }
+    let dir = prefix();
+    std::fs::write(dir.path().join("etc/passwd.edit"), "junk from a crash\n").expect("stale");
+    let ed = editor(
+        &dir,
+        "ed",
+        r#"cp "$1" "$1.seen"; printf 'dave:x:1003:1003::/home/dave:/bin/sh\n' >> "$1""#,
+    );
+    edit_with("vipw", &dir, &[], &[("EDITOR", &ed)]).assert_code(0);
+    let seen = std::fs::read_to_string(dir.path().join("etc/passwd.edit.seen")).expect("seen");
+    assert_eq!(
+        seen, PASSWD,
+        "the editor must be handed the live file, not the stale copy"
+    );
+    assert!(!read(&dir, "passwd").contains("junk"));
+}
+
+// ---------------------------------------------------------------------------
+// Which editor
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_visual_takes_precedence_over_editor() {
+    if skip_unless_root() {
+        return;
+    }
+    let dir = prefix();
+    let visual = editor(
+        &dir,
+        "visual",
+        r#"printf 'fromvisual:x:1004:1004:::/bin/sh\n' >> "$1""#,
+    );
+    let ed = editor(
+        &dir,
+        "ed",
+        r#"printf 'fromeditor:x:1005:1005:::/bin/sh\n' >> "$1""#,
+    );
+    edit_with("vipw", &dir, &[], &[("VISUAL", &visual), ("EDITOR", &ed)]).assert_code(0);
+    let after = read(&dir, "passwd");
+    assert!(after.contains("fromvisual:"));
+    assert!(!after.contains("fromeditor:"));
+}
+
+/// An editor with arguments goes through the shell, as it does everywhere.
+#[test]
+fn test_an_editor_with_arguments_works() {
+    if skip_unless_root() {
+        return;
+    }
+    let dir = prefix();
+    let ed = editor(
+        &dir,
+        "ed",
+        r#"[ "$1" = --flag ] && shift; printf 'erin:x:1006:1006:::/bin/sh\n' >> "$1""#,
+    );
+    let with_flag = format!("{ed} --flag");
+    edit_with("vipw", &dir, &[], &[("EDITOR", &with_flag)]).assert_code(0);
+    assert!(read(&dir, "passwd").contains("erin:"));
+}
+
+#[test]
+fn test_group_and_passwd_flags_conflict() {
+    let dir = prefix();
+    edit_with("vipw", &dir, &["-g", "-p"], &[]).assert_code(2);
+}
+
+#[test]
+fn test_help_exits_zero() {
+    let dir = prefix();
+    edit_with("vipw", &dir, &["--help"], &[])
+        .assert_code(0)
+        .assert_stdout_contains("Usage:");
+    edit_with("vigr", &dir, &["--help"], &[])
+        .assert_code(0)
+        .assert_stdout_contains("Usage:");
+}

--- a/tests/e2e/deploy-test.sh
+++ b/tests/e2e/deploy-test.sh
@@ -100,7 +100,7 @@ hash_password() {
 
 # ── TOOLS list ──────────────────────────────────────────────────────
 
-TOOLS="passwd pwck useradd userdel usermod chpasswd chgpasswd newusers chage groupadd groupdel groupmod gpasswd grpck chfn chsh newgrp sg"
+TOOLS="passwd pwck useradd userdel usermod chpasswd chgpasswd newusers chage groupadd groupdel groupmod gpasswd grpck chfn chsh newgrp sg vipw vigr"
 SETUID_TOOLS="passwd chfn chsh newgrp gpasswd sg"
 
 # The tools an unprivileged user runs are installed in bin, the rest in sbin,
@@ -869,6 +869,70 @@ test_gpasswd_group_admin() {
     userdel -r gp_member 2>/dev/null || true
 }
 
+# ── vipw / vigr: hand edits under the lock ─────────────────────────
+
+test_vipw() {
+    section "vipw / vigr — hand edits under the lock"
+
+    userdel -r vp_alice 2>/dev/null || true
+    userdel -r vp_racer 2>/dev/null || true
+    groupdel vp_team 2>/dev/null || true
+    rm -f /etc/passwd.edit /etc/group.edit
+
+    # An "editor" that appends a line, and one that sleeps so a race can be
+    # arranged. Both come back within the same second as the copy was made,
+    # which the GNU tool would misread as "unchanged".
+    cat > /usr/local/bin/ed-append <<'E'
+#!/bin/sh
+printf '%s\n' "$APPEND" >> "$1"
+E
+    cat > /usr/local/bin/ed-slow <<'E'
+#!/bin/sh
+sleep 3
+printf '%s\n' "$APPEND" >> "$1"
+E
+    chmod +x /usr/local/bin/ed-append /usr/local/bin/ed-slow
+
+    assert_ok "vipw installs an edit" \
+        env APPEND='vp_alice:x:5601:5601::/home/vp_alice:/bin/sh' EDITOR=ed-append vipw -q
+    assert_file_contains "the line is in /etc/passwd" /etc/passwd '^vp_alice:x:5601:'
+    assert_ok "the mode of /etc/passwd is intact" \
+        bash -c "test \"\$(stat -c %a /etc/passwd)\" = 644"
+    assert_ok "no working copy is left behind" bash -c "! test -e /etc/passwd.edit"
+
+    assert_ok "vigr installs an edit" \
+        env APPEND='vp_team:x:5602:vp_alice' EDITOR=ed-append vigr -q
+    assert_file_contains "the group is in /etc/group" /etc/group '^vp_team:x:5602:vp_alice'
+    assert_ok "the mode of /etc/shadow survives vipw -s" \
+        bash -c "EDITOR=true vipw -s -q && test \"\$(stat -c %a /etc/shadow)\" = 640"
+
+    # The reason the tool exists: while the editor is open, another tool that
+    # wants the same file waits, and both changes land.
+    APPEND='vp_racer_placeholder:x:5603:5603:::' EDITOR=ed-slow vipw -q &
+    sleep 1
+    assert_ok "useradd waits for the lock rather than failing" useradd -M vp_racer
+    wait
+    assert_file_contains "the hand edit landed" /etc/passwd '^vp_racer_placeholder:'
+    assert_file_contains "and so did the concurrent useradd" /etc/passwd '^vp_racer:'
+
+    # A result the suite cannot parse is refused and the edit kept.
+    assert_fail "an unparseable result is refused" \
+        env APPEND='this has no colons' EDITOR=ed-append vipw -q
+    assert_file_not_contains "the live file is untouched" /etc/passwd 'no colons'
+    assert_ok "the edit is kept beside the file" \
+        bash -c "grep -q 'no colons' /etc/passwd.edit"
+    rm -f /etc/passwd.edit
+
+    assert_fail "an editor that fails installs nothing" \
+        env EDITOR=false vipw -q
+
+    userdel -r vp_racer 2>/dev/null || true
+    userdel vp_racer_placeholder 2>/dev/null || true
+    userdel -r vp_alice 2>/dev/null || true
+    groupdel vp_team 2>/dev/null || true
+    rm -f /usr/local/bin/ed-append /usr/local/bin/ed-slow
+}
+
 # ── newusers: batch account creation ───────────────────────────────
 
 test_newusers() {
@@ -1159,6 +1223,7 @@ main() {
     test_sg_group_switch
     test_chgpasswd
     test_newusers
+    test_vipw
     test_aging_and_input
     test_audit_logging
     test_root_option

--- a/tests/gnu-compat.sh
+++ b/tests/gnu-compat.sh
@@ -226,6 +226,8 @@ for pair in \
     "chpasswd:/usr/sbin/chpasswd" \
     "chgpasswd:/usr/sbin/chgpasswd" \
     "newusers:/usr/sbin/newusers" \
+    "vipw:/usr/sbin/vipw" \
+    "vigr:/usr/sbin/vigr" \
     "gpasswd:/usr/bin/gpasswd" \
     "pwck:/usr/sbin/pwck" \
     "grpck:/usr/sbin/grpck"; do

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -58,3 +58,5 @@ mod test_useradd;
 mod test_userdel;
 #[path = "by-util/test_usermod.rs"]
 mod test_usermod;
+#[path = "by-util/test_vipw.rs"]
+mod test_vipw;


### PR DESCRIPTION
Adds `vipw` and `vigr`, the nineteenth and twentieth tools: hand edits of the account files, under the suite's lock.

Stacked on #293. Base retargets to `main` as the stack merges.

`vigr` is `vipw` with the group file as its default — the GNU suite ships it as a symlink — so it is a crate that calls `uu_vipw::run` with a different default and nothing else.

## The lock is the point, so that is what is proven

With the editor open on `/etc/passwd`, a concurrent `useradd` **waits** rather than failing or racing, and both changes land. That is an e2e assertion, not a claim.

## How an edit proceeds

1. Take the lock; copy the file to `passwd.edit` beside it, under a zeroed umask with the original's mode and ownership — a copy of `/etc/shadow` is never more readable than `/etc/shadow`. A stale copy from a crashed run is replaced.
2. Run `$VISUAL`, else `$EDITOR`, else `vi`, through the shell so `EDITOR="emacs -nw"` works. The path is a positional argument, not spliced into the command.
3. Editor failed → nothing installed. No change → *file is unchanged*.
4. **Parse the result.** Refused → the edit is **kept**, its path printed, live file untouched.
5. Install the bytes verbatim — comments and blank lines included — atomically, and name the companion file (`vipw -s` after `vipw`, and so on).

## Two deliberate departures from GNU

Both established by running its binary, not reading it.

**GNU installs whatever the editor saved.** A line with no colons went in. So did `evil::0:0:::/bin/sh` — a UID 0 account with an empty password field. Here a file the rest of the suite could not read back is refused. The check is structural (`pwck`/`grpck` still judge the contents), and the edit is kept rather than discarded: an administrator whose ten minutes of work vanished would use a raw editor next time, which is the outcome this tool exists to prevent.

**GNU detects changes by timestamp, in whole seconds.** An edit saved within the same second as the copy was made is silently thrown away. My first probe hit exactly this — every scripted edit came back "unchanged" until I slowed the script down. Here the comparison is by content.

## Signals

`vipw` blocks `SIGINT` and friends for the whole edit so a Ctrl-C aimed at the editor cannot kill it holding the lock. That mask would be inherited by the editor, which then could not be interrupted at all — so `shadow_core::process::spawn_with_signals_unblocked` starts the child with a clean mask. One `pre_exec`, in the module where `unsafe` is allowed.

## Verification

| | |
|---|---|
| `cargo test --workspace` | 852 passed on debian, alpine and fedora |
| `make check` | fmt, clippy ×3, tests ±`pam`, unprivileged run — exit 0 |
| e2e deployment suite | 319 assertions against a real install |
| `make test-gnu-compat` | 47 comparisons against the GNU binaries |
| `make test-arm64` | 24 assertions under emulation |
