### PR TITLE
pwconv, pwunconv, grpconv, grpunconv: convert to and from shadow files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `pwconv`, `pwunconv`, `grpconv` and `grpunconv`, tools twenty-one to
+  twenty-four, which complete the set both Debian and Fedora ship. `pwconv`
+  moves password hashes out of the world-readable `/etc/passwd` into
+  `/etc/shadow`, creating it `0640 root:shadow` when it does not exist, and
+  reconciles the two: a passwd line with no shadow line gets one dated today
+  with the aging from login.defs, a shadow line with no passwd line is
+  dropped, and a hash found in passwd beside an existing shadow line replaces
+  it as the newer of the two. The shadow file is written before passwd, so a
+  failure between the two writes leaves the hashes where they were rather than
+  nowhere; `pwunconv` writes passwd before it removes shadow for the same
+  reason. `grpconv` and `grpunconv` do the same for the group files, with a
+  new gshadow line inheriting the membership `/etc/group` records. All four are
+  one engine; the other three crates name which tool they are
+
 - `vipw` and `vigr`, the nineteenth and twentieth tools: they hand
   `/etc/passwd`, `/etc/shadow`, `/etc/group` or `/etc/gshadow` to the
   administrator's editor under the same lock every other tool takes, so a hand

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -805,6 +805,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "uu_grpconv"
+version = "0.4.0"
+dependencies = [
+ "clap",
+ "uu_pwconv",
+ "uucore",
+]
+
+[[package]]
+name = "uu_grpunconv"
+version = "0.4.0"
+dependencies = [
+ "clap",
+ "uu_pwconv",
+ "uucore",
+]
+
+[[package]]
 name = "uu_newgrp"
 version = "0.4.0"
 dependencies = [
@@ -847,6 +865,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "uu_pwconv"
+version = "0.4.0"
+dependencies = [
+ "clap",
+ "rustix",
+ "shadow-core",
+ "tempfile",
+ "uucore",
+]
+
+[[package]]
+name = "uu_pwunconv"
+version = "0.4.0"
+dependencies = [
+ "clap",
+ "uu_pwconv",
+ "uucore",
+]
+
+[[package]]
 name = "uu_sg"
 version = "0.4.0"
 dependencies = [
@@ -874,10 +912,14 @@ dependencies = [
  "uu_groupdel",
  "uu_groupmod",
  "uu_grpck",
+ "uu_grpconv",
+ "uu_grpunconv",
  "uu_newgrp",
  "uu_newusers",
  "uu_passwd",
  "uu_pwck",
+ "uu_pwconv",
+ "uu_pwunconv",
  "uu_sg",
  "uu_useradd",
  "uu_userdel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,10 @@ members = [
     "src/uu/newusers",
     "src/uu/vipw",
     "src/uu/vigr",
+    "src/uu/pwconv",
+    "src/uu/pwunconv",
+    "src/uu/grpconv",
+    "src/uu/grpunconv",
 ]
 
 [workspace.package]
@@ -102,11 +106,16 @@ chgpasswd = { optional = true, version = "0.4.0", package = "uu_chgpasswd", path
 newusers = { optional = true, version = "0.4.0", package = "uu_newusers", path = "src/uu/newusers" }
 vipw = { optional = true, version = "0.4.0", package = "uu_vipw", path = "src/uu/vipw" }
 vigr = { optional = true, version = "0.4.0", package = "uu_vigr", path = "src/uu/vigr" }
+pwconv = { optional = true, version = "0.4.0", package = "uu_pwconv", path = "src/uu/pwconv" }
+pwunconv = { optional = true, version = "0.4.0", package = "uu_pwunconv", path = "src/uu/pwunconv" }
+grpconv = { optional = true, version = "0.4.0", package = "uu_grpconv", path = "src/uu/grpconv" }
+grpunconv = { optional = true, version = "0.4.0", package = "uu_grpunconv", path = "src/uu/grpunconv" }
 
 [features]
 default = ["passwd", "pwck", "useradd", "userdel", "usermod", "chpasswd", "chage",
            "groupadd", "groupdel", "groupmod", "grpck", "chfn", "chsh", "newgrp", "gpasswd",
-           "sg", "chgpasswd", "newusers", "vipw", "vigr"]
+           "sg", "chgpasswd", "newusers", "vipw", "vigr",
+           "pwconv", "pwunconv", "grpconv", "grpunconv"]
 
 # PAM authentication (requires libpam-dev). The `?` matters: without it,
 # asking for PAM would drag in the three applets that can use it even when the
@@ -146,6 +155,10 @@ chgpasswd = { version = "0.4.0", package = "uu_chgpasswd", path = "src/uu/chgpas
 newusers = { version = "0.4.0", package = "uu_newusers", path = "src/uu/newusers" }
 vipw = { version = "0.4.0", package = "uu_vipw", path = "src/uu/vipw" }
 vigr = { version = "0.4.0", package = "uu_vigr", path = "src/uu/vigr" }
+pwconv = { version = "0.4.0", package = "uu_pwconv", path = "src/uu/pwconv" }
+pwunconv = { version = "0.4.0", package = "uu_pwunconv", path = "src/uu/pwunconv" }
+grpconv = { version = "0.4.0", package = "uu_grpconv", path = "src/uu/grpconv" }
+grpunconv = { version = "0.4.0", package = "uu_grpunconv", path = "src/uu/grpunconv" }
 passwd = { version = "0.4.0", package = "uu_passwd", path = "src/uu/passwd" }
 useradd = { version = "0.4.0", package = "uu_useradd", path = "src/uu/useradd" }
 userdel = { version = "0.4.0", package = "uu_userdel", path = "src/uu/userdel" }

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,8 @@ SETUID_TOOLS = passwd chfn chsh newgrp gpasswd sg
 
 # Root-only tools (no setuid; fail at getuid() check for non-root callers).
 ROOT_TOOLS = useradd userdel usermod chpasswd chgpasswd newusers \
-             groupadd groupdel groupmod pwck grpck vipw vigr
+             groupadd groupdel groupmod pwck grpck vipw vigr \
+             pwconv pwunconv grpconv grpunconv
 
 # Tools an ordinary user runs, and which therefore go in bin rather than sbin:
 # sbin is not on a normal user's PATH, so `passwd` there is `command not
@@ -133,7 +134,7 @@ test-unprivileged:
 test-gnu-compat:
 	bash tests/gnu-compat.sh
 
-# Default install: 20 standalone per-tool binaries, with the setuid layout and
+# Default install: 24 standalone per-tool binaries, with the setuid layout and
 # the bin/sbin split GNU shadow-utils uses. Only $(SETUID_TOOLS) are setuid.
 install: build
 	@for tool in $(SETUID_TOOLS); do \

--- a/README.md
+++ b/README.md
@@ -73,6 +73,10 @@ default-in-Ubuntu in under 3 years. This project follows that playbook.
 | `newusers` | **Implemented.** Batch account creation: passwd, shadow, group and home. |
 | `vipw` | **Implemented.** Edit passwd or shadow under the suite's lock; the result is checked before it is installed. |
 | `vigr` | **Implemented.** `vipw` for group and gshadow. |
+| `pwconv` | **Implemented.** Moves hashes from passwd into shadow and reconciles the two; shadow is written first so a failure loses nothing. |
+| `pwunconv` | **Implemented.** Merges hashes back into passwd and removes shadow. |
+| `grpconv` | **Implemented.** `pwconv` for group and gshadow. |
+| `grpunconv` | **Implemented.** `pwunconv` for group and gshadow. |
 
 ## Building
 
@@ -93,9 +97,9 @@ docker compose run --rm debian cargo build --release
 
 ### Install
 
-Default install: 20 standalone per-tool binaries with least-privilege setuid
+Default install: 24 standalone per-tool binaries with least-privilege setuid
 layout matching GNU shadow-utils. Only `passwd`, `chfn`, `chsh`, `newgrp`,
-`gpasswd` and `sg` are installed setuid-root; the other 14 are plain `0755`.
+`gpasswd` and `sg` are installed setuid-root; the other 18 are plain `0755`.
 
 ```shell
 sudo make install PREFIX=/usr/local
@@ -147,7 +151,8 @@ tar xzf uu_shadow-x86_64-unknown-linux-gnu.tar.gz   # or the -musl-static one
 sudo install -o root -g root -m 4755 \
     uu_shadow-*/shadow-rs /usr/local/bin/shadow-rs
 for tool in passwd chfn chsh newgrp gpasswd sg chage chpasswd chgpasswd newusers \
-            groupadd groupdel groupmod grpck pwck useradd userdel usermod vipw vigr; do
+            groupadd groupdel groupmod grpck pwck useradd userdel usermod vipw vigr \
+            pwconv pwunconv grpconv grpunconv; do
     sudo ln -sf shadow-rs "/usr/local/bin/$tool"
 done
 ```

--- a/docs/man/grpconv.8.md
+++ b/docs/man/grpconv.8.md
@@ -1,0 +1,16 @@
+# grpconv(8) - convert to and from shadow passwords and groups
+
+## NAME
+
+grpconv - see **pwconv**(8)
+
+## DESCRIPTION
+
+**grpconv** is one of the four conversion tools described together in
+**pwconv**(8): **pwconv**, **pwunconv**, **grpconv** and **grpunconv**. They
+are one program with a selector, and share their options, exit codes and
+order-of-write guarantees.
+
+## SEE ALSO
+
+pwconv(8)

--- a/docs/man/grpunconv.8.md
+++ b/docs/man/grpunconv.8.md
@@ -1,0 +1,16 @@
+# grpunconv(8) - convert to and from shadow passwords and groups
+
+## NAME
+
+grpunconv - see **pwconv**(8)
+
+## DESCRIPTION
+
+**grpunconv** is one of the four conversion tools described together in
+**pwconv**(8): **pwconv**, **pwunconv**, **grpconv** and **grpunconv**. They
+are one program with a selector, and share their options, exit codes and
+order-of-write guarantees.
+
+## SEE ALSO
+
+pwconv(8)

--- a/docs/man/pwconv.8.md
+++ b/docs/man/pwconv.8.md
@@ -1,0 +1,110 @@
+# pwconv(8) - convert to and from shadow passwords and groups
+
+## NAME
+
+pwconv, pwunconv, grpconv, grpunconv - convert to and from shadow passwords
+and groups
+
+## SYNOPSIS
+
+**pwconv** [*options*]
+
+**pwunconv** [*options*]
+
+**grpconv** [*options*]
+
+**grpunconv** [*options*]
+
+## DESCRIPTION
+
+The **pwconv** command creates /etc/shadow from /etc/passwd and an optionally
+existing /etc/shadow, moving the password hashes out of the world-readable
+file. **pwunconv** does the reverse: it merges the hashes back into
+/etc/passwd and removes /etc/shadow. **grpconv** and **grpunconv** do the same
+for /etc/group and /etc/gshadow.
+
+The four are one program with a selector. Each takes the same lock every other
+tool in the suite takes, so nothing can interleave with the conversion, and
+writes both files through the same validate-then-write transaction.
+
+## WHAT pwconv DOES
+
+For every line in /etc/passwd:
+
+- A password field that is not `x` is a hash that got into /etc/passwd
+  through a tool or an edit that did not know about /etc/shadow. It is moved
+  to the shadow line — replacing the hash there if the line already exists,
+  and dating the change — and the field is set to `x`.
+- A line with no shadow line gets one. The hash is copied as it stands; the
+  last-change date is today; and the minimum age, maximum age and warning
+  period come from **PASS_MIN_DAYS**, **PASS_MAX_DAYS** and **PASS_WARN_AGE**
+  in /etc/login.defs.
+
+A shadow line for an account that no longer has a passwd line is dropped: a
+stale line with a live hash is a password nobody can use but anyone with the
+file could crack.
+
+A system that is already consistent is left byte for byte alone.
+
+If /etc/shadow did not exist it is created `0640`, owned by root and by the
+`shadow` group of the tree being converted, which is how the distributions
+ship it. Where that tree has no `shadow` group the file is left `0600 root`.
+
+**grpconv** behaves the same way for the group files. A new /etc/gshadow line
+starts with the membership /etc/group records and no administrators.
+
+## WHAT pwunconv DOES
+
+Every account with a shadow line gets that line's hash back in /etc/passwd.
+An account with no shadow line keeps whatever /etc/passwd holds. Then
+/etc/shadow is removed. Aging information has nowhere to go in /etc/passwd
+and is lost, as it is with the GNU tool. A system with no /etc/shadow is
+already in the requested state and is left alone.
+
+**grpunconv** behaves the same way for the group files.
+
+## ORDER OF WRITES
+
+**pwconv** writes /etc/shadow before /etc/passwd: the hashes are copied into
+the shadow file and only then replaced by `x`. A failure between the two writes
+leaves them where they were, rather than nowhere. **pwunconv** writes
+/etc/passwd before it removes /etc/shadow: for a moment the hashes exist twice,
+which is recoverable, where the other order would have a moment with none.
+
+## OPTIONS
+
+**-R**, **--root** *CHROOT_DIR*
+:   Apply changes in *CHROOT_DIR* and use its configuration files.
+
+**-P**, **--prefix** *PREFIX_DIR*
+:   Convert the account files under *PREFIX_DIR* without chrooting.
+
+## EXIT STATUS
+
+**0**
+:   Success.
+
+**1**
+:   The files could not be updated, or the caller is not root.
+
+**2**
+:   Invalid command syntax.
+
+**3**
+:   The **--root** directory could not be entered.
+
+**5**
+:   An account file is locked by another tool. Try again later.
+
+## FILES
+
+/etc/passwd, /etc/shadow, /etc/group, /etc/gshadow
+:   The files converted.
+
+/etc/login.defs
+:   **PASS_MIN_DAYS**, **PASS_MAX_DAYS** and **PASS_WARN_AGE** for new shadow
+    lines.
+
+## SEE ALSO
+
+grpck(8), login.defs(5), pwck(8), shadow(5), gshadow(5)

--- a/docs/man/pwunconv.8.md
+++ b/docs/man/pwunconv.8.md
@@ -1,0 +1,16 @@
+# pwunconv(8) - convert to and from shadow passwords and groups
+
+## NAME
+
+pwunconv - see **pwconv**(8)
+
+## DESCRIPTION
+
+**pwunconv** is one of the four conversion tools described together in
+**pwconv**(8): **pwconv**, **pwunconv**, **grpconv** and **grpunconv**. They
+are one program with a selector, and share their options, exit codes and
+order-of-write guarantees.
+
+## SEE ALSO
+
+pwconv(8)

--- a/src/bin/completions.rs
+++ b/src/bin/completions.rs
@@ -43,6 +43,10 @@ fn get_tool_app(name: &str) -> Option<Command> {
         "gpasswd" => Some(gpasswd::uu_app()),
         #[cfg(feature = "grpck")]
         "grpck" => Some(grpck::uu_app()),
+        #[cfg(feature = "grpconv")]
+        "grpconv" => Some(grpconv::uu_app()),
+        #[cfg(feature = "grpunconv")]
+        "grpunconv" => Some(grpunconv::uu_app()),
         #[cfg(feature = "newgrp")]
         "newgrp" => Some(newgrp::uu_app()),
         #[cfg(feature = "newusers")]
@@ -51,6 +55,10 @@ fn get_tool_app(name: &str) -> Option<Command> {
         "passwd" => Some(passwd::uu_app()),
         #[cfg(feature = "pwck")]
         "pwck" => Some(pwck::uu_app()),
+        #[cfg(feature = "pwconv")]
+        "pwconv" => Some(pwconv::uu_app()),
+        #[cfg(feature = "pwunconv")]
+        "pwunconv" => Some(pwunconv::uu_app()),
         #[cfg(feature = "sg")]
         "sg" => Some(sg::uu_app()),
         #[cfg(feature = "useradd")]
@@ -90,6 +98,10 @@ fn all_tool_names() -> Vec<&'static str> {
     names.push("gpasswd");
     #[cfg(feature = "grpck")]
     names.push("grpck");
+    #[cfg(feature = "grpconv")]
+    names.push("grpconv");
+    #[cfg(feature = "grpunconv")]
+    names.push("grpunconv");
     #[cfg(feature = "newgrp")]
     names.push("newgrp");
     #[cfg(feature = "newusers")]
@@ -98,6 +110,10 @@ fn all_tool_names() -> Vec<&'static str> {
     names.push("passwd");
     #[cfg(feature = "pwck")]
     names.push("pwck");
+    #[cfg(feature = "pwconv")]
+    names.push("pwconv");
+    #[cfg(feature = "pwunconv")]
+    names.push("pwunconv");
     #[cfg(feature = "sg")]
     names.push("sg");
     #[cfg(feature = "useradd")]

--- a/src/bin/shadow-rs.rs
+++ b/src/bin/shadow-rs.rs
@@ -39,7 +39,7 @@ const SETUID_APPLETS: [&str; 6] = ["passwd", "chfn", "chsh", "newgrp", "gpasswd"
 // nothing, and the binding is then not mutated.
 #[allow(unused_mut)]
 fn applets() -> Vec<(&'static str, Applet)> {
-    let mut table: Vec<(&'static str, Applet)> = Vec::with_capacity(20);
+    let mut table: Vec<(&'static str, Applet)> = Vec::with_capacity(24);
     #[cfg(feature = "chage")]
     table.push(("chage", |a| chage::uumain(a.iter().cloned())));
     #[cfg(feature = "chfn")]
@@ -60,6 +60,10 @@ fn applets() -> Vec<(&'static str, Applet)> {
     table.push(("groupmod", |a| groupmod::uumain(a.iter().cloned())));
     #[cfg(feature = "grpck")]
     table.push(("grpck", |a| grpck::uumain(a.iter().cloned())));
+    #[cfg(feature = "grpconv")]
+    table.push(("grpconv", |a| grpconv::uumain(a.iter().cloned())));
+    #[cfg(feature = "grpunconv")]
+    table.push(("grpunconv", |a| grpunconv::uumain(a.iter().cloned())));
     #[cfg(feature = "newgrp")]
     table.push(("newgrp", |a| newgrp::uumain(a.iter().cloned())));
     #[cfg(feature = "newusers")]
@@ -68,6 +72,10 @@ fn applets() -> Vec<(&'static str, Applet)> {
     table.push(("passwd", |a| passwd::uumain(a.iter().cloned())));
     #[cfg(feature = "pwck")]
     table.push(("pwck", |a| pwck::uumain(a.iter().cloned())));
+    #[cfg(feature = "pwconv")]
+    table.push(("pwconv", |a| pwconv::uumain(a.iter().cloned())));
+    #[cfg(feature = "pwunconv")]
+    table.push(("pwunconv", |a| pwunconv::uumain(a.iter().cloned())));
     #[cfg(feature = "sg")]
     table.push(("sg", |a| sg::uumain(a.iter().cloned())));
     #[cfg(feature = "useradd")]
@@ -238,7 +246,7 @@ fn print_available_utils() {
 mod tests {
     use super::*;
 
-    const ALL_TOOLS: [&str; 20] = [
+    const ALL_TOOLS: [&str; 24] = [
         "chage",
         "chfn",
         "chgpasswd",
@@ -249,10 +257,14 @@ mod tests {
         "groupdel",
         "groupmod",
         "grpck",
+        "grpconv",
+        "grpunconv",
         "newgrp",
         "newusers",
         "passwd",
         "pwck",
+        "pwconv",
+        "pwunconv",
         "sg",
         "useradd",
         "userdel",

--- a/src/uu/grpconv/Cargo.toml
+++ b/src/uu/grpconv/Cargo.toml
@@ -1,0 +1,33 @@
+[package]
+name = "uu_grpconv"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+categories.workspace = true
+rust-version.workspace = true
+description = "grpconv ~ (shadow-rs) move group passwords from /etc/group into /etc/gshadow"
+
+[lib]
+path = "src/grpconv.rs"
+
+[[bin]]
+name = "grpconv"
+path = "src/main.rs"
+
+[dependencies]
+clap = { workspace = true }
+uucore = { workspace = true }
+# One engine serves pwconv, pwunconv, grpconv and grpunconv; this crate names
+# which of the four it is.
+uu_pwconv = { path = "../pwconv", version = "0.4.0" }
+
+[lints]
+workspace = true
+
+# Distributed via the `shadow-rs` multicall binary in the workspace root
+# package, not as a standalone archive (see dist-workspace.toml, issue #207).
+[package.metadata.dist]
+dist = false

--- a/src/uu/grpconv/locales/en-US.ftl
+++ b/src/uu/grpconv/locales/en-US.ftl
@@ -1,0 +1,2 @@
+grpconv-about = move group passwords from /etc/group into /etc/gshadow
+grpconv-usage = grpconv [options]

--- a/src/uu/grpconv/src/grpconv.rs
+++ b/src/uu/grpconv/src/grpconv.rs
@@ -1,0 +1,36 @@
+// This file is part of the shadow-rs package.
+//
+// For the full copyright and license information, please view the LICENSE
+// file that was distributed with this source code.
+// spell-checker:ignore pwconv pwunconv grpconv grpunconv gshadow
+
+//! `grpconv` — move group passwords from /etc/group into /etc/gshadow.
+//!
+//! One of the four conversion tools built on the engine in `uu_pwconv`; this
+//! crate only names which one.
+
+use clap::Command;
+use uucore::error::UResult;
+
+/// Entry point for the `grpconv` utility.
+#[uucore::main]
+pub fn uumain(args: impl uucore::Args) -> UResult<()> {
+    uu_pwconv::run(uu_pwconv::Tool::Grpconv, args)
+}
+
+/// Build the clap `Command` for `grpconv`.
+#[must_use]
+pub fn uu_app() -> Command {
+    uu_pwconv::app(uu_pwconv::Tool::Grpconv)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_app_builds_under_its_own_name() {
+        uu_app().debug_assert();
+        assert_eq!(uu_app().get_name(), "grpconv");
+    }
+}

--- a/src/uu/grpconv/src/main.rs
+++ b/src/uu/grpconv/src/main.rs
@@ -1,0 +1,6 @@
+// This file is part of the shadow-rs package.
+//
+// For the full copyright and license information, please view the LICENSE
+// file that was distributed with this source code.
+
+uucore::bin!(uu_grpconv);

--- a/src/uu/grpunconv/Cargo.toml
+++ b/src/uu/grpunconv/Cargo.toml
@@ -1,0 +1,33 @@
+[package]
+name = "uu_grpunconv"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+categories.workspace = true
+rust-version.workspace = true
+description = "grpunconv ~ (shadow-rs) move group passwords from /etc/gshadow back into /etc/group"
+
+[lib]
+path = "src/grpunconv.rs"
+
+[[bin]]
+name = "grpunconv"
+path = "src/main.rs"
+
+[dependencies]
+clap = { workspace = true }
+uucore = { workspace = true }
+# One engine serves pwconv, pwunconv, grpconv and grpunconv; this crate names
+# which of the four it is.
+uu_pwconv = { path = "../pwconv", version = "0.4.0" }
+
+[lints]
+workspace = true
+
+# Distributed via the `shadow-rs` multicall binary in the workspace root
+# package, not as a standalone archive (see dist-workspace.toml, issue #207).
+[package.metadata.dist]
+dist = false

--- a/src/uu/grpunconv/locales/en-US.ftl
+++ b/src/uu/grpunconv/locales/en-US.ftl
@@ -1,0 +1,2 @@
+grpunconv-about = move group passwords from /etc/gshadow back into /etc/group
+grpunconv-usage = grpunconv [options]

--- a/src/uu/grpunconv/src/grpunconv.rs
+++ b/src/uu/grpunconv/src/grpunconv.rs
@@ -1,0 +1,36 @@
+// This file is part of the shadow-rs package.
+//
+// For the full copyright and license information, please view the LICENSE
+// file that was distributed with this source code.
+// spell-checker:ignore pwconv pwunconv grpconv grpunconv gshadow
+
+//! `grpunconv` — move group passwords from /etc/gshadow back into /etc/group.
+//!
+//! One of the four conversion tools built on the engine in `uu_pwconv`; this
+//! crate only names which one.
+
+use clap::Command;
+use uucore::error::UResult;
+
+/// Entry point for the `grpunconv` utility.
+#[uucore::main]
+pub fn uumain(args: impl uucore::Args) -> UResult<()> {
+    uu_pwconv::run(uu_pwconv::Tool::Grpunconv, args)
+}
+
+/// Build the clap `Command` for `grpunconv`.
+#[must_use]
+pub fn uu_app() -> Command {
+    uu_pwconv::app(uu_pwconv::Tool::Grpunconv)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_app_builds_under_its_own_name() {
+        uu_app().debug_assert();
+        assert_eq!(uu_app().get_name(), "grpunconv");
+    }
+}

--- a/src/uu/grpunconv/src/main.rs
+++ b/src/uu/grpunconv/src/main.rs
@@ -1,0 +1,6 @@
+// This file is part of the shadow-rs package.
+//
+// For the full copyright and license information, please view the LICENSE
+// file that was distributed with this source code.
+
+uucore::bin!(uu_grpunconv);

--- a/src/uu/pwconv/Cargo.toml
+++ b/src/uu/pwconv/Cargo.toml
@@ -1,0 +1,35 @@
+[package]
+name = "uu_pwconv"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+categories.workspace = true
+rust-version.workspace = true
+description = "pwconv ~ (shadow-rs) convert between shadowed and unshadowed account files"
+
+[lib]
+path = "src/pwconv.rs"
+
+[[bin]]
+name = "pwconv"
+path = "src/main.rs"
+
+[dependencies]
+clap = { workspace = true }
+rustix = { workspace = true }
+shadow-core = { workspace = true }
+uucore = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }
+
+[lints]
+workspace = true
+
+# Distributed via the `shadow-rs` multicall binary in the workspace root
+# package, not as a standalone archive (see dist-workspace.toml, issue #207).
+[package.metadata.dist]
+dist = false

--- a/src/uu/pwconv/locales/en-US.ftl
+++ b/src/uu/pwconv/locales/en-US.ftl
@@ -1,0 +1,2 @@
+pwconv-about = Move password hashes from /etc/passwd into /etc/shadow
+pwconv-usage = pwconv [options]

--- a/src/uu/pwconv/src/main.rs
+++ b/src/uu/pwconv/src/main.rs
@@ -1,0 +1,6 @@
+// This file is part of the shadow-rs package.
+//
+// For the full copyright and license information, please view the LICENSE
+// file that was distributed with this source code.
+
+uucore::bin!(uu_pwconv);

--- a/src/uu/pwconv/src/pwconv.rs
+++ b/src/uu/pwconv/src/pwconv.rs
@@ -1,0 +1,654 @@
+// This file is part of the shadow-rs package.
+//
+// For the full copyright and license information, please view the LICENSE
+// file that was distributed with this source code.
+// spell-checker:ignore pwconv pwunconv grpconv grpunconv gshadow chroot fchown fchmod sysroot lstchg
+
+//! `pwconv`, `pwunconv`, `grpconv`, `grpunconv` — convert between shadowed
+//! and unshadowed account files.
+//!
+//! Drop-in replacements for the GNU shadow-utils tools of the same names.
+//! `pwconv` moves password hashes out of the world-readable `/etc/passwd`
+//! into `/etc/shadow`, creating it if need be, and reconciles the two: a
+//! passwd line with no shadow line gets one, a shadow line with no passwd
+//! line is dropped. `pwunconv` merges the hashes back and removes
+//! `/etc/shadow`. `grpconv` and `grpunconv` do the same for `/etc/group` and
+//! `/etc/gshadow`.
+//!
+//! The four are one engine with a selector; the other three crates are the
+//! selector.
+
+use std::collections::HashSet;
+use std::fmt;
+use std::path::Path;
+
+use clap::{Arg, Command};
+
+use shadow_core::error::ShadowError;
+use shadow_core::group::GroupEntry;
+use shadow_core::gshadow::GshadowEntry;
+use shadow_core::login_defs::LoginDefs;
+use shadow_core::passwd::PasswdEntry;
+use shadow_core::shadow::ShadowEntry;
+use shadow_core::sysroot::SysRoot;
+use shadow_core::transaction::{self, Commit, LockedFile, Record};
+
+use uucore::error::{UError, UResult};
+
+mod options {
+    pub const ROOT: &str = "root";
+    pub const PREFIX: &str = "prefix";
+}
+
+/// The placeholder in `/etc/passwd` and `/etc/group` that says the real
+/// field lives in the shadow file.
+const SHADOWED: &str = "x";
+
+/// The mode a freshly created shadow file gets, and the group that may read
+/// it. This is how the distributions ship `/etc/shadow`: readable by the
+/// `shadow` group so PAM helpers can check passwords without being root.
+const SHADOW_FILE_MODE: u32 = 0o640;
+const SHADOW_GROUP: &str = "shadow";
+
+/// Which of the four tools was invoked.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Tool {
+    Pwconv,
+    Pwunconv,
+    Grpconv,
+    Grpunconv,
+}
+
+impl Tool {
+    fn name(self) -> &'static str {
+        match self {
+            Self::Pwconv => "pwconv",
+            Self::Pwunconv => "pwunconv",
+            Self::Grpconv => "grpconv",
+            Self::Grpunconv => "grpunconv",
+        }
+    }
+
+    fn about(self) -> &'static str {
+        match self {
+            Self::Pwconv => "Move password hashes from /etc/passwd into /etc/shadow",
+            Self::Pwunconv => "Move password hashes from /etc/shadow back into /etc/passwd",
+            Self::Grpconv => "Move group passwords from /etc/group into /etc/gshadow",
+            Self::Grpunconv => "Move group passwords from /etc/gshadow back into /etc/group",
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Error type
+// ---------------------------------------------------------------------------
+
+/// Errors the four tools can produce, with the exit codes pwconv(8) documents.
+#[derive(Debug)]
+enum ConvError {
+    /// Exit 1 — insufficient privileges.
+    PermissionDenied(String),
+    /// Exit 1 — the files could not be updated.
+    CantUpdate(String),
+    /// Exit 3 — the `--root` directory could not be entered.
+    CantChroot(String),
+    /// Exit 5 — an account file is locked by another tool.
+    FileBusy(String),
+}
+
+impl fmt::Display for ConvError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::PermissionDenied(msg)
+            | Self::CantUpdate(msg)
+            | Self::CantChroot(msg)
+            | Self::FileBusy(msg) => f.write_str(msg),
+        }
+    }
+}
+
+impl std::error::Error for ConvError {}
+
+impl UError for ConvError {
+    fn code(&self) -> i32 {
+        match self {
+            Self::PermissionDenied(_) | Self::CantUpdate(_) => 1,
+            Self::CantChroot(_) => 3,
+            Self::FileBusy(_) => 5,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Entry points
+// ---------------------------------------------------------------------------
+
+/// Entry point for the `pwconv` utility.
+#[uucore::main]
+pub fn uumain(args: impl uucore::Args) -> UResult<()> {
+    run(Tool::Pwconv, args)
+}
+
+/// Build the clap `Command` for `pwconv`.
+#[must_use]
+pub fn uu_app() -> Command {
+    app(Tool::Pwconv)
+}
+
+/// Run any of the four tools.
+pub fn run(tool: Tool, args: impl uucore::Args) -> UResult<()> {
+    shadow_core::hardening::harden_process();
+
+    let Some(matches) = shadow_core::cli::parse_args(app(tool), args, |_| 2)? else {
+        return Ok(());
+    };
+
+    if let Some(chroot_dir) = matches.get_one::<String>(options::ROOT) {
+        shadow_core::hardening::chroot_into(Path::new(chroot_dir))
+            .map_err(|e| ConvError::CantChroot(e.to_string()))?;
+    }
+    let prefix = matches.get_one::<String>(options::PREFIX).map(Path::new);
+    let root = SysRoot::new(prefix);
+
+    if !shadow_core::hardening::caller_is_root() {
+        return Err(ConvError::PermissionDenied(shadow_core::os_error::permission_denied()).into());
+    }
+
+    match tool {
+        Tool::Pwconv => pwconv(&root),
+        Tool::Pwunconv => pwunconv(&root),
+        Tool::Grpconv => grpconv(&root),
+        Tool::Grpunconv => grpunconv(&root),
+    }
+}
+
+/// Build the clap `Command` for any of the four tools.
+#[must_use]
+pub fn app(tool: Tool) -> Command {
+    Command::new(tool.name())
+        .about(tool.about())
+        .override_usage(format!("{} [options]", tool.name()))
+        .version(shadow_core::cli::VERSION)
+        .after_help(shadow_core::cli::AFTER_HELP)
+        .arg(
+            Arg::new(options::ROOT)
+                .short('R')
+                .long("root")
+                .help("chroot into CHROOT_DIR before converting")
+                .value_name("CHROOT_DIR"),
+        )
+        .arg(
+            Arg::new(options::PREFIX)
+                .short('P')
+                .long("prefix")
+                .help("directory prefix")
+                .value_name("PREFIX_DIR"),
+        )
+}
+
+// ---------------------------------------------------------------------------
+// pwconv / pwunconv
+// ---------------------------------------------------------------------------
+
+fn pwconv(root: &SysRoot) -> UResult<()> {
+    let passwd_path = root.passwd_path();
+    let shadow_path = root.shadow_path();
+    let creating = !shadow_path.exists();
+
+    let mut passwd = open::<PasswdEntry>(&passwd_path)?;
+    let mut shadow = open_or_empty::<ShadowEntry>(&shadow_path)?;
+
+    let defs = LoginDefs::load(&root.login_defs_path()).unwrap_or_default();
+    let today = shadow_core::shadow::days_since_epoch()
+        .map_err(|e| ConvError::CantUpdate(format!("cannot determine the current date: {e}")))?;
+
+    reconcile_shadow(passwd.entries_mut(), shadow.entries_mut(), today, &defs);
+
+    // shadow first, then passwd. The hashes are copied into shadow and only
+    // then replaced by `x` in passwd, so a failure between the two writes
+    // leaves the hashes where they were rather than nowhere. Both files are
+    // validated before either is written.
+    let files: Vec<Box<dyn Commit>> = vec![Box::new(shadow), Box::new(passwd)];
+    transaction::commit_all(files)
+        .map_err(|e| ConvError::CantUpdate(format!("cannot write: {e}")))?;
+
+    if creating {
+        let shadow_gid = shadow_group_gid(&root.group_path());
+        set_shadow_file_permissions(&shadow_path, shadow_gid)?;
+    }
+    shadow_core::nscd::invalidate_cache("passwd");
+    Ok(())
+}
+
+/// Bring `shadow` in line with `passwd`, moving every hash across.
+fn reconcile_shadow(
+    passwd: &mut [PasswdEntry],
+    shadow: &mut Vec<ShadowEntry>,
+    today: i64,
+    defs: &LoginDefs,
+) {
+    // A shadow line for an account that no longer exists is stale, and a
+    // stale line with a live hash is a password nobody can use but anyone
+    // with the file could crack.
+    let live: HashSet<&str> = passwd.iter().map(|p| p.name.as_str()).collect();
+    shadow.retain(|s| live.contains(s.name.as_str()));
+
+    for entry in passwd.iter_mut() {
+        match shadow.iter_mut().find(|s| s.name == entry.name) {
+            Some(existing) => {
+                // A real hash in passwd is newer than whatever shadow holds:
+                // it got there through a tool or an edit that did not know
+                // about shadow. It wins, and the change is dated.
+                if entry.passwd != SHADOWED {
+                    existing.passwd.clone_from(&entry.passwd);
+                    existing.last_change = Some(today);
+                }
+            }
+            None => shadow.push(ShadowEntry {
+                name: entry.name.clone(),
+                // Copied as it stands. An `x` here means the hash was lost
+                // before this ran, and an `x` in the hash field matches no
+                // password, which is the honest state of that account.
+                passwd: entry.passwd.clone(),
+                last_change: Some(today),
+                min_age: defs.get_i64("PASS_MIN_DAYS"),
+                max_age: defs.get_i64("PASS_MAX_DAYS"),
+                warn_days: defs.get_i64("PASS_WARN_AGE"),
+                inactive_days: None,
+                expire_date: None,
+                reserved: String::new(),
+            }),
+        }
+        entry.passwd = SHADOWED.to_string();
+    }
+}
+
+fn pwunconv(root: &SysRoot) -> UResult<()> {
+    let passwd_path = root.passwd_path();
+    let shadow_path = root.shadow_path();
+    if !shadow_path.exists() {
+        // Nothing to unshadow: the system is already in the requested state.
+        return Ok(());
+    }
+
+    let mut passwd = open::<PasswdEntry>(&passwd_path)?;
+    let shadow = open::<ShadowEntry>(&shadow_path)?;
+
+    for entry in passwd.entries_mut() {
+        // An account with no shadow line keeps whatever passwd holds; there
+        // is no hash to bring back.
+        if let Some(line) = shadow.find(&entry.name) {
+            entry.passwd.clone_from(&line.passwd);
+        }
+    }
+
+    // passwd first, then the removal. Between the two the hashes exist twice,
+    // which is recoverable; the other order would have a moment with none.
+    passwd
+        .commit()
+        .map_err(|e| ConvError::CantUpdate(format!("cannot write: {e}")))?;
+    remove_while_locked(&shadow_path)?;
+    drop(shadow);
+
+    shadow_core::nscd::invalidate_cache("passwd");
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// grpconv / grpunconv
+// ---------------------------------------------------------------------------
+
+fn grpconv(root: &SysRoot) -> UResult<()> {
+    let group_path = root.group_path();
+    let gshadow_path = root.gshadow_path();
+    let creating = !gshadow_path.exists();
+
+    let mut group = open::<GroupEntry>(&group_path)?;
+    let mut gshadow = open_or_empty::<GshadowEntry>(&gshadow_path)?;
+
+    reconcile_gshadow(group.entries_mut(), gshadow.entries_mut());
+
+    // gshadow first, for the reason pwconv writes shadow first.
+    let shadow_gid = shadow_group_gid_from(group.entries());
+    let files: Vec<Box<dyn Commit>> = vec![Box::new(gshadow), Box::new(group)];
+    transaction::commit_all(files)
+        .map_err(|e| ConvError::CantUpdate(format!("cannot write: {e}")))?;
+
+    if creating {
+        set_shadow_file_permissions(&gshadow_path, shadow_gid)?;
+    }
+    shadow_core::nscd::invalidate_cache("group");
+    Ok(())
+}
+
+/// Bring `gshadow` in line with `group`, moving every password across.
+fn reconcile_gshadow(group: &mut [GroupEntry], gshadow: &mut Vec<GshadowEntry>) {
+    let live: HashSet<&str> = group.iter().map(|g| g.name.as_str()).collect();
+    gshadow.retain(|gs| live.contains(gs.name.as_str()));
+
+    for entry in group.iter_mut() {
+        match gshadow.iter_mut().find(|gs| gs.name == entry.name) {
+            Some(existing) => {
+                if entry.passwd != SHADOWED {
+                    existing.passwd.clone_from(&entry.passwd);
+                }
+            }
+            None => gshadow.push(GshadowEntry {
+                name: entry.name.clone(),
+                passwd: entry.passwd.clone(),
+                admins: Vec::new(),
+                // The new line starts from the membership /etc/group records,
+                // so the two files agree from the first moment.
+                members: entry.members.clone(),
+            }),
+        }
+        entry.passwd = SHADOWED.to_string();
+    }
+}
+
+fn grpunconv(root: &SysRoot) -> UResult<()> {
+    let group_path = root.group_path();
+    let gshadow_path = root.gshadow_path();
+    if !gshadow_path.exists() {
+        return Ok(());
+    }
+
+    let mut group = open::<GroupEntry>(&group_path)?;
+    let gshadow = open::<GshadowEntry>(&gshadow_path)?;
+
+    for entry in group.entries_mut() {
+        if let Some(line) = gshadow.find(&entry.name) {
+            entry.passwd.clone_from(&line.passwd);
+        }
+    }
+
+    group
+        .commit()
+        .map_err(|e| ConvError::CantUpdate(format!("cannot write: {e}")))?;
+    remove_while_locked(&gshadow_path)?;
+    drop(gshadow);
+
+    shadow_core::nscd::invalidate_cache("group");
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn open<T: Record>(path: &Path) -> Result<LockedFile<T>, ConvError> {
+    LockedFile::<T>::open(path).map_err(|e| lock_error(path, e))
+}
+
+fn open_or_empty<T: Record>(path: &Path) -> Result<LockedFile<T>, ConvError> {
+    LockedFile::<T>::open_or_empty(path).map_err(|e| lock_error(path, e))
+}
+
+/// pwconv(8) reserves exit 5 for a locked file, so contention is told apart
+/// from every other way an open can fail.
+fn lock_error(path: &Path, e: ShadowError) -> ConvError {
+    match e {
+        ShadowError::Lock(_) => {
+            ConvError::FileBusy(format!("cannot lock {}; try again later", path.display()))
+        }
+        other => ConvError::CantUpdate(format!("cannot open {}: {other}", path.display())),
+    }
+}
+
+/// Remove a file whose lock the caller still holds.
+///
+/// The caller keeps its `LockedFile` alive across this call, so no other tool
+/// can slip in between the last read of the file and its removal. A file that
+/// is already gone is the state that was wanted.
+fn remove_while_locked(path: &Path) -> Result<(), ConvError> {
+    match std::fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(e) => Err(ConvError::CantUpdate(format!(
+            "cannot remove {}: {e}",
+            path.display()
+        ))),
+    }
+}
+
+/// The GID of the `shadow` group in the tree being converted, if it has one.
+///
+/// Looked up in that tree's own group file rather than through the name
+/// service: under `--prefix` or `--root` the host's `shadow` group says
+/// nothing about the target's.
+fn shadow_group_gid(group_path: &Path) -> Option<u32> {
+    let entries = shadow_core::records::read_entries::<GroupEntry>(group_path).ok()?;
+    shadow_group_gid_from(&entries)
+}
+
+fn shadow_group_gid_from(groups: &[GroupEntry]) -> Option<u32> {
+    groups
+        .iter()
+        .find(|g| g.name == SHADOW_GROUP)
+        .map(|g| g.gid)
+}
+
+/// Give a shadow file created by this run the layout the distributions ship:
+/// `0640 root:shadow`, or `0600 root:root` where there is no `shadow` group.
+///
+/// The atomic writer creates a new file `0600` and owned by the process, which
+/// is the safe default for a file whose owner it does not know; here the owner
+/// is known. Through a descriptor opened `O_NOFOLLOW`, as the home-directory
+/// code does, so a symlink swapped in under `/etc` is not followed.
+fn set_shadow_file_permissions(path: &Path, shadow_gid: Option<u32>) -> Result<(), ConvError> {
+    use rustix::fs::{Mode, OFlags};
+
+    let Some(gid) = shadow_gid else {
+        return Ok(());
+    };
+    let file = rustix::fs::open(path, OFlags::RDONLY | OFlags::NOFOLLOW, Mode::empty())
+        .map_err(|e| ConvError::CantUpdate(format!("cannot open {}: {e}", path.display())))?;
+    rustix::fs::fchown(
+        &file,
+        Some(rustix::fs::Uid::ROOT),
+        Some(rustix::fs::Gid::from_raw(gid)),
+    )
+    .map_err(|e| ConvError::CantUpdate(format!("cannot set owner of {}: {e}", path.display())))?;
+    rustix::fs::fchmod(&file, Mode::from_raw_mode(SHADOW_FILE_MODE))
+        .map_err(|e| ConvError::CantUpdate(format!("cannot set mode of {}: {e}", path.display())))
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn passwd(name: &str, hash: &str) -> PasswdEntry {
+        PasswdEntry {
+            name: name.to_string(),
+            passwd: hash.to_string(),
+            uid: 1000,
+            gid: 1000,
+            gecos: String::new(),
+            home: format!("/home/{name}"),
+            shell: "/bin/sh".to_string(),
+        }
+    }
+
+    fn shadow(name: &str, hash: &str, last_change: i64) -> ShadowEntry {
+        ShadowEntry {
+            name: name.to_string(),
+            passwd: hash.to_string(),
+            last_change: Some(last_change),
+            min_age: Some(0),
+            max_age: Some(99999),
+            warn_days: Some(7),
+            inactive_days: None,
+            expire_date: None,
+            reserved: String::new(),
+        }
+    }
+
+    fn defs(text: &str) -> LoginDefs {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("login.defs");
+        std::fs::write(&path, text).expect("write");
+        LoginDefs::load(&path).expect("load")
+    }
+
+    #[test]
+    fn test_apps_build() {
+        for tool in [Tool::Pwconv, Tool::Pwunconv, Tool::Grpconv, Tool::Grpunconv] {
+            app(tool).debug_assert();
+        }
+    }
+
+    /// An operand is a usage error: none of the four takes one.
+    #[test]
+    fn test_no_operands_are_accepted() {
+        assert!(
+            app(Tool::Pwconv)
+                .try_get_matches_from(["pwconv", "extra"])
+                .is_err()
+        );
+        assert!(app(Tool::Pwconv).try_get_matches_from(["pwconv"]).is_ok());
+    }
+
+    /// A hash in passwd moves to shadow and passwd is left with `x`; a new
+    /// shadow line is dated today and takes its aging from login.defs.
+    #[test]
+    fn test_pwconv_moves_hashes_and_dates_new_lines() {
+        let mut pw = vec![passwd("alice", "$6$salt$hash")];
+        let mut sh = Vec::new();
+        let d = defs("PASS_MIN_DAYS 7\nPASS_MAX_DAYS 90\nPASS_WARN_AGE 14\n");
+        reconcile_shadow(&mut pw, &mut sh, 20000, &d);
+
+        assert_eq!(pw[0].passwd, "x");
+        assert_eq!(sh.len(), 1);
+        assert_eq!(sh[0].name, "alice");
+        assert_eq!(sh[0].passwd, "$6$salt$hash");
+        assert_eq!(sh[0].last_change, Some(20000));
+        assert_eq!(sh[0].min_age, Some(7));
+        assert_eq!(sh[0].max_age, Some(90));
+        assert_eq!(sh[0].warn_days, Some(14));
+        assert_eq!(sh[0].inactive_days, None);
+        assert_eq!(sh[0].expire_date, None);
+    }
+
+    /// A hash in passwd beside an existing shadow line is the newer of the
+    /// two: it replaces the shadow hash and the change is dated. An `x`
+    /// leaves the shadow line, aging included, alone.
+    #[test]
+    fn test_pwconv_existing_line() {
+        let mut pw = vec![passwd("alice", "$6$new$hash"), passwd("bob", "x")];
+        let mut sh = vec![
+            shadow("alice", "$6$old$hash", 19000),
+            shadow("bob", "$6$b$b", 19000),
+        ];
+        reconcile_shadow(&mut pw, &mut sh, 20000, &LoginDefs::default());
+
+        let alice = sh.iter().find(|s| s.name == "alice").expect("alice");
+        assert_eq!(alice.passwd, "$6$new$hash");
+        assert_eq!(alice.last_change, Some(20000));
+        assert_eq!(alice.max_age, Some(99999), "aging must be kept");
+
+        let bob = sh.iter().find(|s| s.name == "bob").expect("bob");
+        assert_eq!(bob.passwd, "$6$b$b");
+        assert_eq!(
+            bob.last_change,
+            Some(19000),
+            "an untouched line keeps its date"
+        );
+    }
+
+    /// A shadow line for an account that is not in passwd is dropped.
+    #[test]
+    fn test_pwconv_drops_orphan_shadow_lines() {
+        let mut pw = vec![passwd("alice", "x")];
+        let mut sh = vec![
+            shadow("alice", "$6$a$a", 19000),
+            shadow("ghost", "$6$g$g", 19000),
+        ];
+        reconcile_shadow(&mut pw, &mut sh, 20000, &LoginDefs::default());
+        assert_eq!(sh.len(), 1);
+        assert_eq!(sh[0].name, "alice");
+    }
+
+    /// Running twice changes nothing the second time.
+    #[test]
+    fn test_pwconv_is_idempotent() {
+        let mut pw = vec![passwd("alice", "$6$salt$hash")];
+        let mut sh = Vec::new();
+        let d = LoginDefs::default();
+        reconcile_shadow(&mut pw, &mut sh, 20000, &d);
+        let (pw_once, sh_once) = (pw.clone(), sh.clone());
+        reconcile_shadow(&mut pw, &mut sh, 20001, &d);
+        assert_eq!(pw, pw_once);
+        assert_eq!(sh, sh_once, "a second run must not re-date the line");
+    }
+
+    /// A new gshadow line inherits the membership /etc/group records.
+    #[test]
+    fn test_grpconv_new_line_carries_the_members() {
+        let mut gr = vec![GroupEntry {
+            name: "team".to_string(),
+            passwd: "$6$t$t".to_string(),
+            gid: 5000,
+            members: vec!["alice".to_string(), "bob".to_string()],
+        }];
+        let mut gs = Vec::new();
+        reconcile_gshadow(&mut gr, &mut gs);
+        assert_eq!(gr[0].passwd, "x");
+        assert_eq!(gs[0].passwd, "$6$t$t");
+        assert!(gs[0].admins.is_empty());
+        assert_eq!(gs[0].members, vec!["alice".to_string(), "bob".to_string()]);
+    }
+
+    /// An existing gshadow line keeps its administrators and members; only
+    /// a real password in /etc/group moves across.
+    #[test]
+    fn test_grpconv_existing_line_keeps_admins() {
+        let mut gr = vec![GroupEntry {
+            name: "team".to_string(),
+            passwd: "$6$new$new".to_string(),
+            gid: 5000,
+            members: vec!["alice".to_string()],
+        }];
+        let mut gs = vec![GshadowEntry {
+            name: "team".to_string(),
+            passwd: "$6$old$old".to_string(),
+            admins: vec!["carol".to_string()],
+            members: vec!["alice".to_string()],
+        }];
+        reconcile_gshadow(&mut gr, &mut gs);
+        assert_eq!(gs[0].passwd, "$6$new$new");
+        assert_eq!(gs[0].admins, vec!["carol".to_string()]);
+    }
+
+    #[test]
+    fn test_shadow_group_lookup_uses_the_given_tree() {
+        let groups = vec![
+            GroupEntry {
+                name: "root".into(),
+                passwd: "x".into(),
+                gid: 0,
+                members: vec![],
+            },
+            GroupEntry {
+                name: "shadow".into(),
+                passwd: "x".into(),
+                gid: 42,
+                members: vec![],
+            },
+        ];
+        assert_eq!(shadow_group_gid_from(&groups), Some(42));
+        assert_eq!(shadow_group_gid_from(&groups[..1]), None);
+    }
+
+    /// The codes are the interface pwconv(8) documents.
+    #[test]
+    fn test_exit_codes() {
+        assert_eq!(ConvError::PermissionDenied("x".into()).code(), 1);
+        assert_eq!(ConvError::CantUpdate("x".into()).code(), 1);
+        assert_eq!(ConvError::CantChroot("x".into()).code(), 3);
+        assert_eq!(ConvError::FileBusy("x".into()).code(), 5);
+    }
+}

--- a/src/uu/pwunconv/Cargo.toml
+++ b/src/uu/pwunconv/Cargo.toml
@@ -1,0 +1,33 @@
+[package]
+name = "uu_pwunconv"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+categories.workspace = true
+rust-version.workspace = true
+description = "pwunconv ~ (shadow-rs) move password hashes from /etc/shadow back into /etc/passwd"
+
+[lib]
+path = "src/pwunconv.rs"
+
+[[bin]]
+name = "pwunconv"
+path = "src/main.rs"
+
+[dependencies]
+clap = { workspace = true }
+uucore = { workspace = true }
+# One engine serves pwconv, pwunconv, grpconv and grpunconv; this crate names
+# which of the four it is.
+uu_pwconv = { path = "../pwconv", version = "0.4.0" }
+
+[lints]
+workspace = true
+
+# Distributed via the `shadow-rs` multicall binary in the workspace root
+# package, not as a standalone archive (see dist-workspace.toml, issue #207).
+[package.metadata.dist]
+dist = false

--- a/src/uu/pwunconv/locales/en-US.ftl
+++ b/src/uu/pwunconv/locales/en-US.ftl
@@ -1,0 +1,2 @@
+pwunconv-about = move password hashes from /etc/shadow back into /etc/passwd
+pwunconv-usage = pwunconv [options]

--- a/src/uu/pwunconv/src/main.rs
+++ b/src/uu/pwunconv/src/main.rs
@@ -1,0 +1,6 @@
+// This file is part of the shadow-rs package.
+//
+// For the full copyright and license information, please view the LICENSE
+// file that was distributed with this source code.
+
+uucore::bin!(uu_pwunconv);

--- a/src/uu/pwunconv/src/pwunconv.rs
+++ b/src/uu/pwunconv/src/pwunconv.rs
@@ -1,0 +1,36 @@
+// This file is part of the shadow-rs package.
+//
+// For the full copyright and license information, please view the LICENSE
+// file that was distributed with this source code.
+// spell-checker:ignore pwconv pwunconv grpconv grpunconv gshadow
+
+//! `pwunconv` — move password hashes from /etc/shadow back into /etc/passwd.
+//!
+//! One of the four conversion tools built on the engine in `uu_pwconv`; this
+//! crate only names which one.
+
+use clap::Command;
+use uucore::error::UResult;
+
+/// Entry point for the `pwunconv` utility.
+#[uucore::main]
+pub fn uumain(args: impl uucore::Args) -> UResult<()> {
+    uu_pwconv::run(uu_pwconv::Tool::Pwunconv, args)
+}
+
+/// Build the clap `Command` for `pwunconv`.
+#[must_use]
+pub fn uu_app() -> Command {
+    uu_pwconv::app(uu_pwconv::Tool::Pwunconv)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_app_builds_under_its_own_name() {
+        uu_app().debug_assert();
+        assert_eq!(uu_app().get_name(), "pwunconv");
+    }
+}

--- a/tests/arm64-smoke.sh
+++ b/tests/arm64-smoke.sh
@@ -64,10 +64,10 @@ version=$("${QEMU[@]}" "$BIN" --version 2>&1)
 if [ -n "$version" ]; then ok "runs: $version"; else bad "would not run"; exit 1; fi
 
 applets=$("${QEMU[@]}" "$BIN" --list 2>/dev/null | tail -n +2 | wc -l)
-if [ "$applets" -ge 20 ]; then
+if [ "$applets" -ge 24 ]; then
     ok "carries $applets applets"
 else
-    bad "expected at least 20 applets, found $applets"
+    bad "expected at least 24 applets, found $applets"
 fi
 
 # ── A prefix tree, so nothing here touches the container's own accounts ──
@@ -133,7 +133,25 @@ printf 'batched:a long passphrase:2500:2500:Batched::/bin/sh\n' \
     | "${QEMU[@]}" "$BIN" newusers -P "$T" >/dev/null 2>&1
 contains "newusers created the account" "$T/etc/passwd" '^batched:x:2500:2500:'
 contains "with a SHA-512 hash" "$T/etc/shadow" '^batched:\$6\$'
-contains "and a group of its own" "$T/etc/group" '^batched:x:2500:' 
+contains "and a group of its own" "$T/etc/group" '^batched:x:2500:'
+
+# The conversion tools rewrite two files each and create or remove one, so a
+# round trip against the prefix tree exercises the transaction layer under
+# emulation. `batched`, created just above, carries the hash; it must come back
+# byte for byte.
+before=$(grep '^batched:' "$T/etc/shadow" | cut -d: -f2)
+check "pwunconv merges the hashes back" "${QEMU[@]}" "$BIN" pwunconv -P "$T"
+check "and removes the shadow file" test ! -e "$T/etc/shadow"
+check "pwconv recreates it" "${QEMU[@]}" "$BIN" pwconv -P "$T"
+after=$(grep '^batched:' "$T/etc/shadow" | cut -d: -f2)
+if [ -n "$before" ] && [ "$before" = "$after" ]; then
+    ok "the hash survived the round trip unchanged"
+else
+    bad "the hash changed across pwunconv/pwconv: '$before' -> '$after'"
+fi
+check "grpunconv removes gshadow" "${QEMU[@]}" "$BIN" grpunconv -P "$T"
+check "grpconv recreates it" "${QEMU[@]}" "$BIN" grpconv -P "$T"
+contains "and the group is back in gshadow" "$T/etc/gshadow" '^batched:'
 
 # pwck exits 2 for warnings, which a synthetic tree produces (no real shells),
 # so anything up to 2 means it read and checked the files rather than failing.

--- a/tests/by-util/test_chgpasswd.rs
+++ b/tests/by-util/test_chgpasswd.rs
@@ -11,7 +11,6 @@
 //! agreeing: the hash belongs in `/etc/gshadow`, and `/etc/group` carries the
 //! `x` that says so.
 
-use std::io::Write as _;
 use std::process::Stdio;
 
 use crate::common::{Output, skip_unless_root, tool};
@@ -52,22 +51,25 @@ fn field(dir: &tempfile::TempDir, file: &str, group: &str) -> String {
 
 /// Run `chgpasswd --prefix <dir> <args...>` with `input` on stdin.
 fn chgpasswd(dir: &tempfile::TempDir, args: &[&str], input: &str) -> Output {
+    // stdin is a file, not a pipe. The tools exit as soon as a line is bad,
+    // and a pipe whose reader has gone raises SIGPIPE in the writer. Rust
+    // ignores that signal at startup, but every `uumain` run in-process by
+    // another test puts it back to its default -- uucore does so for GNU
+    // pipeline compatibility -- after which the write kills the whole test
+    // binary. A file has no reader to lose.
+    let stdin_path = dir.path().join("stdin.chgpasswd");
+    std::fs::write(&stdin_path, input).expect("write stdin file");
+    let stdin = std::fs::File::open(&stdin_path).expect("open stdin file");
+
     let mut cmd = tool("chgpasswd");
     cmd.arg("--prefix")
         .arg(dir.path())
         .args(args)
-        .stdin(Stdio::piped())
+        .stdin(Stdio::from(stdin))
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
 
-    let mut child = cmd.spawn().expect("cannot spawn chgpasswd");
-    child
-        .stdin
-        .as_mut()
-        .expect("stdin")
-        .write_all(input.as_bytes())
-        .expect("cannot write to chgpasswd");
-    let out = child.wait_with_output().expect("chgpasswd did not finish");
+    let out = cmd.output().expect("chgpasswd did not finish");
     Output {
         code: out.status.code().unwrap_or(1),
         stdout: String::from_utf8_lossy(&out.stdout).into_owned(),

--- a/tests/by-util/test_chpasswd.rs
+++ b/tests/by-util/test_chpasswd.rs
@@ -12,7 +12,6 @@
 //! `--prefix` then, and `--root` performs a real `chroot(2)` an in-process
 //! test cannot use.
 
-use std::io::Write as _;
 use std::process::Stdio;
 
 use crate::common::{Output, run, tool};
@@ -36,22 +35,25 @@ fn read_shadow(dir: &tempfile::TempDir) -> String {
 
 /// Run `chpasswd --prefix <dir> <args...>` with `input` on stdin.
 fn chpasswd(dir: &tempfile::TempDir, args: &[&str], input: &str) -> Output {
+    // stdin is a file, not a pipe. The tools exit as soon as a line is bad,
+    // and a pipe whose reader has gone raises SIGPIPE in the writer. Rust
+    // ignores that signal at startup, but every `uumain` run in-process by
+    // another test puts it back to its default -- uucore does so for GNU
+    // pipeline compatibility -- after which the write kills the whole test
+    // binary. A file has no reader to lose.
+    let stdin_path = dir.path().join("stdin.chpasswd");
+    std::fs::write(&stdin_path, input).expect("write stdin file");
+    let stdin = std::fs::File::open(&stdin_path).expect("open stdin file");
+
     let mut cmd = tool("chpasswd");
     cmd.arg("--prefix")
         .arg(dir.path())
         .args(args)
-        .stdin(Stdio::piped())
+        .stdin(Stdio::from(stdin))
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
 
-    let mut child = cmd.spawn().expect("cannot spawn chpasswd");
-    child
-        .stdin
-        .as_mut()
-        .expect("stdin")
-        .write_all(input.as_bytes())
-        .expect("cannot write to chpasswd");
-    let out = child.wait_with_output().expect("chpasswd did not finish");
+    let out = cmd.output().expect("chpasswd did not finish");
     Output {
         code: out.status.code().unwrap_or(1),
         stdout: String::from_utf8_lossy(&out.stdout).into_owned(),

--- a/tests/by-util/test_multicall.rs
+++ b/tests/by-util/test_multicall.rs
@@ -16,7 +16,7 @@ use std::process::Command;
 use crate::common::{run, run_cmd};
 
 /// Every applet this build is expected to carry, in `--list` order.
-const TOOLS: [&str; 20] = [
+const TOOLS: [&str; 24] = [
     "chage",
     "chfn",
     "chgpasswd",
@@ -27,10 +27,14 @@ const TOOLS: [&str; 20] = [
     "groupdel",
     "groupmod",
     "grpck",
+    "grpconv",
+    "grpunconv",
     "newgrp",
     "newusers",
     "passwd",
     "pwck",
+    "pwconv",
+    "pwunconv",
     "sg",
     "useradd",
     "userdel",

--- a/tests/by-util/test_newusers.rs
+++ b/tests/by-util/test_newusers.rs
@@ -11,7 +11,6 @@
 //! Checking only `/etc/passwd` would miss the half of the job that makes the
 //! account usable.
 
-use std::io::Write as _;
 use std::process::Stdio;
 
 use crate::common::{Output, skip_unless_root, tool};
@@ -59,22 +58,25 @@ fn has_entry(dir: &tempfile::TempDir, file: &str, name: &str) -> bool {
 
 /// Run `newusers --prefix <dir> <args...>` with `input` on stdin.
 fn newusers(dir: &tempfile::TempDir, args: &[&str], input: &str) -> Output {
+    // stdin is a file, not a pipe. The tools exit as soon as a line is bad,
+    // and a pipe whose reader has gone raises SIGPIPE in the writer. Rust
+    // ignores that signal at startup, but every `uumain` run in-process by
+    // another test puts it back to its default -- uucore does so for GNU
+    // pipeline compatibility -- after which the write kills the whole test
+    // binary. A file has no reader to lose.
+    let stdin_path = dir.path().join("stdin.newusers");
+    std::fs::write(&stdin_path, input).expect("write stdin file");
+    let stdin = std::fs::File::open(&stdin_path).expect("open stdin file");
+
     let mut cmd = tool("newusers");
     cmd.arg("--prefix")
         .arg(dir.path())
         .args(args)
-        .stdin(Stdio::piped())
+        .stdin(Stdio::from(stdin))
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
 
-    let mut child = cmd.spawn().expect("cannot spawn newusers");
-    child
-        .stdin
-        .as_mut()
-        .expect("stdin")
-        .write_all(input.as_bytes())
-        .expect("cannot write to newusers");
-    let out = child.wait_with_output().expect("newusers did not finish");
+    let out = cmd.output().expect("newusers did not finish");
     Output {
         code: out.status.code().unwrap_or(1),
         stdout: String::from_utf8_lossy(&out.stdout).into_owned(),

--- a/tests/by-util/test_pwconv.rs
+++ b/tests/by-util/test_pwconv.rs
@@ -1,0 +1,314 @@
+// This file is part of the shadow-rs package.
+//
+// For the full copyright and license information, please view the LICENSE
+// file that was distributed with this source code.
+// spell-checker:ignore pwconv pwunconv grpconv grpunconv gshadow
+
+//! Integration tests for `pwconv`, `pwunconv`, `grpconv` and `grpunconv`.
+//!
+//! Each tool moves fields between two files and may create or remove one of
+//! them, so the tests run the real binary against a prefix tree and read both
+//! files back, along with the mode and owner of anything created.
+
+use std::os::unix::fs::{MetadataExt as _, PermissionsExt as _};
+
+use crate::common::{run_cmd, skip_unless_root, tool};
+
+/// A prefix tree. `shadowed` decides whether the shadow files exist.
+fn prefix(shadowed: bool) -> tempfile::TempDir {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let etc = dir.path().join("etc");
+    std::fs::create_dir_all(&etc).expect("etc");
+    std::fs::write(
+        etc.join("login.defs"),
+        "PASS_MIN_DAYS 7\nPASS_MAX_DAYS 90\nPASS_WARN_AGE 14\n",
+    )
+    .expect("login.defs");
+    std::fs::write(
+        etc.join("group"),
+        "root:x:0:\nshadow:x:42:\nteam:x:5000:alice\n",
+    )
+    .expect("group");
+    if shadowed {
+        std::fs::write(
+            etc.join("passwd"),
+            "root:x:0:0:root:/root:/bin/sh\nalice:x:1000:1000::/home/alice:/bin/sh\n",
+        )
+        .expect("passwd");
+        std::fs::write(
+            etc.join("shadow"),
+            "root:!:19000:0:99999:7:::\nalice:$6$a$hash:19000:0:99999:7:::\n",
+        )
+        .expect("shadow");
+        std::fs::write(
+            etc.join("gshadow"),
+            "root:!::\nshadow:!::\nteam:$6$t$hash::alice\n",
+        )
+        .expect("gshadow");
+    } else {
+        std::fs::write(
+            etc.join("passwd"),
+            "root:!:0:0:root:/root:/bin/sh\nalice:$6$a$hash:1000:1000::/home/alice:/bin/sh\n",
+        )
+        .expect("passwd");
+        std::fs::write(
+            etc.join("group"),
+            "root:x:0:\nshadow:x:42:\nteam:$6$t$hash:5000:alice\n",
+        )
+        .expect("group");
+    }
+    dir
+}
+
+fn run(which: &str, dir: &tempfile::TempDir, args: &[&str]) -> crate::common::Output {
+    let mut cmd = tool(which);
+    cmd.arg("--prefix").arg(dir.path()).args(args);
+    run_cmd(&mut cmd)
+}
+
+fn read(dir: &tempfile::TempDir, name: &str) -> String {
+    std::fs::read_to_string(dir.path().join("etc").join(name))
+        .unwrap_or_else(|e| panic!("cannot read {name}: {e}"))
+}
+
+fn exists(dir: &tempfile::TempDir, name: &str) -> bool {
+    dir.path().join("etc").join(name).exists()
+}
+
+fn fields(dir: &tempfile::TempDir, file: &str, name: &str) -> Vec<String> {
+    read(dir, file)
+        .lines()
+        .find(|l| l.starts_with(&format!("{name}:")))
+        .unwrap_or_else(|| panic!("no {file} entry for {name}"))
+        .split(':')
+        .map(str::to_string)
+        .collect()
+}
+
+fn today() -> i64 {
+    shadow_core::shadow::days_since_epoch().expect("clock")
+}
+
+// ---------------------------------------------------------------------------
+// pwconv
+// ---------------------------------------------------------------------------
+
+/// The core job: hashes leave the world-readable file, a new shadow file is
+/// created with the right mode and owner, and new lines are dated today with
+/// the aging login.defs asks for.
+#[test]
+fn test_pwconv_creates_shadow_from_passwd() {
+    if skip_unless_root() {
+        return;
+    }
+    let dir = prefix(false);
+    run("pwconv", &dir, &[]).assert_code(0);
+
+    assert_eq!(fields(&dir, "passwd", "alice")[1], "x");
+    assert_eq!(fields(&dir, "passwd", "root")[1], "x");
+
+    let alice = fields(&dir, "shadow", "alice");
+    assert_eq!(alice[1], "$6$a$hash");
+    assert_eq!(alice[2], today().to_string(), "a new line is dated today");
+    assert_eq!(alice[3], "7");
+    assert_eq!(alice[4], "90");
+    assert_eq!(alice[5], "14");
+    assert_eq!(fields(&dir, "shadow", "root")[1], "!");
+
+    let meta = std::fs::metadata(dir.path().join("etc/shadow")).expect("stat");
+    assert_eq!(
+        meta.permissions().mode() & 0o777,
+        0o640,
+        "a new shadow file is 0640"
+    );
+    assert_eq!(
+        meta.gid(),
+        42,
+        "owned by the tree's shadow group, not the host's"
+    );
+    assert_eq!(meta.uid(), 0);
+}
+
+/// A consistent system is left byte-for-byte alone.
+#[test]
+fn test_pwconv_is_idempotent() {
+    if skip_unless_root() {
+        return;
+    }
+    let dir = prefix(true);
+    let (passwd, shadow) = (read(&dir, "passwd"), read(&dir, "shadow"));
+    run("pwconv", &dir, &[]).assert_code(0);
+    assert_eq!(read(&dir, "passwd"), passwd);
+    assert_eq!(read(&dir, "shadow"), shadow);
+}
+
+/// A hash in passwd beside an existing shadow line is the newer one: it
+/// replaces the shadow hash and the change is dated; the aging is kept.
+#[test]
+fn test_pwconv_hash_in_passwd_wins_over_shadow() {
+    if skip_unless_root() {
+        return;
+    }
+    let dir = prefix(true);
+    let passwd = read(&dir, "passwd").replace("alice:x:", "alice:$6$new$hash:");
+    std::fs::write(dir.path().join("etc/passwd"), passwd).expect("write");
+
+    run("pwconv", &dir, &[]).assert_code(0);
+    let alice = fields(&dir, "shadow", "alice");
+    assert_eq!(alice[1], "$6$new$hash");
+    assert_eq!(alice[2], today().to_string());
+    assert_eq!(alice[4], "99999", "the existing aging must be kept");
+    assert_eq!(fields(&dir, "passwd", "alice")[1], "x");
+}
+
+/// A shadow line for an account no longer in passwd is dropped, and a passwd
+/// line with `x` but no shadow line gets one carrying that `x` -- an honest
+/// record that the hash is gone.
+#[test]
+fn test_pwconv_reconciles_orphans_both_ways() {
+    if skip_unless_root() {
+        return;
+    }
+    let dir = prefix(true);
+    let shadow = read(&dir, "shadow") + "ghost:$6$g$g:19000:0:99999:7:::\n";
+    std::fs::write(dir.path().join("etc/shadow"), shadow).expect("write");
+    let passwd = read(&dir, "passwd") + "dave:x:1001:1001::/home/dave:/bin/sh\n";
+    std::fs::write(dir.path().join("etc/passwd"), passwd).expect("write");
+
+    run("pwconv", &dir, &[]).assert_code(0);
+    assert!(
+        !read(&dir, "shadow").contains("ghost:"),
+        "the orphan shadow line stayed"
+    );
+    assert_eq!(fields(&dir, "shadow", "dave")[1], "x");
+}
+
+/// Comments survive: the files are rewritten through the layout-preserving
+/// writer, not regenerated.
+#[test]
+fn test_pwconv_keeps_comments() {
+    if skip_unless_root() {
+        return;
+    }
+    let dir = prefix(false);
+    let passwd = "# local accounts\n".to_string() + &read(&dir, "passwd");
+    std::fs::write(dir.path().join("etc/passwd"), passwd).expect("write");
+    run("pwconv", &dir, &[]).assert_code(0);
+    assert!(read(&dir, "passwd").starts_with("# local accounts\n"));
+}
+
+// ---------------------------------------------------------------------------
+// pwunconv
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_pwunconv_merges_hashes_back_and_removes_shadow() {
+    if skip_unless_root() {
+        return;
+    }
+    let dir = prefix(true);
+    run("pwunconv", &dir, &[]).assert_code(0);
+    assert_eq!(fields(&dir, "passwd", "alice")[1], "$6$a$hash");
+    assert_eq!(fields(&dir, "passwd", "root")[1], "!");
+    assert!(!exists(&dir, "shadow"), "the shadow file must be removed");
+}
+
+/// An account with no shadow line keeps whatever passwd holds, and a system
+/// with no shadow file is already in the requested state.
+#[test]
+fn test_pwunconv_without_a_shadow_line_or_file() {
+    if skip_unless_root() {
+        return;
+    }
+    let dir = prefix(true);
+    let passwd = read(&dir, "passwd") + "bob:x:1001:1001::/home/bob:/bin/sh\n";
+    std::fs::write(dir.path().join("etc/passwd"), passwd).expect("write");
+    run("pwunconv", &dir, &[]).assert_code(0);
+    assert_eq!(fields(&dir, "passwd", "bob")[1], "x");
+
+    let before = read(&dir, "passwd");
+    run("pwunconv", &dir, &[]).assert_code(0);
+    assert_eq!(read(&dir, "passwd"), before);
+}
+
+/// A round trip is the identity on the hashes.
+#[test]
+fn test_pwconv_pwunconv_round_trip() {
+    if skip_unless_root() {
+        return;
+    }
+    let dir = prefix(true);
+    let shadow_hash = fields(&dir, "shadow", "alice")[1].clone();
+    run("pwunconv", &dir, &[]).assert_code(0);
+    run("pwconv", &dir, &[]).assert_code(0);
+    assert_eq!(fields(&dir, "shadow", "alice")[1], shadow_hash);
+    assert_eq!(fields(&dir, "passwd", "alice")[1], "x");
+}
+
+// ---------------------------------------------------------------------------
+// grpconv / grpunconv
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_grpconv_creates_gshadow_with_members() {
+    if skip_unless_root() {
+        return;
+    }
+    let dir = prefix(false);
+    run("grpconv", &dir, &[]).assert_code(0);
+    assert_eq!(fields(&dir, "group", "team")[1], "x");
+    let team = fields(&dir, "gshadow", "team");
+    assert_eq!(team[1], "$6$t$hash");
+    assert_eq!(team[2], "", "no administrators are invented");
+    assert_eq!(team[3], "alice", "the members come from /etc/group");
+
+    let meta = std::fs::metadata(dir.path().join("etc/gshadow")).expect("stat");
+    assert_eq!(meta.permissions().mode() & 0o777, 0o640);
+    assert_eq!(meta.gid(), 42);
+}
+
+#[test]
+fn test_grpunconv_merges_back_and_removes_gshadow() {
+    if skip_unless_root() {
+        return;
+    }
+    let dir = prefix(true);
+    run("grpunconv", &dir, &[]).assert_code(0);
+    assert_eq!(fields(&dir, "group", "team")[1], "$6$t$hash");
+    assert!(!exists(&dir, "gshadow"));
+}
+
+#[test]
+fn test_grpconv_drops_orphan_gshadow_lines() {
+    if skip_unless_root() {
+        return;
+    }
+    let dir = prefix(true);
+    let gshadow = read(&dir, "gshadow") + "orphan:!::\n";
+    std::fs::write(dir.path().join("etc/gshadow"), gshadow).expect("write");
+    run("grpconv", &dir, &[]).assert_code(0);
+    assert!(!read(&dir, "gshadow").contains("orphan:"));
+}
+
+// ---------------------------------------------------------------------------
+// Flags
+// ---------------------------------------------------------------------------
+
+/// None of the four takes an operand: that is a usage error, exit 2.
+#[test]
+fn test_operands_are_a_usage_error() {
+    let dir = prefix(true);
+    for which in ["pwconv", "pwunconv", "grpconv", "grpunconv"] {
+        run(which, &dir, &["extra"]).assert_code(2);
+    }
+}
+
+#[test]
+fn test_help_exits_zero() {
+    let dir = prefix(true);
+    for which in ["pwconv", "pwunconv", "grpconv", "grpunconv"] {
+        run(which, &dir, &["--help"])
+            .assert_code(0)
+            .assert_stdout_contains("Usage:");
+    }
+}

--- a/tests/e2e/deploy-test.sh
+++ b/tests/e2e/deploy-test.sh
@@ -100,7 +100,7 @@ hash_password() {
 
 # ── TOOLS list ──────────────────────────────────────────────────────
 
-TOOLS="passwd pwck useradd userdel usermod chpasswd chgpasswd newusers chage groupadd groupdel groupmod gpasswd grpck chfn chsh newgrp sg vipw vigr"
+TOOLS="passwd pwck useradd userdel usermod chpasswd chgpasswd newusers chage groupadd groupdel groupmod gpasswd grpck chfn chsh newgrp sg vipw vigr pwconv pwunconv grpconv grpunconv"
 SETUID_TOOLS="passwd chfn chsh newgrp gpasswd sg"
 
 # The tools an unprivileged user runs are installed in bin, the rest in sbin,
@@ -869,6 +869,60 @@ test_gpasswd_group_admin() {
     userdel -r gp_member 2>/dev/null || true
 }
 
+# ── pwconv family: shadow round trips ──────────────────────────────
+
+test_pwconv_family() {
+    section "pwconv / pwunconv / grpconv / grpunconv — shadow round trips"
+
+    userdel -r pc_alice 2>/dev/null || true
+    userdel -r pc_outsider 2>/dev/null || true
+    groupdel pc_team 2>/dev/null || true
+    assert_ok "useradd -m pc_alice" useradd -m pc_alice
+    assert_ok "useradd -m pc_outsider" useradd -m pc_outsider
+    assert_ok "groupadd pc_team" groupadd pc_team
+    assert_ok "set a group password" bash -c "printf 'pc_team:teampw\n' | chgpasswd"
+    assert_ok "set a user password" bash -c "printf 'pc_alice:userpw\n' | chpasswd"
+
+    grep '^pc_alice:' /etc/shadow | cut -d: -f2 > /tmp/pc_hash.before
+    cp -p /etc/shadow /tmp/pc_shadow.before
+
+    assert_ok "pwunconv" pwunconv
+    assert_ok "the shadow file is gone" bash -c "! test -e /etc/shadow"
+    assert_ok "the hash moved into /etc/passwd" \
+        bash -c "grep '^pc_alice:' /etc/passwd | cut -d: -f2 | diff -q - /tmp/pc_hash.before"
+
+    assert_ok "pwconv" pwconv
+    assert_file_contains "/etc/passwd holds x again" /etc/passwd '^pc_alice:x:'
+    assert_ok "the hash is back in /etc/shadow, byte for byte" \
+        bash -c "grep '^pc_alice:' /etc/shadow | cut -d: -f2 | diff -q - /tmp/pc_hash.before"
+    assert_ok "the recreated shadow file is 0640 root:shadow" \
+        bash -c "test \"\$(stat -c '%a %U %G' /etc/shadow)\" = '640 root shadow'"
+    # The cross-tool proof: passwd still reads the account's state, and the
+    # aging that pwconv set from login.defs is what chage reports.
+    assert_contains "passwd -S still sees a set password" " P " passwd -S pc_alice
+    assert_ok "pwconv on a consistent system changes nothing" \
+        bash -c "cp -p /etc/shadow /tmp/pc_s1 && pwconv && cmp -s /etc/shadow /tmp/pc_s1"
+
+    # And the group side, with sg as the witness: a non-member must still be
+    # able to enter the group with the password after the round trip.
+    assert_ok "grpunconv" grpunconv
+    assert_ok "the gshadow file is gone" bash -c "! test -e /etc/gshadow"
+    assert_ok "grpconv" grpconv
+    assert_ok "the recreated gshadow file is 0640 root:shadow" \
+        bash -c "test \"\$(stat -c '%a %U %G' /etc/gshadow)\" = '640 root shadow'"
+    assert_contains "sg accepts the group password after the round trip" "pc_team" \
+        bash -c "echo teampw | su -s /bin/bash pc_outsider -c \"sg pc_team -c 'id -gn'\""
+    assert_fail "and still refuses a wrong one" \
+        bash -c "echo wrong | su -s /bin/bash pc_outsider -c \"sg pc_team -c 'id -gn'\""
+
+    assert_fail "an operand is a usage error" pwconv extra
+
+    userdel -r pc_alice 2>/dev/null || true
+    userdel -r pc_outsider 2>/dev/null || true
+    groupdel pc_team 2>/dev/null || true
+    rm -f /tmp/pc_hash.before /tmp/pc_shadow.before /tmp/pc_s1
+}
+
 # ── vipw / vigr: hand edits under the lock ─────────────────────────
 
 test_vipw() {
@@ -1224,6 +1278,7 @@ main() {
     test_chgpasswd
     test_newusers
     test_vipw
+    test_pwconv_family
     test_aging_and_input
     test_audit_logging
     test_root_option

--- a/tests/gnu-compat.sh
+++ b/tests/gnu-compat.sh
@@ -228,6 +228,10 @@ for pair in \
     "newusers:/usr/sbin/newusers" \
     "vipw:/usr/sbin/vipw" \
     "vigr:/usr/sbin/vigr" \
+    "pwconv:/usr/sbin/pwconv" \
+    "pwunconv:/usr/sbin/pwunconv" \
+    "grpconv:/usr/sbin/grpconv" \
+    "grpunconv:/usr/sbin/grpunconv" \
     "gpasswd:/usr/bin/gpasswd" \
     "pwck:/usr/sbin/pwck" \
     "grpck:/usr/sbin/grpck"; do

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -50,6 +50,8 @@ mod test_newusers;
 mod test_passwd;
 #[path = "by-util/test_pwck.rs"]
 mod test_pwck;
+#[path = "by-util/test_pwconv.rs"]
+mod test_pwconv;
 #[path = "by-util/test_sg.rs"]
 mod test_sg;
 #[path = "by-util/test_useradd.rs"]


### PR DESCRIPTION
Adds `pwconv`, `pwunconv`, `grpconv` and `grpunconv` — the last four of the nine tools both Debian and Fedora ship and we did not. With this PR, every tool the two distributions agree on exists here.

Stacked on #294. Base retargets to `main` as the stack merges.

One engine with a selector; the other three crates are the selector.

## The order of writes is the substance

| | first | then | so a failure in between… |
|---|---|---|---|
| `pwconv` | write `shadow` | write `passwd` | leaves the hashes where they were, not nowhere |
| `pwunconv` | write `passwd` | remove `shadow` | leaves the hashes twice, which is recoverable |

The removal happens while the lock on the shadow file is still held, so nothing can slip in between the last read and the disappearance.

## What `pwconv` does — established by running the GNU tool

- A hash found in `passwd` beside an existing `shadow` line is the newer of the two (it got there through a tool or an edit that did not know about shadow): it replaces the shadow hash and the change is dated; the aging is kept.
- A `passwd` line with no `shadow` line gets one — dated today, aging from `PASS_MIN_DAYS`/`PASS_MAX_DAYS`/`PASS_WARN_AGE`. The hash field is copied as it stands, an `x` included: an `x` in the hash field matches no password, which is the honest state of an account whose hash was lost.
- A `shadow` line for an account no longer in `passwd` is dropped.
- A consistent system is left byte for byte alone.

A shadow file this run creates is `0640 root:shadow`, with the `shadow` group looked up **in the tree being converted**, not through the name service — under `--prefix` or `--root` the host's `shadow` group says nothing about the target's. No such group → `0600 root`, the atomic writer's default.

## Witnesses, not just file reads

The e2e section uses the other tools to check the result: after `pwunconv` + `pwconv` the hash is byte for byte what it was and `passwd -S` still reports a set password; after `grpunconv` + `grpconv`, `sg` still admits a non-member with the group password and still refuses a wrong one.

## Verification

| | |
|---|---|
| `cargo test --workspace` | 878 passed on debian, alpine and fedora |
| `make check` | fmt, clippy ×3, tests ±`pam`, unprivileged run — exit 0 |
| e2e deployment suite | 356 assertions against a real install |
| `make test-gnu-compat` | 51 comparisons against the GNU binaries |
| `make test-arm64` | 31 assertions under emulation, the round trip included |
