### PR TITLE
login: begin a session on the system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `login`, the twenty-fifth tool and the one `uutils/login` was archived
+  towards: what getty runs on a terminal. It prompts for a name and, through
+  the `login` PAM service, a password; refuses after `LOGIN_RETRIES` failures
+  or `LOGIN_TIMEOUT` seconds, answering a wrong password and an unknown name
+  with the same words; opens the PAM session and takes its environment;
+  records the login in utmp and wtmp; hands the terminal to the user
+  (`TTYGROUP`, `TTYPERM`); and runs the login shell as the user, in the home
+  or in `/` with a notice when `DEFAULT_HOME` allows. When the shell exits it
+  closes the session and records the logout. `-p`, `-f`, `-h` are shadow's;
+  `-H` and `--help` are util-linux's, which Debian 13 and Ubuntu 25.10 ship.
+  `-r`, the rlogin protocol, is refused. Needs the `pam` feature; without it
+  the applet says so and exits, since a login that cannot authenticate is not
+  a login. The shell runs as a child, not in place, so the session can be
+  closed afterwards; it gets a clean signal mask and login keeps its own
+
 - `pwconv`, `pwunconv`, `grpconv` and `grpunconv`, tools twenty-one to
   twenty-four, which complete the set both Debian and Fedora ship. `pwconv`
   moves password hashes out of the world-readable `/etc/passwd` into
@@ -71,6 +86,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `uutils/util-linux`'s, `su` is `sudo-rs`'s. It also lists every place this
   project deliberately departs from GNU shadow, with the rule behind them
 
+- `shadow_core::pam::PamContext` gained `setcred`, `open_session`,
+  `close_session`, `user` and `environment`; `shadow_core::process` gained
+  utmp/wtmp recording, `getpwnam`, a getty-style `spawn_with_controlling_tty`,
+  a `spawn_as_user` that drops groups, gid and uid in that order, and a
+  watchdog `exit_after` -- everything `login` needs and nothing else had
+
 - `shadow_core::process::spawn_with_signals_unblocked` starts a child with a
   clean signal mask. A tool that blocks `SIGINT` while it holds a lock passes
   that mask to every child, and an editor started under it could not be
@@ -94,6 +115,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   attacking. Both tools now prompt either way
 
 ### Fixed
+
+- Two tools working on different account files at the same time could
+  deadlock until both timed out. `FileLock` took the per-file `.lock` first
+  and `/etc/.pwd.lock` second, so a tool holding `passwd.lock` and waiting for
+  `.pwd.lock` could meet one holding `shadow.lock` and waiting for the first to
+  let go -- fifteen seconds of nothing, then two failures, on a system that was
+  merely busy. `.pwd.lock` now comes first, the order lckpwdf(3) and the GNU
+  tools use; whoever holds it never waits for anyone who is waiting for it.
+  Found by running the whole suite under load
+
+- `useradd` could leave an account half made. It wrote `/etc/passwd` and the
+  group files in one transaction, then opened `/etc/shadow` on its own; a
+  shadow lock that timed out at that point left a passwd line with no shadow
+  line, which a second `useradd` reported as already existing. The shadow file
+  is now locked with the others before anything is written, and written first,
+  so a failure between the writes leaves no passwd line whose hash is nowhere
 
 - `newgrp` dropped the caller's original primary group when it rebuilt the
   supplementary group list. `initgroups()` builds that list from the member

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -823,6 +823,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "uu_login"
+version = "0.4.0"
+dependencies = [
+ "clap",
+ "rustix",
+ "shadow-core",
+ "tempfile",
+ "uucore",
+ "zeroize",
+]
+
+[[package]]
 name = "uu_newgrp"
 version = "0.4.0"
 dependencies = [
@@ -914,6 +926,7 @@ dependencies = [
  "uu_grpck",
  "uu_grpconv",
  "uu_grpunconv",
+ "uu_login",
  "uu_newgrp",
  "uu_newusers",
  "uu_passwd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ members = [
     "src/uu/pwunconv",
     "src/uu/grpconv",
     "src/uu/grpunconv",
+    "src/uu/login",
 ]
 
 [workspace.package]
@@ -67,7 +68,7 @@ uucore = "0.11"
 thiserror = "2"
 
 # Unix/Linux
-rustix = { version = "1", features = ["fs", "param", "process", "rand", "termios"] }
+rustix = { version = "1", features = ["event", "fs", "param", "process", "pty", "rand", "termios"] }
 libc = "0.2"
 
 # Security
@@ -110,17 +111,18 @@ pwconv = { optional = true, version = "0.4.0", package = "uu_pwconv", path = "sr
 pwunconv = { optional = true, version = "0.4.0", package = "uu_pwunconv", path = "src/uu/pwunconv" }
 grpconv = { optional = true, version = "0.4.0", package = "uu_grpconv", path = "src/uu/grpconv" }
 grpunconv = { optional = true, version = "0.4.0", package = "uu_grpunconv", path = "src/uu/grpunconv" }
+login = { optional = true, version = "0.4.0", package = "uu_login", path = "src/uu/login" }
 
 [features]
 default = ["passwd", "pwck", "useradd", "userdel", "usermod", "chpasswd", "chage",
            "groupadd", "groupdel", "groupmod", "grpck", "chfn", "chsh", "newgrp", "gpasswd",
            "sg", "chgpasswd", "newusers", "vipw", "vigr",
-           "pwconv", "pwunconv", "grpconv", "grpunconv"]
+           "pwconv", "pwunconv", "grpconv", "grpunconv", "login"]
 
 # PAM authentication (requires libpam-dev). The `?` matters: without it,
 # asking for PAM would drag in the three applets that can use it even when the
 # build deliberately left them out.
-pam = ["passwd?/pam", "chfn?/pam", "chsh?/pam"]
+pam = ["passwd?/pam", "chfn?/pam", "chsh?/pam", "login?/pam"]
 
 # Shell completions generator
 completions = ["dep:clap_complete"]
@@ -159,6 +161,7 @@ pwconv = { version = "0.4.0", package = "uu_pwconv", path = "src/uu/pwconv" }
 pwunconv = { version = "0.4.0", package = "uu_pwunconv", path = "src/uu/pwunconv" }
 grpconv = { version = "0.4.0", package = "uu_grpconv", path = "src/uu/grpconv" }
 grpunconv = { version = "0.4.0", package = "uu_grpunconv", path = "src/uu/grpunconv" }
+login = { version = "0.4.0", package = "uu_login", path = "src/uu/login" }
 passwd = { version = "0.4.0", package = "uu_passwd", path = "src/uu/passwd" }
 useradd = { version = "0.4.0", package = "uu_useradd", path = "src/uu/useradd" }
 userdel = { version = "0.4.0", package = "uu_userdel", path = "src/uu/userdel" }

--- a/Makefile
+++ b/Makefile
@@ -17,9 +17,12 @@ ROOT_TOOLS = useradd userdel usermod chpasswd chgpasswd newusers \
 # package, which ships passwd, chage, chfn, chsh and newgrp in /usr/bin and
 # everything else in /usr/sbin. chage is here for `chage -l`, the one mode a
 # user may run on their own account.
-USER_TOOLS = $(SETUID_TOOLS) chage
+# login lives in bin too, and is root-only without being setuid: getty runs
+# it as root, and it refuses to run as anyone else.
+USER_BIN_TOOLS = chage login
+USER_TOOLS = $(SETUID_TOOLS) $(USER_BIN_TOOLS)
 
-ALL_TOOLS = $(SETUID_TOOLS) $(ROOT_TOOLS) chage
+ALL_TOOLS = $(SETUID_TOOLS) $(ROOT_TOOLS) $(USER_BIN_TOOLS)
 
 .PHONY: all build build-multicall build-arm64 dist-musl check test test-gnu-compat test-unprivileged test-arm64 install install-multicall uninstall clean
 
@@ -31,7 +34,7 @@ all: build
 # build requirement in the README.
 build:
 	cargo build --release --workspace --bins --exclude uu_shadow \
-		--features uu_passwd/pam,uu_chfn/pam,uu_chsh/pam
+		--features uu_passwd/pam,uu_chfn/pam,uu_chsh/pam,uu_login/pam
 
 build-multicall:
 	cargo build --release --bin shadow-rs --features pam
@@ -134,19 +137,21 @@ test-unprivileged:
 test-gnu-compat:
 	bash tests/gnu-compat.sh
 
-# Default install: 24 standalone per-tool binaries, with the setuid layout and
+# Default install: 25 standalone per-tool binaries, with the setuid layout and
 # the bin/sbin split GNU shadow-utils uses. Only $(SETUID_TOOLS) are setuid.
 install: build
 	@for tool in $(SETUID_TOOLS); do \
 		install -Dm4755 target/release/$$tool $(DESTDIR)$(BINDIR)/$$tool || exit 1; \
 	done
-	@install -Dm0755 target/release/chage $(DESTDIR)$(BINDIR)/chage
+	@for tool in $(USER_BIN_TOOLS); do \
+		install -Dm0755 target/release/$$tool $(DESTDIR)$(BINDIR)/$$tool || exit 1; \
+	done
 	@for tool in $(ROOT_TOOLS); do \
 		install -Dm0755 target/release/$$tool $(DESTDIR)$(SBINDIR)/$$tool || exit 1; \
 	done
 	@echo "Installed $(words $(ALL_TOOLS)) standalone binaries"
 	@echo "  $(DESTDIR)$(BINDIR)/  setuid (4755): $(SETUID_TOOLS)"
-	@echo "  $(DESTDIR)$(BINDIR)/  user (0755):   chage"
+	@echo "  $(DESTDIR)$(BINDIR)/  user (0755):   $(USER_BIN_TOOLS)"
 	@echo "  $(DESTDIR)$(SBINDIR)/ root (0755):   $(ROOT_TOOLS)"
 
 # Opt-in install: single multicall binary with symlinks. Smaller footprint.

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ default-in-Ubuntu in under 3 years. This project follows that playbook.
 | `pwunconv` | **Implemented.** Merges hashes back into passwd and removes shadow. |
 | `grpconv` | **Implemented.** `pwconv` for group and gshadow. |
 | `grpunconv` | **Implemented.** `pwunconv` for group and gshadow. |
+| `login` | **Implemented.** What getty runs: prompts, PAM authentication and session, utmp/wtmp, terminal handover, a login shell. Needs the `pam` feature. |
 
 ## Scope
 
@@ -90,7 +91,7 @@ implemented. Of the rest:
 
 | tool | status |
 |---|---|
-| `login` | in scope, not yet shipped. Debian 13 and Ubuntu 25.10 take `login` from util-linux, but every release in service today — Ubuntu 20.04, 22.04 and 24.04, Debian 12 — ships shadow's, and `uutils/login` was archived pointing here. The target is the option set the two implementations share |
+| `login` | shipped. Debian 13 and Ubuntu 25.10 take `login` from util-linux, but every release in service today — Ubuntu 20.04, 22.04 and 24.04, Debian 12 — ships shadow's, and `uutils/login` was archived pointing here. It implements the option set the two share, plus util-linux's `-H` |
 | `expiry`, `groupmems` | Debian's tail; in scope, not yet shipped. `faillog` and `lastlog` left the Debian package with 13 and are not planned |
 | `newuidmap`, `newgidmap` | Fedora's pair, the basis of rootless containers; in scope, not yet shipped |
 | `shadowconfig`, `cpgr`, `cppw`, `adduser` | Debian packaging scripts and a Fedora symlink, not upstream tools; out of scope |
@@ -101,7 +102,7 @@ organisation, and are deliberately not duplicated here — the same rule
 
 - `nologin` is in [`uutils/util-linux`](https://github.com/uutils/util-linux). Debian has taken it from util-linux for years; shadow's copy is not shipped.
 - `su` is in [`sudo-rs`](https://github.com/trifectatechfoundation/sudo-rs).
-- `login` is here, per the table above: on the installed base it is shadow's tool, whatever the newest releases do.
+- `login` is here: on the installed base it is shadow's tool, whatever the newest releases do.
 
 ### Where this differs from GNU shadow
 
@@ -144,9 +145,9 @@ docker compose run --rm debian cargo build --release
 
 ### Install
 
-Default install: 24 standalone per-tool binaries with least-privilege setuid
+Default install: 25 standalone per-tool binaries with least-privilege setuid
 layout matching GNU shadow-utils. Only `passwd`, `chfn`, `chsh`, `newgrp`,
-`gpasswd` and `sg` are installed setuid-root; the other 18 are plain `0755`.
+`gpasswd` and `sg` are installed setuid-root; the other 19 are plain `0755`.
 
 ```shell
 sudo make install PREFIX=/usr/local
@@ -199,7 +200,7 @@ sudo install -o root -g root -m 4755 \
     uu_shadow-*/shadow-rs /usr/local/bin/shadow-rs
 for tool in passwd chfn chsh newgrp gpasswd sg chage chpasswd chgpasswd newusers \
             groupadd groupdel groupmod grpck pwck useradd userdel usermod vipw vigr \
-            pwconv pwunconv grpconv grpunconv; do
+            pwconv pwunconv grpconv grpunconv login; do
     sudo ln -sf shadow-rs "/usr/local/bin/$tool"
 done
 ```

--- a/docker/Dockerfile.fedora
+++ b/docker/Dockerfile.fedora
@@ -13,6 +13,9 @@ FROM fedora:46
 RUN dnf install -y \
     gcc \
     pam-devel \
+    # util-linux carries /etc/pam.d/login on Fedora; without it PAM falls back
+    # to `other`, which denies everything, and login cannot be tested at all.
+    util-linux \
     libselinux-devel \
     audit-libs-devel \
     pkgconf-pkg-config \

--- a/docs/PLATFORM-SUPPORT.md
+++ b/docs/PLATFORM-SUPPORT.md
@@ -86,6 +86,12 @@ Effect, and this is the heaviest of the three gaps:
   than apply an unverified one, so without PAM they refuse every non-root
   invocation outright.
 
+`login` is the fourth: without PAM it has no way to authenticate, so the
+applet prints *PAM support is not compiled in* and exits 1. A static image
+that needs a getty-driven login must use the glibc archive. utmp and wtmp
+recording is also a no-op under musl, which has stub `pututxline` and
+`updwtmpx`; `who(1)` and `last(1)` see nothing there.
+
 Unaffected: `passwd -S/-l/-u/-d/-e/-n/-x/-w/-i`, and `newgrp`, `sg` and
 `gpasswd`, which authenticate against the group password through crypt(3)
 rather than PAM -- so a group administrator can still use them. The other ten

--- a/docs/man/login.1.md
+++ b/docs/man/login.1.md
@@ -1,0 +1,151 @@
+# login(1) - begin a session on the system
+
+## NAME
+
+login - begin a session on the system
+
+## SYNOPSIS
+
+**login** [**-p**] [**-h** *host*] [**-H**] [[**-f**] *name*]
+
+## DESCRIPTION
+
+**login** is what **getty**(8) runs on a terminal once someone is there. It
+establishes who they are and starts their session: it prompts for a login
+name and, through PAM, a password; checks the account may log in; records the
+login; hands the terminal to the user; and runs their login shell with a login
+environment. When the shell exits, it closes the session and records the
+logout.
+
+It is run by root — by getty, or by a server such as **telnetd** that has
+already authenticated its peer — and does nothing for anyone else: *Cannot
+possibly work without effective root*. It is not setuid. It needs a
+controlling terminal and refuses without one.
+
+Two implementations of this program are in service: shadow-utils' on Ubuntu
+20.04, 22.04 and 24.04 and Debian 12, and util-linux's from Debian 13 and
+Ubuntu 25.10. This one implements the options and behaviour the two share, and
+adds util-linux's **-H** and **--help**, which conflict with nothing.
+
+## HOW A LOGIN PROCEEDS
+
+1. The prompt is `hostname login: `, or `login: ` with **-H** or
+   **LOGIN_PLAIN_PROMPT**. Any input typed ahead of the prompt is discarded, so
+   a password typed early does not land in the name field in clear.
+2. The name goes to the `login` PAM service. Without **-f** the stack
+   authenticates it, which for a local account means a password prompt. A
+   wrong password and an unknown name get the same answer, *Login incorrect*,
+   after the same delay, so the answer reveals nothing about which accounts
+   exist. After **LOGIN_RETRIES** failures **login** exits. **LOGIN_TIMEOUT**
+   seconds after it started, if no login has succeeded, it exits.
+3. The account is checked: expiry, and a password that must be changed, which
+   is changed on the spot. An expired account is told *Your account has
+   expired; please contact your system administrator.*
+4. Credentials are established and the PAM session opened. Whatever the
+   session stack exports — locale from **pam_env**, `XDG_*` from
+   **pam_systemd** — becomes part of the environment.
+5. The login is recorded in utmp and wtmp, with the remote host if **-h**
+   named one, so **who**(1) and **last**(1) see it.
+6. The terminal is given to the user: owner the account, group **TTYGROUP**
+   where that group exists and the account's primary group otherwise, mode
+   **TTYPERM**.
+7. The shell named in the passwd record runs — `/bin/sh` if the field is
+   empty — as the user, with `-` prefixed to its name so it behaves as a login
+   shell, in the home directory. If the home is missing and **DEFAULT_HOME**
+   is `yes`, the session starts in `/` with *No directory, logging in with
+   HOME=/*; otherwise it is refused.
+8. The shell runs as a child of **login**, not in its place, so that when it
+   exits the session can be closed and the logout recorded. Signals aimed at
+   the shell do not reach **login**.
+
+## ENVIRONMENT
+
+Without **-p** the caller's environment is discarded, except **TERM**,
+**COLORTERM** and **NO_COLOR**, which a session inherits from the terminal.
+With **-p** it is kept. Either way **HOME**, **SHELL**, **USER**, **LOGNAME**,
+**MAIL** and **PATH** are set from the account: **PATH** is **ENV_SUPATH** for
+root and **ENV_PATH** for everyone else, and **MAIL** is **MAIL_DIR**/*name*.
+The PAM session's variables are applied last and win.
+
+## OPTIONS
+
+**-p**
+:   Preserve the environment.
+
+**-f**
+:   Do not authenticate; the user is already authenticated. This is what
+    getty's autologin uses. Requires *name*. Because authentication is
+    skipped, so is everything the `auth` stack would do, including
+    **pam_nologin**.
+
+**-h** *host*
+:   The remote host, recorded in utmp and passed to PAM as **PAM_RHOST**.
+
+**-H**
+:   Do not show the hostname in the prompt.
+
+**--help**
+:   Display help and exit. There is no **-h** for help: **-h** is the host,
+    as it has been since telnetd.
+
+**-r** *host*
+:   The rlogin autologin protocol. Refused.
+
+## CONFIGURATION
+
+Read from /etc/login.defs. The defaults are login(1)'s.
+
+**LOGIN_RETRIES** (3), **LOGIN_TIMEOUT** (60), **FAIL_DELAY** (0, added to
+the delay the PAM stack already imposes), **TTYGROUP** (tty), **TTYPERM**
+(0600), **ENV_PATH**, **ENV_SUPATH**, **MAIL_DIR** (/var/mail),
+**DEFAULT_HOME** (yes), **HUSHLOGIN_FILE** (.hushlogin), **MOTD_FILE** (unset;
+a colon-separated list printed unless the login is hushed — on most systems
+**pam_motd** does this instead), **LOGIN_PLAIN_PROMPT** (no).
+
+A login is *hushed* — no message of the day — when the file named by
+**HUSHLOGIN_FILE** exists in the home directory, or /etc/hushlogins lists the
+user or their shell.
+
+## DIFFERENCES FROM THE GNU TOOLS
+
+**-r** is refused rather than implemented. rlogin has been off every system
+that matters for two decades.
+
+The terminal is not hung up. util-linux's **login** calls **vhangup**(2) to
+shake off any process still listening on the line; shadow's, which every
+current LTS ships, does not. Getty owns the line before **login** runs, and
+this program trusts that as shadow's does.
+
+**lastlog** is not written. Debian 13 removed /var/log/lastlog; where it still
+exists, **pam_lastlog** in the `login` service maintains it, as it does on
+Ubuntu.
+
+## EXIT STATUS
+
+**0**
+:   The session ran and the shell exited.
+
+**1**
+:   Not root, no terminal, authentication or account checks failed, the
+    session could not be set up, or a usage error.
+
+## FILES
+
+/etc/passwd, /etc/shadow
+:   Accounts, through the name service.
+
+/etc/pam.d/login
+:   The PAM service.
+
+/etc/login.defs
+:   Configuration; see above.
+
+/etc/hushlogins, ~/.hushlogin
+:   Suppress the message of the day.
+
+/var/run/utmp, /var/log/wtmp
+:   Login accounting.
+
+## SEE ALSO
+
+getty(8), login.defs(5), nologin(8), pam(8), passwd(5), su(1), who(1)

--- a/src/bin/completions.rs
+++ b/src/bin/completions.rs
@@ -47,6 +47,8 @@ fn get_tool_app(name: &str) -> Option<Command> {
         "grpconv" => Some(grpconv::uu_app()),
         #[cfg(feature = "grpunconv")]
         "grpunconv" => Some(grpunconv::uu_app()),
+        #[cfg(feature = "login")]
+        "login" => Some(login::uu_app()),
         #[cfg(feature = "newgrp")]
         "newgrp" => Some(newgrp::uu_app()),
         #[cfg(feature = "newusers")]
@@ -102,6 +104,8 @@ fn all_tool_names() -> Vec<&'static str> {
     names.push("grpconv");
     #[cfg(feature = "grpunconv")]
     names.push("grpunconv");
+    #[cfg(feature = "login")]
+    names.push("login");
     #[cfg(feature = "newgrp")]
     names.push("newgrp");
     #[cfg(feature = "newusers")]

--- a/src/bin/shadow-rs.rs
+++ b/src/bin/shadow-rs.rs
@@ -39,7 +39,7 @@ const SETUID_APPLETS: [&str; 6] = ["passwd", "chfn", "chsh", "newgrp", "gpasswd"
 // nothing, and the binding is then not mutated.
 #[allow(unused_mut)]
 fn applets() -> Vec<(&'static str, Applet)> {
-    let mut table: Vec<(&'static str, Applet)> = Vec::with_capacity(24);
+    let mut table: Vec<(&'static str, Applet)> = Vec::with_capacity(25);
     #[cfg(feature = "chage")]
     table.push(("chage", |a| chage::uumain(a.iter().cloned())));
     #[cfg(feature = "chfn")]
@@ -64,6 +64,8 @@ fn applets() -> Vec<(&'static str, Applet)> {
     table.push(("grpconv", |a| grpconv::uumain(a.iter().cloned())));
     #[cfg(feature = "grpunconv")]
     table.push(("grpunconv", |a| grpunconv::uumain(a.iter().cloned())));
+    #[cfg(feature = "login")]
+    table.push(("login", |a| login::uumain(a.iter().cloned())));
     #[cfg(feature = "newgrp")]
     table.push(("newgrp", |a| newgrp::uumain(a.iter().cloned())));
     #[cfg(feature = "newusers")]
@@ -246,7 +248,7 @@ fn print_available_utils() {
 mod tests {
     use super::*;
 
-    const ALL_TOOLS: [&str; 24] = [
+    const ALL_TOOLS: [&str; 25] = [
         "chage",
         "chfn",
         "chgpasswd",
@@ -259,6 +261,7 @@ mod tests {
         "grpck",
         "grpconv",
         "grpunconv",
+        "login",
         "newgrp",
         "newusers",
         "passwd",

--- a/src/shadow-core/src/lock.rs
+++ b/src/shadow-core/src/lock.rs
@@ -87,25 +87,40 @@ impl FileLock {
         let deadline = Instant::now() + timeout;
         let tmp_path = tmp_lock_path(&lock_path);
 
-        // Write our PID to the temp file once, then try to link it in a loop.
-        write_pid_file(&tmp_path)?;
+        // For the account files, /etc/.pwd.lock comes *first*, then the
+        // per-file lock -- the order lckpwdf(3) and the GNU tools use, and the
+        // only order that cannot deadlock. Taken the other way round, a tool
+        // holding passwd.lock and waiting for .pwd.lock met a tool holding
+        // shadow.lock and waiting for .pwd.lock's holder to let go of
+        // passwd.lock: both sat out the full timeout and both failed, on a
+        // system that was merely busy. With .pwd.lock first, whoever holds it
+        // is the only one asking for per-file locks, and it never has to wait
+        // for anyone who is waiting for it.
+        let pwd_path = account_pwd_lock_path(file_path);
+        if let Some(pwd_path) = &pwd_path {
+            acquire_pwd_lock(pwd_path, deadline)?;
+        }
 
-        let result = Self::acquire_loop(&lock_path, &tmp_path, deadline);
+        // Write our PID to the temp file once, then try to link it in a loop.
+        let result = write_pid_file(&tmp_path)
+            .and_then(|()| Self::acquire_loop(&lock_path, &tmp_path, deadline));
 
         // Always clean up our temp file, regardless of success or failure.
         let _ = fs::remove_file(&tmp_path);
 
-        let mut lock = result?;
-
-        // For the account files, also take /etc/.pwd.lock so we exclude the
-        // system's own account tools. If it cannot be taken, drop the .lock we
-        // just got (via the early return running `lock`'s destructor).
-        if let Some(pwd_path) = account_pwd_lock_path(file_path) {
-            acquire_pwd_lock(&pwd_path, deadline)?;
-            lock.pwd_lock_path = Some(pwd_path);
+        match result {
+            Ok(mut lock) => {
+                lock.pwd_lock_path = pwd_path;
+                Ok(lock)
+            }
+            Err(e) => {
+                // Give the suite-wide lock back: nothing is held on failure.
+                if let Some(pwd_path) = &pwd_path {
+                    release_pwd_lock(pwd_path);
+                }
+                Err(e)
+            }
         }
-
-        Ok(lock)
     }
 
     /// Inner acquisition loop. Separated so the caller can guarantee temp file cleanup.

--- a/src/shadow-core/src/pam.rs
+++ b/src/shadow-core/src/pam.rs
@@ -133,6 +133,10 @@ pub mod flags {
     pub const PAM_CHANGE_EXPIRED_AUTHTOK: i32 = 0x0020;
     /// Don't update the last-changed timestamp.
     pub const PAM_DISALLOW_NULL_AUTHTOK: i32 = 0x0001;
+    /// `pam_setcred`: establish the user's credentials.
+    pub const PAM_ESTABLISH_CRED: i32 = 0x0002;
+    /// `pam_setcred`: delete the user's credentials.
+    pub const PAM_DELETE_CRED: i32 = 0x0004;
 }
 
 // ---------------------------------------------------------------------------
@@ -209,6 +213,15 @@ unsafe extern "C" {
     ) -> libc::c_int;
 
     fn pam_strerror(pamh: *mut PamHandle, errnum: libc::c_int) -> *const libc::c_char;
+    fn pam_setcred(pamh: *mut PamHandle, flags: libc::c_int) -> libc::c_int;
+    fn pam_open_session(pamh: *mut PamHandle, flags: libc::c_int) -> libc::c_int;
+    fn pam_close_session(pamh: *mut PamHandle, flags: libc::c_int) -> libc::c_int;
+    fn pam_get_item(
+        pamh: *const PamHandle,
+        item_type: libc::c_int,
+        item: *mut *const libc::c_void,
+    ) -> libc::c_int;
+    fn pam_getenvlist(pamh: *mut PamHandle) -> *mut *mut libc::c_char;
 }
 
 // ---------------------------------------------------------------------------
@@ -649,6 +662,110 @@ impl PamContext {
         }
 
         Ok(())
+    }
+
+    /// Establish or delete the user's credentials (`pam_setcred`).
+    ///
+    /// `login(1)` calls this with `PAM_ESTABLISH_CRED` after authentication
+    /// and before the session opens, which is when modules such as
+    /// `pam_group` hand out supplementary groups.
+    ///
+    /// # Errors
+    ///
+    /// Returns `ShadowError::Auth` if the stack refuses.
+    pub fn setcred(&mut self, flags: i32) -> Result<(), ShadowError> {
+        // SAFETY: `self.handle` is a valid PAM handle (same invariant as above).
+        let rc = unsafe { pam_setcred(self.handle, flags) };
+        self.last_status = rc;
+        if rc != return_code::PAM_SUCCESS {
+            return Err(ShadowError::Auth(self.strerror(rc).into()));
+        }
+        Ok(())
+    }
+
+    /// Open a session (`pam_open_session`): motd, limits, environment,
+    /// audit uid -- whatever the `session` stack of the service does.
+    ///
+    /// # Errors
+    ///
+    /// Returns `ShadowError::Auth` if the stack refuses.
+    pub fn open_session(&mut self, flags: i32) -> Result<(), ShadowError> {
+        // SAFETY: `self.handle` is a valid PAM handle (same invariant as above).
+        let rc = unsafe { pam_open_session(self.handle, flags) };
+        self.last_status = rc;
+        if rc != return_code::PAM_SUCCESS {
+            return Err(ShadowError::Auth(self.strerror(rc).into()));
+        }
+        Ok(())
+    }
+
+    /// Close a session opened with [`open_session`](Self::open_session).
+    ///
+    /// # Errors
+    ///
+    /// Returns `ShadowError::Auth` if the stack reports a failure; callers at
+    /// the end of a session usually have nothing left to do about it.
+    pub fn close_session(&mut self, flags: i32) -> Result<(), ShadowError> {
+        // SAFETY: `self.handle` is a valid PAM handle (same invariant as above).
+        let rc = unsafe { pam_close_session(self.handle, flags) };
+        self.last_status = rc;
+        if rc != return_code::PAM_SUCCESS {
+            return Err(ShadowError::Auth(self.strerror(rc).into()));
+        }
+        Ok(())
+    }
+
+    /// The user the stack settled on.
+    ///
+    /// A module may change `PAM_USER` during authentication -- mapping a
+    /// login name to an account, say -- so the name given to
+    /// [`new`](Self::new) is not necessarily the one to log in.
+    #[must_use]
+    pub fn user(&self) -> Option<String> {
+        let mut item: *const libc::c_void = ptr::null();
+        // SAFETY: `self.handle` is valid and `item` is a valid out-pointer. On
+        // success PAM points it at a string it owns, which is not freed here.
+        let rc = unsafe { pam_get_item(self.handle, item_type::PAM_USER, &raw mut item) };
+        if rc != return_code::PAM_SUCCESS || item.is_null() {
+            return None;
+        }
+        // SAFETY: a successful PAM_USER lookup yields a null-terminated string.
+        let cstr = unsafe { CStr::from_ptr(item.cast::<libc::c_char>()) };
+        Some(cstr.to_string_lossy().into_owned())
+    }
+
+    /// The environment the session stack built (`pam_getenvlist`), as
+    /// `KEY=value` strings.
+    ///
+    /// `pam_env` and `pam_systemd` put the variables a login shell should see
+    /// here, and a session started without them is missing its locale, its
+    /// `XDG_*` directories and whatever the administrator configured.
+    #[must_use]
+    pub fn environment(&mut self) -> Vec<String> {
+        // SAFETY: `self.handle` is valid. `pam_getenvlist` returns a
+        // null-terminated array of malloc'd strings the caller owns, or null.
+        let list = unsafe { pam_getenvlist(self.handle) };
+        if list.is_null() {
+            return Vec::new();
+        }
+        let mut vars = Vec::new();
+        let mut i = 0;
+        loop {
+            // SAFETY: the array is null-terminated; each entry up to the null
+            // is a valid string allocated with malloc, freed exactly once here.
+            unsafe {
+                let entry = *list.add(i);
+                if entry.is_null() {
+                    break;
+                }
+                vars.push(CStr::from_ptr(entry).to_string_lossy().into_owned());
+                libc::free(entry.cast::<libc::c_void>());
+            }
+            i += 1;
+        }
+        // SAFETY: the array itself was malloc'd by PAM and is ours to free.
+        unsafe { libc::free(list.cast::<libc::c_void>()) };
+        vars
     }
 
     /// Get the human-readable error string for a PAM return code.

--- a/src/shadow-core/src/process.rs
+++ b/src/shadow-core/src/process.rs
@@ -14,7 +14,7 @@
 //! This is one of the few modules that permits `unsafe` — all unsafe is
 //! confined to well-understood POSIX C library calls.
 
-use std::ffi::CStr;
+use std::ffi::{CStr, CString};
 use std::io;
 
 // ---------------------------------------------------------------------------
@@ -108,6 +108,231 @@ pub fn setgroups(groups: &[u32]) -> io::Result<()> {
     } else {
         Err(io::Error::last_os_error())
     }
+}
+
+// ---------------------------------------------------------------------------
+// Sessions: utmp/wtmp, controlling terminals, watchdogs
+// ---------------------------------------------------------------------------
+
+unsafe extern "C" {
+    // In glibc and musl alike; not in the libc crate's bindings. musl's is a
+    // no-op, which is the documented state of utmp there.
+    fn updwtmpx(file: *const libc::c_char, ut: *const libc::utmpx);
+}
+
+/// Where login records go for `last(1)`.
+const WTMP_FILE: &CStr = c"/var/log/wtmp";
+
+/// Copy `s` into a fixed C char array, truncating; the tail stays zero.
+fn fill(dst: &mut [libc::c_char], s: &str) {
+    for (d, b) in dst.iter_mut().zip(s.bytes()) {
+        // c_char is i8 on x86 and u8 on arm; both hold a byte bit for bit.
+        #[allow(clippy::cast_possible_wrap)]
+        {
+            *d = b as libc::c_char;
+        }
+    }
+}
+
+/// A login or logout event for the accounting files.
+#[derive(Debug, Clone)]
+pub struct SessionRecord<'a> {
+    /// The terminal, without `/dev/` (`pts/3`, `tty1`).
+    pub line: &'a str,
+    /// The account name; empty for a logout.
+    pub user: &'a str,
+    /// The remote host, or empty.
+    pub host: &'a str,
+    /// The pid of the session leader.
+    pub pid: i32,
+}
+
+/// Record a login in utmp and wtmp, so `who(1)` and `last(1)` see it.
+///
+/// Best effort: a machine without utmp -- musl, or a system that moved to
+/// wtmpdb -- is a normal machine, and a failure to record a session must not
+/// stop the session. The `ut_id` is the tail of the line, which is what init
+/// and getty use, so the slot is the one they will later mark dead.
+pub fn record_login(rec: &SessionRecord<'_>) {
+    write_utmp(rec, libc::USER_PROCESS);
+}
+
+/// Record the end of a session in utmp and wtmp.
+pub fn record_logout(rec: &SessionRecord<'_>) {
+    let ended = SessionRecord {
+        user: "",
+        host: "",
+        ..rec.clone()
+    };
+    write_utmp(&ended, libc::DEAD_PROCESS);
+}
+
+fn write_utmp(rec: &SessionRecord<'_>, ut_type: libc::c_short) {
+    // SAFETY: utmpx is a plain C struct of integers and char arrays; all-zero
+    // is a valid value, and every field written below is written in bounds.
+    let mut ut: libc::utmpx = unsafe { std::mem::zeroed() };
+    ut.ut_type = ut_type;
+    ut.ut_pid = rec.pid;
+    fill(&mut ut.ut_line, rec.line);
+    let id_start = rec.line.len().saturating_sub(4);
+    fill(&mut ut.ut_id, &rec.line[id_start..]);
+    fill(&mut ut.ut_user, rec.user);
+    fill(&mut ut.ut_host, rec.host);
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_or(0, |d| d.as_secs());
+    // glibc keeps a 32-bit tv_sec in utmpx on 64-bit hosts for compatibility;
+    // musl uses a full timeval. The cast follows whichever the target has.
+    #[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
+    {
+        ut.ut_tv.tv_sec = now as _;
+    }
+
+    // SAFETY: standard utmpx API; `ut` is fully initialized and outlives the
+    // calls. pututxline copies the record. Failures are deliberately ignored:
+    // see the doc comment on record_login.
+    unsafe {
+        libc::setutxent();
+        libc::pututxline(&raw const ut);
+        libc::endutxent();
+        updwtmpx(WTMP_FILE.as_ptr(), &raw const ut);
+    }
+}
+
+/// Spawn `cmd` as a new session with `tty` as its controlling terminal.
+///
+/// This is what getty does before it runs `login`, and what a test has to do
+/// to run `login` the way getty would. The child becomes a session leader and
+/// claims the terminal; nothing else about the process changes.
+pub fn spawn_with_controlling_tty(
+    cmd: &mut std::process::Command,
+    tty: std::os::unix::io::RawFd,
+) -> io::Result<std::process::Child> {
+    use std::os::unix::process::CommandExt as _;
+
+    // SAFETY: runs in the forked child before exec, and calls only setsid and
+    // ioctl, both async-signal-safe; `tty` is a descriptor the parent opened
+    // and keeps open across the fork.
+    unsafe {
+        cmd.pre_exec(move || {
+            if libc::setsid() < 0 {
+                return Err(io::Error::last_os_error());
+            }
+            if libc::ioctl(tty, libc::TIOCSCTTY, 0) < 0 {
+                return Err(io::Error::last_os_error());
+            }
+            Ok(())
+        });
+    }
+    cmd.spawn()
+}
+
+/// Spawn `cmd` as `uid`:`gid` with the given supplementary groups, and a
+/// clean signal mask.
+///
+/// The order is the one that works: supplementary groups and the primary
+/// group while still root, then the uid, after which nothing can be changed
+/// back. `std::process::Command` offers the same through `uid`, `gid` and
+/// `groups`, but `groups` is not stable, and half of the drop through one API
+/// and half through another is how the order gets wrong.
+pub fn spawn_as_user(
+    cmd: &mut std::process::Command,
+    uid: u32,
+    gid: u32,
+    groups: Vec<u32>,
+) -> io::Result<std::process::Child> {
+    use std::os::unix::process::CommandExt as _;
+
+    // SAFETY: runs in the forked child before exec and calls only
+    // sigprocmask, setgroups, setgid and setuid, all async-signal-safe;
+    // `groups` was allocated by the parent and is only read here.
+    unsafe {
+        cmd.pre_exec(move || {
+            let mut empty: libc::sigset_t = std::mem::zeroed();
+            if libc::sigemptyset(&raw mut empty) != 0
+                || libc::sigprocmask(libc::SIG_SETMASK, &raw const empty, std::ptr::null_mut()) != 0
+            {
+                return Err(io::Error::last_os_error());
+            }
+            if libc::setgroups(groups.len(), groups.as_ptr()) != 0 {
+                return Err(io::Error::last_os_error());
+            }
+            if libc::setgid(gid) != 0 {
+                return Err(io::Error::last_os_error());
+            }
+            if libc::setuid(uid) != 0 {
+                return Err(io::Error::last_os_error());
+            }
+            Ok(())
+        });
+    }
+    cmd.spawn()
+}
+
+/// End the process after `seconds` unless it has exec'd or exited by then.
+///
+/// `login(1)` gives a caller `LOGIN_TIMEOUT` seconds to get through the
+/// prompts, so an abandoned getty line does not hold a half-open session for
+/// ever. A successful login execs the shell, which replaces the process,
+/// thread included; a failed one exits on its own. Only a stalled prompt is
+/// left for this to end.
+pub fn exit_after(seconds: u64, message: &'static str) {
+    use std::io::Write as _;
+
+    std::thread::spawn(move || {
+        std::thread::sleep(std::time::Duration::from_secs(seconds));
+        let _ = writeln!(io::stderr(), "{message}");
+        // SAFETY: _exit terminates the process without unwinding or running
+        // destructors, which is what a watchdog wants: nothing here holds a
+        // lock or a half-written file.
+        unsafe { libc::_exit(0) };
+    });
+}
+
+/// Look up an account by name through NSS (`getpwnam_r`).
+///
+/// Like [`getpwuid`], so a directory user can log in where `/etc/passwd` has
+/// never heard of them.
+pub fn getpwnam(name: &str) -> io::Result<Option<crate::passwd::PasswdEntry>> {
+    let name_c = CString::new(name).map_err(|_| io::Error::from(io::ErrorKind::InvalidInput))?;
+    let mut pwd: libc::passwd = unsafe { std::mem::zeroed() };
+    let mut result: *mut libc::passwd = std::ptr::null_mut();
+    let mut buf = vec![0u8; 16 * 1024];
+    // SAFETY: getpwnam_r writes into `pwd` and `buf`, both sized and live for
+    // the call; `result` points at `pwd` on success or is null.
+    let rc = unsafe {
+        libc::getpwnam_r(
+            name_c.as_ptr(),
+            &raw mut pwd,
+            buf.as_mut_ptr().cast::<libc::c_char>(),
+            buf.len(),
+            &raw mut result,
+        )
+    };
+    if rc != 0 {
+        return Err(io::Error::from_raw_os_error(rc));
+    }
+    if result.is_null() {
+        return Ok(None);
+    }
+    // SAFETY: on success every string pointer in `pwd` points into `buf`,
+    // which is still alive, and is null-terminated.
+    let field = |p: *const libc::c_char| unsafe {
+        if p.is_null() {
+            String::new()
+        } else {
+            CStr::from_ptr(p).to_string_lossy().into_owned()
+        }
+    };
+    Ok(Some(crate::passwd::PasswdEntry {
+        name: field(pwd.pw_name),
+        passwd: field(pwd.pw_passwd),
+        uid: pwd.pw_uid,
+        gid: pwd.pw_gid,
+        gecos: field(pwd.pw_gecos),
+        home: field(pwd.pw_dir),
+        shell: field(pwd.pw_shell),
+    }))
 }
 
 // ---------------------------------------------------------------------------

--- a/src/uu/login/Cargo.toml
+++ b/src/uu/login/Cargo.toml
@@ -1,0 +1,40 @@
+[package]
+name = "uu_login"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+categories.workspace = true
+rust-version.workspace = true
+description = "login ~ (shadow-rs) begin a session on the system"
+
+[lib]
+path = "src/login.rs"
+
+[[bin]]
+name = "login"
+path = "src/main.rs"
+
+[dependencies]
+clap = { workspace = true }
+rustix = { workspace = true }
+shadow-core = { workspace = true }
+uucore = { workspace = true }
+zeroize = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }
+
+[features]
+default = []
+pam = ["shadow-core/pam"]
+
+[lints]
+workspace = true
+
+# Distributed via the `shadow-rs` multicall binary in the workspace root
+# package, not as a standalone archive (see dist-workspace.toml, issue #207).
+[package.metadata.dist]
+dist = false

--- a/src/uu/login/locales/en-US.ftl
+++ b/src/uu/login/locales/en-US.ftl
@@ -1,0 +1,2 @@
+login-about = Begin a session on the system
+login-usage = login [-p] [-h host] [-H] [[-f] name]

--- a/src/uu/login/src/login.rs
+++ b/src/uu/login/src/login.rs
@@ -1,0 +1,908 @@
+// This file is part of the shadow-rs package.
+//
+// For the full copyright and license information, please view the LICENSE
+// file that was distributed with this source code.
+// spell-checker:ignore getty hushlogin hushlogins motd utmp wtmp rlogin setcred initgroups pts tcflush TTYGROUP TTYPERM SUPATH
+
+//! `login` — begin a session on the system.
+//!
+//! Drop-in replacement for `login(1)` as the distributions ship it: shadow's
+//! on Ubuntu 20.04 to 24.04 and Debian 12, util-linux's from Debian 13. The
+//! two agree on what matters and this implements the set they share, plus the
+//! util-linux options that cannot conflict with anything.
+//!
+//! `login` is what getty runs on a terminal. It prompts for a name and,
+//! through PAM, a password; refuses after `LOGIN_RETRIES` failures or
+//! `LOGIN_TIMEOUT` seconds; opens the PAM session; records the login in utmp
+//! and wtmp; hands the terminal to the user; and runs their login shell with
+//! a login environment. When the shell exits it closes the session and
+//! records the logout.
+//!
+//! It is not setuid. getty runs it as root, and it refuses to do anything
+//! else: "Cannot possibly work without effective root", as the GNU tool
+//! puts it.
+
+// Everything past the argument parser exists for the PAM build: without PAM
+// there is no authentication and `run` is a refusal. The workspace denies dead
+// code, rightly; in the no-PAM configuration that would deny the whole tool.
+#![cfg_attr(not(feature = "pam"), allow(dead_code, unused_imports))]
+
+use std::fmt;
+use std::io::Write as _;
+use std::path::{Path, PathBuf};
+
+use clap::{Arg, ArgAction, Command};
+
+use shadow_core::login_defs::LoginDefs;
+use shadow_core::passwd::PasswdEntry;
+
+use uucore::error::{UError, UResult};
+
+mod options {
+    pub const PRESERVE_ENV: &str = "preserve-environment";
+    pub const SKIP_AUTH: &str = "skip-auth";
+    pub const HOST: &str = "host";
+    pub const PLAIN_PROMPT: &str = "plain-prompt";
+    pub const RLOGIN: &str = "rlogin";
+    pub const NAME: &str = "name";
+}
+
+/// Defaults for the login.defs keys, from login(1).
+const DEFAULT_RETRIES: i64 = 3;
+const DEFAULT_TIMEOUT: i64 = 60;
+const DEFAULT_TTYPERM: u32 = 0o600;
+const DEFAULT_TTYGROUP: &str = "tty";
+const DEFAULT_ENV_PATH: &str = "/usr/local/bin:/bin:/usr/bin";
+const DEFAULT_ENV_SUPATH: &str = "/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin";
+const DEFAULT_MAIL_DIR: &str = "/var/mail";
+const DEFAULT_HUSHLOGIN_FILE: &str = ".hushlogin";
+const DEFAULT_SHELL: &str = "/bin/sh";
+
+/// The PAM service both implementations use.
+const PAM_SERVICE: &str = "login";
+
+/// Variables a login session inherits from the terminal rather than the
+/// profile, and so keeps even when the environment is otherwise discarded.
+const KEPT_FROM_CALLER: [&str; 3] = ["TERM", "COLORTERM", "NO_COLOR"];
+
+// ---------------------------------------------------------------------------
+// Error type
+// ---------------------------------------------------------------------------
+
+/// Errors `login` can produce. Every failure exits 1, which is what both
+/// implementations do; the variants exist so the message says which it was.
+#[derive(Debug)]
+enum LoginError {
+    /// Not running as root.
+    NotRoot,
+    /// No controlling terminal, or one that cannot be used.
+    NoTerminal(String),
+    /// Authentication or account checks failed for good.
+    Refused(String),
+    /// The session could not be set up.
+    Session(String),
+    /// Usage.
+    Usage(String),
+}
+
+impl fmt::Display for LoginError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::NotRoot => f.write_str("Cannot possibly work without effective root"),
+            Self::NoTerminal(msg) | Self::Refused(msg) | Self::Session(msg) | Self::Usage(msg) => {
+                f.write_str(msg)
+            }
+        }
+    }
+}
+
+impl std::error::Error for LoginError {}
+
+impl UError for LoginError {
+    fn code(&self) -> i32 {
+        match self {
+            Self::NotRoot
+            | Self::NoTerminal(_)
+            | Self::Refused(_)
+            | Self::Session(_)
+            | Self::Usage(_) => 1,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
+/// What login.defs says, with login(1)'s defaults filled in.
+#[derive(Debug, Clone)]
+struct Config {
+    retries: u32,
+    timeout: u64,
+    tty_group: String,
+    tty_perm: u32,
+    env_path: String,
+    env_supath: String,
+    mail_dir: String,
+    default_home: bool,
+    hushlogin_file: String,
+    motd_files: Vec<PathBuf>,
+    plain_prompt: bool,
+    fail_delay: u64,
+}
+
+impl Config {
+    fn from_defs(defs: &LoginDefs) -> Self {
+        // ENV_PATH is written `PATH=/a:/b` in login.defs; either spelling is
+        // accepted.
+        let path_of = |key: &str, default: &str| {
+            defs.get(key).map_or_else(
+                || default.to_string(),
+                |v| v.strip_prefix("PATH=").unwrap_or(v).to_string(),
+            )
+        };
+        let yes = |key: &str, default: bool| {
+            defs.get(key)
+                .map_or(default, |v| v.eq_ignore_ascii_case("yes"))
+        };
+        Self {
+            retries: u32::try_from(defs.get_i64("LOGIN_RETRIES").unwrap_or(DEFAULT_RETRIES))
+                .unwrap_or(1)
+                .max(1),
+            timeout: u64::try_from(defs.get_i64("LOGIN_TIMEOUT").unwrap_or(DEFAULT_TIMEOUT))
+                .unwrap_or(0),
+            tty_group: defs.get("TTYGROUP").unwrap_or(DEFAULT_TTYGROUP).to_string(),
+            tty_perm: defs
+                .get("TTYPERM")
+                .and_then(|v| u32::from_str_radix(v.trim_start_matches('0'), 8).ok())
+                .unwrap_or(DEFAULT_TTYPERM),
+            env_path: path_of("ENV_PATH", DEFAULT_ENV_PATH),
+            env_supath: path_of("ENV_SUPATH", DEFAULT_ENV_SUPATH),
+            mail_dir: defs.get("MAIL_DIR").unwrap_or(DEFAULT_MAIL_DIR).to_string(),
+            default_home: yes("DEFAULT_HOME", true),
+            hushlogin_file: defs
+                .get("HUSHLOGIN_FILE")
+                .unwrap_or(DEFAULT_HUSHLOGIN_FILE)
+                .to_string(),
+            motd_files: defs
+                .get("MOTD_FILE")
+                .map(|v| {
+                    v.split(':')
+                        .filter(|p| !p.is_empty())
+                        .map(PathBuf::from)
+                        .collect()
+                })
+                .unwrap_or_default(),
+            plain_prompt: yes("LOGIN_PLAIN_PROMPT", false),
+            fail_delay: u64::try_from(defs.get_i64("FAIL_DELAY").unwrap_or(0)).unwrap_or(0),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Pure pieces, kept separate so they can be tested without a terminal
+// ---------------------------------------------------------------------------
+
+/// The prompt: `hostname login: `, or `login: ` when the hostname is
+/// suppressed by `-H` or `LOGIN_PLAIN_PROMPT`.
+fn prompt_text(hostname: Option<&str>) -> String {
+    match hostname {
+        Some(h) if !h.is_empty() => format!("{h} login: "),
+        _ => "login: ".to_string(),
+    }
+}
+
+/// The terminal line as utmp records it: the path without `/dev/`.
+fn utmp_line(tty: &str) -> &str {
+    tty.strip_prefix("/dev/").unwrap_or(tty)
+}
+
+/// Whether the greeting -- motd, mail -- is to be suppressed for this account.
+///
+/// Either the per-user file named by `HUSHLOGIN_FILE` exists in the home
+/// directory, or `/etc/hushlogins` lists the user or their shell.
+fn is_hushed(home: &Path, hushlogin_file: &str, user: &str, shell: &str, etc: &Path) -> bool {
+    if home.join(hushlogin_file).exists() {
+        return true;
+    }
+    std::fs::read_to_string(etc.join("hushlogins"))
+        .is_ok_and(|s| s.lines().any(|l| l.trim() == user || l.trim() == shell))
+}
+
+/// Build the environment for the shell.
+///
+/// Without `-p` everything the caller carried is dropped except what a
+/// session inherits from the terminal; with it the caller's environment is
+/// kept. Either way `HOME`, `SHELL`, `USER`, `LOGNAME`, `PATH` and `MAIL` are
+/// set from the account, and whatever the PAM session stack exported is
+/// layered on top -- `pam_env`'s locale, `pam_systemd`'s `XDG_*`.
+fn build_environment(
+    caller: &[(String, String)],
+    preserve: bool,
+    entry: &PasswdEntry,
+    shell: &str,
+    home: &str,
+    config: &Config,
+    pam_env: &[String],
+) -> Vec<(String, String)> {
+    let mut env: Vec<(String, String)> = if preserve {
+        caller.to_vec()
+    } else {
+        caller
+            .iter()
+            .filter(|(k, _)| KEPT_FROM_CALLER.contains(&k.as_str()))
+            .cloned()
+            .collect()
+    };
+    let mut set = |k: &str, v: String| {
+        env.retain(|(key, _)| key != k);
+        env.push((k.to_string(), v));
+    };
+    set("HOME", home.to_string());
+    set("SHELL", shell.to_string());
+    set("USER", entry.name.clone());
+    set("LOGNAME", entry.name.clone());
+    set(
+        "PATH",
+        if entry.uid == 0 {
+            config.env_supath.clone()
+        } else {
+            config.env_path.clone()
+        },
+    );
+    set("MAIL", format!("{}/{}", config.mail_dir, entry.name));
+    for kv in pam_env {
+        if let Some((k, v)) = kv.split_once('=') {
+            set(k, v.to_string());
+        }
+    }
+    env
+}
+
+/// The shell to run, and the argv[0] that makes it a login shell.
+fn shell_for(entry: &PasswdEntry) -> (String, String) {
+    let shell = if entry.shell.is_empty() {
+        DEFAULT_SHELL.to_string()
+    } else {
+        entry.shell.clone()
+    };
+    let base = Path::new(&shell)
+        .file_name()
+        .map_or_else(|| "sh".to_string(), |n| n.to_string_lossy().into_owned());
+    (shell, format!("-{base}"))
+}
+
+// ---------------------------------------------------------------------------
+// Entry point
+// ---------------------------------------------------------------------------
+
+/// Entry point for the `login` utility.
+#[uucore::main]
+pub fn uumain(args: impl uucore::Args) -> UResult<()> {
+    // Nothing is sanitized: `-p` hands the caller's environment to the shell
+    // on purpose, and the shell is an interactive child that must keep its
+    // limits. Core dumps are off, since a password passes through here.
+    shadow_core::hardening::suppress_core_dumps();
+
+    let Some(matches) = shadow_core::cli::parse_args(uu_app(), args, |_| 1)? else {
+        return Ok(());
+    };
+
+    if rustix::process::geteuid().as_raw() != 0 {
+        return Err(LoginError::NotRoot.into());
+    }
+    if matches.get_flag(options::RLOGIN) {
+        return Err(LoginError::Usage(
+            "-r (the rlogin autologin protocol) is not supported".into(),
+        )
+        .into());
+    }
+
+    let request = Request {
+        preserve_env: matches.get_flag(options::PRESERVE_ENV),
+        skip_auth: matches.get_flag(options::SKIP_AUTH),
+        host: matches.get_one::<String>(options::HOST).cloned(),
+        plain_prompt: matches.get_flag(options::PLAIN_PROMPT),
+        name: matches.get_one::<String>(options::NAME).cloned(),
+    };
+    if request.skip_auth && request.name.is_none() {
+        return Err(LoginError::Usage("-f requires a user name".into()).into());
+    }
+
+    run(&request)
+}
+
+/// What the command line asked for.
+struct Request {
+    preserve_env: bool,
+    skip_auth: bool,
+    host: Option<String>,
+    plain_prompt: bool,
+    name: Option<String>,
+}
+
+/// Build the clap `Command` for `login`.
+#[must_use]
+pub fn uu_app() -> Command {
+    Command::new("login")
+        .about("Begin a session on the system")
+        .override_usage("login [-p] [-h host] [-H] [[-f] name]")
+        .version(shadow_core::cli::VERSION)
+        .after_help(shadow_core::cli::AFTER_HELP)
+        // `-h` is the remote host, as it has been in every login(1) since
+        // telnetd; help is `--help` only.
+        .disable_help_flag(true)
+        .arg(
+            Arg::new("help")
+                .long("help")
+                .help("display this help and exit")
+                .action(ArgAction::Help),
+        )
+        .arg(
+            Arg::new(options::PRESERVE_ENV)
+                .short('p')
+                .help("preserve the environment")
+                .action(ArgAction::SetTrue),
+        )
+        .arg(
+            Arg::new(options::SKIP_AUTH)
+                .short('f')
+                .help("skip authentication: the user is already authenticated (getty autologin)")
+                .action(ArgAction::SetTrue),
+        )
+        .arg(
+            Arg::new(options::HOST)
+                .short('h')
+                .help("name of the remote host, recorded in utmp and passed to PAM")
+                .value_name("host"),
+        )
+        .arg(
+            Arg::new(options::PLAIN_PROMPT)
+                .short('H')
+                .help("do not show the hostname in the login prompt")
+                .action(ArgAction::SetTrue),
+        )
+        .arg(
+            Arg::new(options::RLOGIN)
+                .short('r')
+                .help("rejected: the rlogin autologin protocol is not supported")
+                .value_name("host")
+                .hide(true)
+                .action(ArgAction::SetTrue),
+        )
+        .arg(
+            Arg::new(options::NAME)
+                .help("the account to log in")
+                .value_name("name"),
+        )
+}
+
+// ---------------------------------------------------------------------------
+// The session
+// ---------------------------------------------------------------------------
+
+#[cfg(feature = "pam")]
+fn run(request: &Request) -> UResult<()> {
+    let tty = shadow_core::tty::name()
+        .ok_or_else(|| LoginError::NoTerminal("no controlling terminal; login needs one".into()))?;
+    let root = shadow_core::sysroot::SysRoot::default();
+    let defs = LoginDefs::load(&root.login_defs_path()).unwrap_or_default();
+    let config = Config::from_defs(&defs);
+
+    // The caller's environment, captured before anything below can change it.
+    let caller_env: Vec<(String, String)> = std::env::vars().collect();
+
+    if config.timeout > 0 {
+        shadow_core::process::exit_after(config.timeout, "Login timed out.");
+    }
+
+    let (pam, entry) = authenticate(request, &config, &tty)?;
+    start_session(request, &config, &root, &tty, pam, &entry, &caller_env)
+}
+
+/// Discard anything typed ahead of a prompt, so a password typed early does
+/// not land in the name field in clear -- or in the shell's input later.
+#[cfg(feature = "pam")]
+fn discard_typeahead() {
+    let _ = rustix::termios::tcflush(std::io::stdin(), rustix::termios::QueueSelector::IFlush);
+}
+
+/// Prompt for names and passwords until one is accepted or the retries run
+/// out. Returns the PAM context, still open, and the account it settled on.
+#[cfg(feature = "pam")]
+fn authenticate(
+    request: &Request,
+    config: &Config,
+    tty: &str,
+) -> Result<(shadow_core::pam::PamContext, PasswdEntry), LoginError> {
+    use shadow_core::pam::{ConvMode, PamContext, flags, item_type, return_code};
+
+    let hostname = if request.plain_prompt || config.plain_prompt {
+        None
+    } else {
+        std::fs::read_to_string("/proc/sys/kernel/hostname")
+            .ok()
+            .map(|h| h.trim().to_string())
+    };
+    let prompt = prompt_text(hostname.as_deref());
+
+    let too_many = || {
+        LoginError::Refused(format!(
+            "maximum number of tries exceeded ({})",
+            config.retries
+        ))
+    };
+    // The same words for a wrong password and an unknown name, so a caller
+    // cannot tell accounts apart by the answer.
+    let incorrect = |login_name: &str| {
+        if config.fail_delay > 0 {
+            std::thread::sleep(std::time::Duration::from_secs(config.fail_delay));
+        }
+        let _ = writeln!(std::io::stderr(), "\nLogin incorrect");
+        shadow_core::audit::log_user_event("LOGIN", login_name, 0, false);
+    };
+
+    let mut name = request.name.clone();
+    for attempt in 1..=config.retries {
+        let login_name = if let Some(n) = name.take() {
+            n
+        } else {
+            discard_typeahead();
+            match shadow_core::tty::prompt_line(&prompt) {
+                Ok(n) if !n.trim().is_empty() => n.trim().to_string(),
+                Ok(_) => continue,
+                Err(e) => {
+                    return Err(LoginError::NoTerminal(format!(
+                        "cannot read the login name: {e}"
+                    )));
+                }
+            }
+        };
+
+        let mut ctx = PamContext::new(PAM_SERVICE, &login_name, ConvMode::Tty)
+            .map_err(|e| LoginError::Session(format!("PAM: {e}")))?;
+        let _ = ctx.set_item_str(item_type::PAM_TTY, tty);
+        if let Some(host) = &request.host {
+            let _ = ctx.set_item_str(item_type::PAM_RHOST, host);
+        }
+
+        if !request.skip_auth {
+            discard_typeahead();
+            if ctx.authenticate(0).is_err() {
+                incorrect(&login_name);
+                if attempt == config.retries {
+                    return Err(too_many());
+                }
+                continue;
+            }
+        }
+
+        // Aging and locks. nologin for the password path is in the auth
+        // stack and has already had its say.
+        match ctx.acct_mgmt(0) {
+            Ok(()) => {}
+            Err(_) if ctx.last_status() == return_code::PAM_NEW_AUTHTOK_REQD => {
+                ctx.chauthtok(flags::PAM_CHANGE_EXPIRED_AUTHTOK)
+                    .map_err(|e| LoginError::Refused(format!("password change failed: {e}")))?;
+            }
+            Err(e) => {
+                let msg = if ctx.last_status() == return_code::PAM_ACCT_EXPIRED {
+                    "Your account has expired; please contact your system administrator."
+                        .to_string()
+                } else {
+                    e.to_string()
+                };
+                let _ = writeln!(std::io::stderr(), "{msg}");
+                return Err(LoginError::Refused("Authentication failure".into()));
+            }
+        }
+
+        // PAM may have mapped the name to another account.
+        let account = ctx.user().unwrap_or(login_name.clone());
+        if let Ok(Some(found)) = shadow_core::process::getpwnam(&account) {
+            return Ok((ctx, found));
+        }
+        incorrect(&login_name);
+        if attempt == config.retries {
+            return Err(too_many());
+        }
+    }
+    Err(LoginError::Refused("Login incorrect".into()))
+}
+
+/// Open the session, record it, hand over the terminal, run the shell as the
+/// user, and close everything when the shell exits.
+#[cfg(feature = "pam")]
+fn start_session(
+    request: &Request,
+    config: &Config,
+    root: &shadow_core::sysroot::SysRoot,
+    tty: &str,
+    mut pam: shadow_core::pam::PamContext,
+    entry: &PasswdEntry,
+    caller_env: &[(String, String)],
+) -> UResult<()> {
+    use shadow_core::pam::flags;
+
+    pam.setcred(flags::PAM_ESTABLISH_CRED)
+        .map_err(|e| LoginError::Session(format!("cannot establish credentials: {e}")))?;
+    pam.open_session(0)
+        .map_err(|e| LoginError::Session(format!("cannot open session: {e}")))?;
+    let pam_env = pam.environment();
+
+    let record = shadow_core::process::SessionRecord {
+        line: utmp_line(tty),
+        user: &entry.name,
+        host: request.host.as_deref().unwrap_or(""),
+        pid: std::process::id().cast_signed(),
+    };
+    shadow_core::process::record_login(&record);
+    shadow_core::audit::log_user_event("LOGIN", &entry.name, entry.uid, true);
+
+    hand_over_terminal(tty, entry, config, root);
+
+    // Home: fall back to `/` when DEFAULT_HOME says so, as both tools do.
+    let home = if Path::new(&entry.home).is_dir() {
+        entry.home.clone()
+    } else if config.default_home {
+        let _ = writeln!(std::io::stderr(), "No directory, logging in with HOME=/");
+        "/".to_string()
+    } else {
+        return Err(LoginError::Session(format!("Unable to cd to '{}'", entry.home)).into());
+    };
+
+    let (shell, argv0) = shell_for(entry);
+    let env = build_environment(
+        caller_env,
+        request.preserve_env,
+        entry,
+        &shell,
+        &home,
+        config,
+        &pam_env,
+    );
+
+    if !is_hushed(
+        Path::new(&home),
+        &config.hushlogin_file,
+        &entry.name,
+        &shell,
+        Path::new("/etc"),
+    ) {
+        for motd in &config.motd_files {
+            if let Ok(text) = std::fs::read_to_string(motd) {
+                let _ = std::io::stdout().write_all(text.as_bytes());
+            }
+        }
+    }
+
+    // The shell runs as a child, not in this process: the PAM session has to
+    // be closed and the logout recorded once it exits, which needs someone
+    // left to do it. Signals aimed at the shell must not reach this process
+    // meanwhile, and the shell itself gets a clean mask.
+    let _signals = shadow_core::hardening::SignalBlocker::block_critical()
+        .map_err(|e| LoginError::Session(e.to_string()))?;
+    let mut cmd = std::process::Command::new(&shell);
+    {
+        use std::os::unix::process::CommandExt as _;
+        cmd.arg0(&argv0)
+            .current_dir(&home)
+            .env_clear()
+            .envs(env.iter().map(|(k, v)| (k.as_str(), v.as_str())));
+    }
+    let status = shadow_core::process::spawn_as_user(
+        &mut cmd,
+        entry.uid,
+        entry.gid,
+        supplementary_groups(entry),
+    )
+    .and_then(|mut child| child.wait());
+
+    shadow_core::process::record_logout(&record);
+    let _ = pam.close_session(0);
+    let _ = pam.setcred(flags::PAM_DELETE_CRED);
+
+    match status {
+        Ok(_) => Ok(()),
+        Err(e) => Err(LoginError::Session(format!("cannot run {shell}: {e}")).into()),
+    }
+}
+
+/// The supplementary groups the account belongs to, as `initgroups` would
+/// compute them, plus the ones PAM's `pam_group` may have added to this
+/// process -- which is why the current list is consulted too.
+#[cfg(feature = "pam")]
+fn supplementary_groups(entry: &PasswdEntry) -> Vec<u32> {
+    let mut groups: Vec<u32> =
+        shadow_core::records::read_entries::<shadow_core::group::GroupEntry>(Path::new(
+            "/etc/group",
+        ))
+        .map(|gs| {
+            gs.iter()
+                .filter(|g| g.members.contains(&entry.name))
+                .map(|g| g.gid)
+                .collect()
+        })
+        .unwrap_or_default();
+    if let Ok(current) = shadow_core::process::getgroups() {
+        for g in current {
+            if g != entry.gid && !groups.contains(&g) {
+                groups.push(g);
+            }
+        }
+    }
+    groups
+}
+
+/// Give the terminal to the user: owner the account, group `TTYGROUP` where
+/// it exists (else the account's primary group), mode `TTYPERM`.
+#[cfg(feature = "pam")]
+fn hand_over_terminal(
+    tty: &str,
+    entry: &PasswdEntry,
+    config: &Config,
+    root: &shadow_core::sysroot::SysRoot,
+) {
+    use rustix::fs::{Gid, Mode, OFlags, Uid};
+
+    let gid =
+        shadow_core::records::read_entries::<shadow_core::group::GroupEntry>(&root.group_path())
+            .ok()
+            .and_then(|gs| {
+                gs.iter()
+                    .find(|g| g.name == config.tty_group)
+                    .map(|g| g.gid)
+            })
+            .unwrap_or(entry.gid);
+    // Through a descriptor opened O_NOFOLLOW on the path we were handed, so a
+    // link planted under /dev cannot redirect the chown.
+    if let Ok(fd) = rustix::fs::open(
+        tty,
+        OFlags::RDWR | OFlags::NOFOLLOW | OFlags::NOCTTY,
+        Mode::empty(),
+    ) {
+        let _ = rustix::fs::fchown(
+            &fd,
+            Some(Uid::from_raw(entry.uid)),
+            Some(Gid::from_raw(gid)),
+        );
+        let _ = rustix::fs::fchmod(&fd, Mode::from_raw_mode(config.tty_perm));
+    }
+}
+
+#[cfg(not(feature = "pam"))]
+fn run(_request: &Request) -> UResult<()> {
+    // A login that cannot authenticate is not a login. The static musl build
+    // leaves PAM out on purpose (see docs/PLATFORM-SUPPORT.md), and this
+    // applet says so rather than pretending.
+    Err(LoginError::Session(
+        "PAM support is not compiled in \u{2014} login cannot authenticate".into(),
+    )
+    .into())
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn entry(name: &str, uid: u32, shell: &str) -> PasswdEntry {
+        PasswdEntry {
+            name: name.to_string(),
+            passwd: "x".to_string(),
+            uid,
+            gid: uid,
+            gecos: String::new(),
+            home: format!("/home/{name}"),
+            shell: shell.to_string(),
+        }
+    }
+
+    fn defs(text: &str) -> LoginDefs {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("login.defs");
+        std::fs::write(&path, text).expect("write");
+        LoginDefs::load(&path).expect("load")
+    }
+
+    #[test]
+    fn test_app_builds() {
+        uu_app().debug_assert();
+    }
+
+    #[test]
+    fn test_prompt_shows_the_hostname_unless_suppressed() {
+        assert_eq!(prompt_text(Some("box")), "box login: ");
+        assert_eq!(prompt_text(None), "login: ");
+        assert_eq!(prompt_text(Some("")), "login: ");
+    }
+
+    #[test]
+    fn test_utmp_line_drops_dev() {
+        assert_eq!(utmp_line("/dev/pts/3"), "pts/3");
+        assert_eq!(utmp_line("/dev/tty1"), "tty1");
+        assert_eq!(utmp_line("ttyS0"), "ttyS0");
+    }
+
+    /// Without `-p` the caller's environment is gone except what the
+    /// terminal provides; with it, everything stays. The account variables
+    /// are set either way and win over anything the caller carried.
+    #[test]
+    fn test_environment_is_a_login_environment() {
+        let caller = vec![
+            ("TERM".to_string(), "xterm".to_string()),
+            ("LD_PRELOAD".to_string(), "/evil.so".to_string()),
+            ("HOME".to_string(), "/wrong".to_string()),
+        ];
+        let config = Config::from_defs(&LoginDefs::default());
+        let alice = entry("alice", 1000, "/bin/bash");
+
+        let env = build_environment(
+            &caller,
+            false,
+            &alice,
+            "/bin/bash",
+            "/home/alice",
+            &config,
+            &[],
+        );
+        let get = |k: &str| {
+            env.iter()
+                .find(|(key, _)| key == k)
+                .map(|(_, v)| v.as_str())
+        };
+        assert_eq!(get("TERM"), Some("xterm"), "TERM comes from the terminal");
+        assert_eq!(
+            get("LD_PRELOAD"),
+            None,
+            "the caller's environment is dropped"
+        );
+        assert_eq!(get("HOME"), Some("/home/alice"));
+        assert_eq!(get("USER"), Some("alice"));
+        assert_eq!(get("LOGNAME"), Some("alice"));
+        assert_eq!(get("SHELL"), Some("/bin/bash"));
+        assert_eq!(get("PATH"), Some(DEFAULT_ENV_PATH));
+        assert_eq!(get("MAIL"), Some("/var/mail/alice"));
+
+        let kept = build_environment(
+            &caller,
+            true,
+            &alice,
+            "/bin/bash",
+            "/home/alice",
+            &config,
+            &[],
+        );
+        assert!(
+            kept.iter().any(|(k, _)| k == "LD_PRELOAD"),
+            "-p keeps the environment"
+        );
+        assert!(
+            kept.iter().any(|(k, v)| k == "HOME" && v == "/home/alice"),
+            "-p still sets the account's HOME"
+        );
+    }
+
+    /// Root gets the superuser path, and PAM's environment is layered last.
+    #[test]
+    fn test_root_path_and_pam_environment() {
+        let config = Config::from_defs(&defs("ENV_SUPATH PATH=/sbin:/bin\nENV_PATH PATH=/bin\n"));
+        let env = build_environment(
+            &[],
+            false,
+            &entry("root", 0, "/bin/sh"),
+            "/bin/sh",
+            "/root",
+            &config,
+            &["LANG=fr_BE.UTF-8".to_string()],
+        );
+        let get = |k: &str| {
+            env.iter()
+                .find(|(key, _)| key == k)
+                .map(|(_, v)| v.as_str())
+        };
+        assert_eq!(get("PATH"), Some("/sbin:/bin"));
+        assert_eq!(get("LANG"), Some("fr_BE.UTF-8"));
+    }
+
+    #[test]
+    fn test_shell_defaults_and_login_argv0() {
+        assert_eq!(
+            shell_for(&entry("a", 1, "")),
+            ("/bin/sh".to_string(), "-sh".to_string())
+        );
+        assert_eq!(
+            shell_for(&entry("a", 1, "/usr/bin/zsh")),
+            ("/usr/bin/zsh".to_string(), "-zsh".to_string())
+        );
+    }
+
+    #[test]
+    fn test_hushlogin_by_file_and_by_list() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let home = dir.path().join("home");
+        let etc = dir.path().join("etc");
+        std::fs::create_dir_all(&home).expect("home");
+        std::fs::create_dir_all(&etc).expect("etc");
+        assert!(!is_hushed(&home, ".hushlogin", "alice", "/bin/sh", &etc));
+        std::fs::write(home.join(".hushlogin"), "").expect("touch");
+        assert!(is_hushed(&home, ".hushlogin", "alice", "/bin/sh", &etc));
+        std::fs::remove_file(home.join(".hushlogin")).expect("rm");
+        std::fs::write(etc.join("hushlogins"), "bob\n/bin/sh\n").expect("list");
+        assert!(
+            is_hushed(&home, ".hushlogin", "alice", "/bin/sh", &etc),
+            "listed by shell"
+        );
+        assert!(
+            is_hushed(&home, ".hushlogin", "bob", "/bin/bash", &etc),
+            "listed by name"
+        );
+        assert!(!is_hushed(&home, ".hushlogin", "carol", "/bin/bash", &etc));
+    }
+
+    /// The login.defs keys, with their defaults and their spellings.
+    #[test]
+    fn test_config_from_login_defs() {
+        let c = Config::from_defs(&LoginDefs::default());
+        assert_eq!(c.retries, 3);
+        assert_eq!(c.timeout, 60);
+        assert_eq!(c.tty_perm, 0o600);
+        assert_eq!(c.tty_group, "tty");
+        assert!(c.default_home);
+        assert!(c.motd_files.is_empty());
+
+        let c = Config::from_defs(&defs(
+            "LOGIN_RETRIES 5\nLOGIN_TIMEOUT 0\nTTYPERM 0620\nDEFAULT_HOME no\nMOTD_FILE /etc/motd:/run/motd\nLOGIN_PLAIN_PROMPT yes\nFAIL_DELAY 4\n",
+        ));
+        assert_eq!(c.retries, 5);
+        assert_eq!(c.timeout, 0, "0 disables the timeout");
+        assert_eq!(c.tty_perm, 0o620);
+        assert!(!c.default_home);
+        assert_eq!(
+            c.motd_files,
+            vec![PathBuf::from("/etc/motd"), PathBuf::from("/run/motd")]
+        );
+        assert!(c.plain_prompt);
+        assert_eq!(c.fail_delay, 4);
+    }
+
+    /// `-f` needs a name and `-r` is refused; both are usage errors, not
+    /// prompts.
+    #[test]
+    fn test_flags() {
+        let m = uu_app()
+            .try_get_matches_from(["login", "-p", "-h", "example.org", "-H", "-f", "alice"])
+            .expect("parses");
+        assert!(m.get_flag(options::PRESERVE_ENV));
+        assert!(m.get_flag(options::SKIP_AUTH));
+        assert!(m.get_flag(options::PLAIN_PROMPT));
+        assert_eq!(
+            m.get_one::<String>(options::HOST).map(String::as_str),
+            Some("example.org")
+        );
+        assert_eq!(
+            m.get_one::<String>(options::NAME).map(String::as_str),
+            Some("alice")
+        );
+    }
+
+    #[test]
+    fn test_every_failure_exits_one() {
+        for e in [
+            LoginError::NotRoot,
+            LoginError::NoTerminal("x".into()),
+            LoginError::Refused("x".into()),
+            LoginError::Session("x".into()),
+            LoginError::Usage("x".into()),
+        ] {
+            assert_eq!(e.code(), 1);
+        }
+        assert_eq!(
+            LoginError::NotRoot.to_string(),
+            "Cannot possibly work without effective root"
+        );
+    }
+}

--- a/src/uu/login/src/main.rs
+++ b/src/uu/login/src/main.rs
@@ -1,0 +1,6 @@
+// This file is part of the shadow-rs package.
+//
+// For the full copyright and license information, please view the LICENSE
+// file that was distributed with this source code.
+
+uucore::bin!(uu_login);

--- a/src/uu/useradd/src/useradd.rs
+++ b/src/uu/useradd/src/useradd.rs
@@ -576,6 +576,14 @@ fn do_useradd(opts: &UseraddOptions) -> UResult<()> {
     } else {
         None
     };
+    // The shadow file is locked here with the others, not after they are
+    // written. It used to be opened on its own after the passwd commit, and a
+    // lock that timed out at that point -- which a busy system produces --
+    // left a passwd line with no shadow line: an account half made, that a
+    // second useradd then reported as already existing.
+    let shadow_path = opts.root.shadow_path();
+    let mut shadow_file = LockedFile::<ShadowEntry>::open_or_empty(&shadow_path)
+        .map_err(|e| UseraddError::CannotUpdatePasswd(format!("cannot open shadow: {e}")))?;
 
     // Step 3: Check the username is not already in use.
     if passwd_file.find(&opts.login).is_some() {
@@ -655,14 +663,6 @@ fn do_useradd(opts: &UseraddOptions) -> UResult<()> {
         shell: opts.shell.clone(),
     });
 
-    let mut files: Vec<Box<dyn Commit>> = vec![Box::new(passwd_file), Box::new(group_file)];
-    if let Some(gshadow_file) = gshadow_file {
-        files.push(Box::new(gshadow_file));
-    }
-    transaction::commit_all(files).map_err(|e| UseraddError::CannotUpdatePasswd(format!("{e}")))?;
-
-    // Step 13: Write /etc/shadow entry (passwd+group locks still held).
-    let shadow_path = opts.root.shadow_path();
     // useradd(8): a system account is "created with no aging information in
     // /etc/shadow" -- verified against shadow-utils, which writes
     // `svc:!:20700::::::` for -r and the full policy for a regular account.
@@ -691,7 +691,19 @@ fn do_useradd(opts: &UseraddOptions) -> UResult<()> {
             reserved: String::new(),
         }
     };
-    write_shadow_entry(&shadow_path, &shadow_entry)?;
+    shadow_file.entries_mut().push(shadow_entry);
+
+    // Step 12/13: every file is validated, then written -- shadow first, so a
+    // failure between the writes leaves no passwd line whose hash is nowhere.
+    let mut files: Vec<Box<dyn Commit>> = vec![
+        Box::new(shadow_file),
+        Box::new(passwd_file),
+        Box::new(group_file),
+    ];
+    if let Some(gshadow_file) = gshadow_file {
+        files.push(Box::new(gshadow_file));
+    }
+    transaction::commit_all(files).map_err(|e| UseraddError::CannotUpdatePasswd(format!("{e}")))?;
 
     // The transactions above released their locks when they committed.
     // Subsequent steps (subid, supplementary groups, home creation) are
@@ -881,6 +893,7 @@ fn resolve_group(gid_arg: &str, group_entries: &[GroupEntry]) -> Result<u32, Use
 ///
 /// A shadow file that does not exist yet is created: a fresh `--prefix` tree
 /// carries none.
+#[cfg(test)]
 fn write_shadow_entry(shadow_path: &Path, new_entry: &ShadowEntry) -> UResult<()> {
     let mut shadow = LockedFile::<ShadowEntry>::open_or_empty(shadow_path)
         .map_err(|e| UseraddError::CannotUpdatePasswd(format!("{e}")))?;

--- a/tests/arm64-smoke.sh
+++ b/tests/arm64-smoke.sh
@@ -64,10 +64,10 @@ version=$("${QEMU[@]}" "$BIN" --version 2>&1)
 if [ -n "$version" ]; then ok "runs: $version"; else bad "would not run"; exit 1; fi
 
 applets=$("${QEMU[@]}" "$BIN" --list 2>/dev/null | tail -n +2 | wc -l)
-if [ "$applets" -ge 24 ]; then
+if [ "$applets" -ge 25 ]; then
     ok "carries $applets applets"
 else
-    bad "expected at least 24 applets, found $applets"
+    bad "expected at least 25 applets, found $applets"
 fi
 
 # ── A prefix tree, so nothing here touches the container's own accounts ──
@@ -125,6 +125,7 @@ fi
 check "sg starts" "${QEMU[@]}" "$BIN" sg --help
 check "vipw starts" "${QEMU[@]}" "$BIN" vipw --help
 check "vigr starts" "${QEMU[@]}" "$BIN" vigr --help
+check "login starts" "${QEMU[@]}" "$BIN" login --help
 
 # newusers writes three files and a home directory from one line, so it
 # exercises the allocator, crypt(3) and the fchown in shadow_core::home

--- a/tests/by-util/test_login.rs
+++ b/tests/by-util/test_login.rs
@@ -1,0 +1,474 @@
+// This file is part of the shadow-rs package.
+//
+// For the full copyright and license information, please view the LICENSE
+// file that was distributed with this source code.
+// spell-checker:ignore getty pts openpt grantpt unlockpt ptsname NOCTTY motd
+
+//! Integration tests for `login`.
+//!
+//! `login` needs what getty gives it: a controlling terminal it is the
+//! session leader of. So each test opens a pseudo-terminal, starts the tool
+//! on its slave the way getty would, and talks to the master -- answering a
+//! prompt only once it has appeared, and reading what the session prints.
+//! Nothing here is driven through a pipe; nothing here would work through one.
+
+// The session helpers serve the PAM-gated tests; without PAM only the refusal
+// is tested and they go unused.
+#![cfg_attr(not(feature = "pam"), allow(dead_code))]
+
+use std::io::{Read as _, Write as _};
+use std::os::fd::OwnedFd;
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant};
+
+use crate::common::{run, skip_unless_root};
+
+/// A poll timeout.
+fn millis(ms: i64) -> rustix::event::Timespec {
+    rustix::event::Timespec {
+        tv_sec: 0,
+        tv_nsec: ms * 1_000_000,
+    }
+}
+
+/// A terminal session running the multicall binary as `login`.
+struct Session {
+    master: OwnedFd,
+    child: Child,
+    buf: String,
+}
+
+impl Session {
+    /// Start `login <args>` on a fresh pty, as getty would.
+    fn start(args: &[&str], env: &[(&str, &str)]) -> Session {
+        use rustix::pty::{OpenptFlags, grantpt, openpt, ptsname, unlockpt};
+
+        let master = openpt(OpenptFlags::RDWR | OpenptFlags::NOCTTY).expect("openpt");
+        grantpt(&master).expect("grantpt");
+        unlockpt(&master).expect("unlockpt");
+        let slave_path = ptsname(&master, Vec::new()).expect("ptsname");
+        let slave = std::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(slave_path.to_str().expect("utf8"))
+            .expect("open slave");
+
+        let mut cmd = Command::new(env!("CARGO_BIN_EXE_shadow-rs"));
+        cmd.arg("login").args(args);
+        cmd.env_clear()
+            .env("PATH", "/usr/bin:/bin:/usr/sbin:/sbin")
+            .env("TERM", "dumb");
+        for (k, v) in env {
+            cmd.env(k, v);
+        }
+        cmd.stdin(Stdio::from(slave.try_clone().expect("dup")))
+            .stdout(Stdio::from(slave.try_clone().expect("dup")))
+            .stderr(Stdio::from(slave));
+        // `login` must be a session leader with the slave as its controlling
+        // tty; a plain spawn would leave it in the test's session.
+        let child = shadow_core::process::spawn_with_controlling_tty(&mut cmd, 0).expect("spawn");
+        // The pre_exec above claimed fd 0, which is the slave after the
+        // redirections; the raw fd is only needed to satisfy the signature.
+        let _ = cmd.get_program();
+        Session {
+            master,
+            child,
+            buf: String::new(),
+        }
+    }
+
+    /// Read until `needle` shows up, or the deadline passes. Returns what
+    /// was read up to and including the needle.
+    fn expect(&mut self, needle: &str, timeout: Duration) -> String {
+        let deadline = Instant::now() + timeout;
+        loop {
+            if let Some(pos) = self.buf.find(needle) {
+                let end = pos + needle.len();
+                let got: String = self.buf.drain(..end).collect();
+                return got;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "timed out waiting for {needle:?}; had {:?}",
+                self.buf
+            );
+            let mut chunk = [0u8; 4096];
+            // Non-blocking read with a short poll.
+            let mut fds = [rustix::event::PollFd::new(
+                &self.master,
+                rustix::event::PollFlags::IN,
+            )];
+            let _ = rustix::event::poll(&mut fds, Some(&millis(200)));
+            match rustix::io::read(&self.master, &mut chunk) {
+                Ok(0) | Err(rustix::io::Errno::AGAIN) => {}
+                Ok(n) => self.buf.push_str(&String::from_utf8_lossy(&chunk[..n])),
+                // EIO on a pty master means the slave side closed: session over.
+                Err(rustix::io::Errno::IO) => {
+                    assert!(
+                        self.buf.contains(needle),
+                        "session ended before {needle:?}; had {:?}",
+                        self.buf
+                    );
+                }
+                Err(e) => panic!("read from pty: {e}"),
+            }
+        }
+    }
+
+    fn send(&mut self, line: &str) {
+        let mut f = std::fs::File::from(self.master.try_clone().expect("dup"));
+        f.write_all(line.as_bytes()).expect("write");
+        f.write_all(b"\n").expect("write");
+    }
+
+    /// Wait for the tool to exit, draining output meanwhile.
+    fn finish(mut self, timeout: Duration) -> (i32, String) {
+        let deadline = Instant::now() + timeout;
+        loop {
+            if let Ok(Some(status)) = self.child.try_wait() {
+                let mut rest = String::new();
+                let mut f = std::fs::File::from(self.master.try_clone().expect("dup"));
+                let mut fds = [rustix::event::PollFd::new(
+                    &self.master,
+                    rustix::event::PollFlags::IN,
+                )];
+                if rustix::event::poll(&mut fds, Some(&millis(100))).is_ok() {
+                    let _ = f.read_to_string(&mut rest);
+                }
+                self.buf.push_str(&rest);
+                return (status.code().unwrap_or(-1), std::mem::take(&mut self.buf));
+            }
+            assert!(
+                Instant::now() < deadline,
+                "login did not exit; had {:?}",
+                self.buf
+            );
+            let mut chunk = [0u8; 4096];
+            let mut fds = [rustix::event::PollFd::new(
+                &self.master,
+                rustix::event::PollFlags::IN,
+            )];
+            let _ = rustix::event::poll(&mut fds, Some(&millis(100)));
+            if let Ok(n) = rustix::io::read(&self.master, &mut chunk) {
+                self.buf.push_str(&String::from_utf8_lossy(&chunk[..n]));
+            }
+        }
+    }
+}
+
+impl Drop for Session {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+const PASSWORD: &str = "pw-for-login-tests";
+
+/// Create a test account with a home, a known password and a shell.
+///
+/// The name carries the test's tag and this process's pid: the tests run in
+/// parallel and the suite runs more than once per `make check`, and a shell
+/// from an earlier session may still be winding down under the old name,
+/// which makes `userdel` refuse and `useradd` report the name in use.
+///
+/// Under the full suite the account files are contended by dozens of tests
+/// at once, and `useradd` gives up after the same 15 seconds the GNU tool
+/// does. That timeout is right for a tool and wrong for a harness that only
+/// wants an account to exist, so the wait is repeated -- on that failure and
+/// no other.
+fn ensure_account(tag: &str) -> String {
+    let user = format!("{tag}_{}", std::process::id());
+    // Either lock can be the one that timed out: the per-file `.lock` or the
+    // suite-wide `/etc/.pwd.lock`.
+    let contended = |stderr: &str| stderr.contains("timed out") && stderr.contains("lock");
+
+    let mut out = run("useradd", &["-m", "-s", "/bin/sh", &user]);
+    for _ in 0..4 {
+        if out.code == 0 || !contended(&out.stderr) {
+            break;
+        }
+        std::thread::sleep(Duration::from_secs(2));
+        out = run("useradd", &["-m", "-s", "/bin/sh", &user]);
+    }
+    assert_eq!(out.code, 0, "useradd {user} failed: {}", out.stderr);
+
+    for attempt in 0..5 {
+        let mut cmd = crate::common::tool("chpasswd");
+        cmd.stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+        let mut child = cmd.spawn().expect("chpasswd");
+        child
+            .stdin
+            .take()
+            .expect("stdin")
+            .write_all(format!("{user}:{PASSWORD}\n").as_bytes())
+            .expect("write");
+        let out = child.wait_with_output().expect("wait");
+        if out.status.success() {
+            return user;
+        }
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        assert!(
+            contended(&stderr) && attempt < 4,
+            "chpasswd failed: {stderr}"
+        );
+        std::thread::sleep(Duration::from_secs(2));
+    }
+    user
+}
+
+/// Best-effort removal once a test is done; a shell still winding down makes
+/// this fail harmlessly, and the name is never reused.
+fn remove_account(user: &str) {
+    let _ = run("userdel", &["-r", user]);
+}
+
+/// The prompt names the host unless -H asks otherwise.
+fn hostname() -> String {
+    std::fs::read_to_string("/proc/sys/kernel/hostname")
+        .unwrap_or_default()
+        .trim()
+        .to_string()
+}
+
+// ---------------------------------------------------------------------------
+// Paths that need no terminal
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_help_exits_zero() {
+    run("login", &["--help"])
+        .assert_code(0)
+        .assert_stdout_contains("Usage:");
+}
+
+/// `-f` without a name is a usage error in shadow's login and is treated as
+/// one here, before any prompt.
+#[test]
+fn test_f_needs_a_name() {
+    if skip_unless_root() {
+        return;
+    }
+    run("login", &["-f"])
+        .assert_code(1)
+        .assert_stderr_contains("requires a user name");
+}
+
+/// Without a controlling terminal there is nothing to log in on.
+#[cfg(feature = "pam")]
+#[test]
+fn test_no_terminal_is_refused() {
+    if skip_unless_root() {
+        return;
+    }
+    run("login", &["-f", "root"])
+        .assert_code(1)
+        .assert_stderr_contains("terminal");
+}
+
+/// Without PAM there is no way to authenticate, and the applet says so rather
+/// than pretending. The static musl archive is built this way.
+#[cfg(not(feature = "pam"))]
+#[test]
+fn test_without_pam_login_refuses_clearly() {
+    if skip_unless_root() {
+        return;
+    }
+    let s = Session::start(&["-f", "root"], &[]);
+    let (code, out) = s.finish(Duration::from_secs(10));
+    assert_eq!(code, 1);
+    assert!(out.contains("PAM support is not compiled in"), "{out:?}");
+}
+
+// ---------------------------------------------------------------------------
+// Sessions on a pty -- these need a PAM stack
+// ---------------------------------------------------------------------------
+
+/// getty autologin: no prompt, a login shell as the user, in their home, with
+/// a login environment and the terminal handed over.
+#[cfg(feature = "pam")]
+#[test]
+fn test_f_starts_a_login_shell_as_the_user() {
+    if skip_unless_root() {
+        return;
+    }
+    let user = ensure_account("lg_shell");
+    let user = user.as_str();
+    let mut s = Session::start(&["-f", user], &[]);
+    s.expect("$ ", Duration::from_secs(10));
+    // The terminal echoes what is typed, so the marker is split in the
+    // command and whole only in the output.
+    s.send(
+        "printf 'O''UT U=%s UID=%s HOME=%s USER=%s LOGNAME=%s SHELL=%s PWD=%s ARGV0=%s\\n' \
+         \"$(id -un)\" \"$(id -u)\" \"$HOME\" \"$USER\" \"$LOGNAME\" \"$SHELL\" \"$PWD\" \"$0\"",
+    );
+    s.expect("OUT ", Duration::from_secs(5));
+    let out = s.expect("\n", Duration::from_secs(5));
+    assert!(out.contains(&format!("U={user} UID=")), "{out:?}");
+    assert!(
+        out.contains(&format!(
+            "HOME=/home/{user} USER={user} LOGNAME={user} SHELL=/bin/sh PWD=/home/{user}"
+        )),
+        "{out:?}"
+    );
+    s.send("stat -c '%U %a' $(tty); exit");
+    let (code, rest) = s.finish(Duration::from_secs(10));
+    assert!(
+        rest.contains(&format!("{user} 600")),
+        "the terminal was not handed over: {rest:?}"
+    );
+    assert_eq!(code, 0, "login exits 0 when the shell exits");
+    remove_account(user);
+}
+
+/// The environment of the caller is discarded -- except what the terminal
+/// provides -- unless -p asks to keep it.
+#[cfg(feature = "pam")]
+#[test]
+fn test_environment_dropped_unless_p() {
+    if skip_unless_root() {
+        return;
+    }
+    let user = ensure_account("lg_env");
+    let user = user.as_str();
+    let mut s = Session::start(&["-f", user], &[("PROBEVAR", "leaked"), ("TERM", "vt100")]);
+    s.expect("$ ", Duration::from_secs(10));
+    s.send("echo PROBEVAR=[$PROBEVAR] TERM=[$TERM]; exit");
+    let (_, out) = s.finish(Duration::from_secs(10));
+    assert!(out.contains("PROBEVAR=[] TERM=[vt100]"), "{out:?}");
+
+    let mut s = Session::start(&["-p", "-f", user], &[("PROBEVAR", "kept")]);
+    s.expect("$ ", Duration::from_secs(10));
+    s.send("echo PROBEVAR=[$PROBEVAR]; exit");
+    let (_, out) = s.finish(Duration::from_secs(10));
+    assert!(out.contains("PROBEVAR=[kept]"), "{out:?}");
+    remove_account(user);
+}
+
+/// The password path: the prompt carries the hostname, a wrong password gets
+/// "Login incorrect" and another prompt, the right one gets a shell.
+#[cfg(feature = "pam")]
+#[test]
+fn test_wrong_then_right_password() {
+    if skip_unless_root() {
+        return;
+    }
+    let user = ensure_account("lg_pw");
+    let user = user.as_str();
+    let mut s = Session::start(&[], &[]);
+    let prompt = s.expect("login: ", Duration::from_secs(10));
+    assert!(
+        prompt.contains(&hostname()),
+        "the prompt should name the host: {prompt:?}"
+    );
+    s.send(user);
+    s.expect("assword:", Duration::from_secs(10));
+    s.send("not-the-password");
+    s.expect("Login incorrect", Duration::from_secs(15));
+    s.expect("login: ", Duration::from_secs(10));
+    s.send(user);
+    s.expect("assword:", Duration::from_secs(10));
+    s.send(PASSWORD);
+    s.expect("$ ", Duration::from_secs(15));
+    s.send("id -un; exit");
+    let (code, out) = s.finish(Duration::from_secs(10));
+    assert!(out.contains(user), "{out:?}");
+    assert_eq!(code, 0);
+    remove_account(user);
+}
+
+/// An unknown name is asked for a password all the same, and answered with
+/// the same words as a wrong one: nothing tells accounts apart.
+#[cfg(feature = "pam")]
+#[test]
+fn test_unknown_user_is_indistinguishable() {
+    if skip_unless_root() {
+        return;
+    }
+    let mut s = Session::start(&["-H"], &[]);
+    let prompt = s.expect("login: ", Duration::from_secs(10));
+    assert!(
+        !prompt.contains(&hostname()),
+        "-H must suppress the hostname: {prompt:?}"
+    );
+    s.send("no_such_user_lg");
+    s.expect("assword:", Duration::from_secs(10));
+    s.send("anything");
+    s.expect("Login incorrect", Duration::from_secs(15));
+}
+
+/// After `LOGIN_RETRIES` failures login gives up and exits 1.
+#[cfg(feature = "pam")]
+#[test]
+fn test_gives_up_after_the_retries() {
+    if skip_unless_root() {
+        return;
+    }
+    let user = ensure_account("lg_retry");
+    let user = user.as_str();
+    let retries = shadow_core::login_defs::LoginDefs::load(std::path::Path::new("/etc/login.defs"))
+        .ok()
+        .and_then(|d| d.get_i64("LOGIN_RETRIES"))
+        .unwrap_or(3);
+    let mut s = Session::start(&["-H"], &[]);
+    for _ in 0..retries {
+        s.expect("login: ", Duration::from_secs(10));
+        s.send(user);
+        s.expect("assword:", Duration::from_secs(10));
+        s.send("wrong");
+        s.expect("Login incorrect", Duration::from_secs(15));
+    }
+    let (code, _) = s.finish(Duration::from_secs(15));
+    assert_eq!(code, 1);
+    remove_account(user);
+}
+
+/// An account whose home is gone still gets a session, in `/`, with a notice.
+#[cfg(feature = "pam")]
+#[test]
+fn test_missing_home_falls_back_to_root_directory() {
+    if skip_unless_root() {
+        return;
+    }
+    let user = ensure_account("lg_nohome");
+    let user = user.as_str();
+    std::fs::remove_dir_all(format!("/home/{user}")).expect("remove home");
+    let mut s = Session::start(&["-f", user], &[]);
+    s.expect(
+        "No directory, logging in with HOME=/",
+        Duration::from_secs(10),
+    );
+    s.expect("$ ", Duration::from_secs(10));
+    s.send("echo HOME=$HOME PWD=$PWD; exit");
+    let (_, out) = s.finish(Duration::from_secs(10));
+    assert!(out.contains("HOME=/ PWD=/"), "{out:?}");
+    remove_account(user);
+}
+
+/// The login is recorded where `who` looks, and the logout clears it.
+#[cfg(feature = "pam")]
+#[test]
+fn test_login_is_recorded_in_utmp() {
+    if skip_unless_root() {
+        return;
+    }
+    if !std::path::Path::new("/var/run/utmp").exists()
+        && !std::path::Path::new("/run/utmp").exists()
+    {
+        // No utmp on this system: nothing to record into, which is allowed.
+        return;
+    }
+    let user = ensure_account("lg_utmp");
+    let user = user.as_str();
+    let mut s = Session::start(&["-h", "probe.example", "-f", user], &[]);
+    s.expect("$ ", Duration::from_secs(10));
+    s.send("who; exit");
+    let (_, out) = s.finish(Duration::from_secs(10));
+    assert!(
+        out.contains(user) && out.contains("probe.example"),
+        "utmp should carry the login and the host: {out:?}"
+    );
+    remove_account(user);
+}

--- a/tests/by-util/test_multicall.rs
+++ b/tests/by-util/test_multicall.rs
@@ -16,7 +16,7 @@ use std::process::Command;
 use crate::common::{run, run_cmd};
 
 /// Every applet this build is expected to carry, in `--list` order.
-const TOOLS: [&str; 24] = [
+const TOOLS: [&str; 25] = [
     "chage",
     "chfn",
     "chgpasswd",
@@ -29,6 +29,7 @@ const TOOLS: [&str; 24] = [
     "grpck",
     "grpconv",
     "grpunconv",
+    "login",
     "newgrp",
     "newusers",
     "passwd",

--- a/tests/by-util/test_useradd.rs
+++ b/tests/by-util/test_useradd.rs
@@ -775,3 +775,41 @@ fn test_base_dir_flag_and_uid_sentinel() {
     );
     assert!(!read_passwd(&dir).contains("bad:"), "nothing written");
 }
+
+/// Every account file is locked before any is written. A shadow file that
+/// cannot be opened -- here, a directory in its place -- has to fail the
+/// whole creation with `/etc/passwd` untouched, not leave a passwd line
+/// whose shadow line never came: that half-made account is what a second
+/// `useradd` then reports as already existing.
+#[test]
+fn test_unusable_shadow_file_leaves_passwd_untouched() {
+    if crate::common::skip_unless_root() {
+        return;
+    }
+    let dir = tempfile::tempdir().expect("tempdir");
+    let etc = dir.path().join("etc");
+    std::fs::create_dir_all(&etc).expect("etc");
+    std::fs::write(etc.join("passwd"), "root:x:0:0:root:/root:/bin/sh\n").expect("passwd");
+    std::fs::write(etc.join("group"), "root:x:0:\n").expect("group");
+    std::fs::write(etc.join("login.defs"), "UID_MIN 1000\nGID_MIN 1000\n").expect("defs");
+    std::fs::create_dir(etc.join("shadow")).expect("a directory where the shadow file goes");
+
+    let out = crate::common::run(
+        "useradd",
+        &[
+            "--prefix",
+            dir.path().to_str().expect("utf8"),
+            "-M",
+            "halfmade",
+        ],
+    );
+    assert_ne!(
+        out.code, 0,
+        "useradd must fail when shadow cannot be written"
+    );
+    let passwd = std::fs::read_to_string(etc.join("passwd")).expect("read");
+    assert!(
+        !passwd.contains("halfmade"),
+        "passwd was written although shadow could not be: {passwd:?}"
+    );
+}

--- a/tests/e2e/deploy-test.sh
+++ b/tests/e2e/deploy-test.sh
@@ -100,13 +100,13 @@ hash_password() {
 
 # ── TOOLS list ──────────────────────────────────────────────────────
 
-TOOLS="passwd pwck useradd userdel usermod chpasswd chgpasswd newusers chage groupadd groupdel groupmod gpasswd grpck chfn chsh newgrp sg vipw vigr pwconv pwunconv grpconv grpunconv"
+TOOLS="passwd pwck useradd userdel usermod chpasswd chgpasswd newusers chage groupadd groupdel groupmod gpasswd grpck chfn chsh newgrp sg vipw vigr pwconv pwunconv grpconv grpunconv login"
 SETUID_TOOLS="passwd chfn chsh newgrp gpasswd sg"
 
 # The tools an unprivileged user runs are installed in bin, the rest in sbin,
 # which is the split the GNU package uses: sbin is not on a normal user's
 # PATH, so `passwd` there would be "command not found".
-USER_TOOLS="$SETUID_TOOLS chage"
+USER_TOOLS="$SETUID_TOOLS chage login"
 BINDIR="/usr/sbin"
 USER_BINDIR="/usr/bin"
 
@@ -869,6 +869,73 @@ test_gpasswd_group_admin() {
     userdel -r gp_member 2>/dev/null || true
 }
 
+# ── login: a session on a terminal ─────────────────────────────────
+
+test_login() {
+    section "login — a session on a terminal"
+
+    if ! command -v python3 >/dev/null 2>&1; then
+        echo -e "  ${YELLOW}⊘${NC} python3 not available, skipping the pty-driven checks"
+        return
+    fi
+    userdel -r lg_e2e 2>/dev/null || true
+    assert_ok "useradd -m lg_e2e" useradd -m -s /bin/sh lg_e2e
+    assert_ok "set a password" bash -c "printf 'lg_e2e:e2epw\n' | chpasswd"
+
+    # Drive login the way getty would: on a fresh pty, as session leader,
+    # answering each prompt only once it has appeared.
+    cat > /tmp/drive_login.py <<'PYDRV'
+import os, pty, select, sys, time
+def run(argv, steps, timeout=40):
+    pid, fd = pty.fork()
+    if pid == 0:
+        os.environ["TERM"] = "dumb"; os.execvp(argv[0], argv)
+    buf = b""; i = 0; t0 = time.time(); seen = b""
+    while time.time() - t0 < timeout:
+        r, _, _ = select.select([fd], [], [], 0.2)
+        if r:
+            try:
+                chunk = os.read(fd, 4096)
+            except OSError:
+                break
+            buf += chunk; seen += chunk
+        if i < len(steps) and steps[i][0].encode() in buf:
+            os.write(fd, steps[i][1].encode() + b"\n"); buf = b""; i += 1
+        if i == len(steps) and steps and steps[-1][1].endswith("exit"):
+            done, _ = os.waitpid(pid, os.WNOHANG)
+            if done:
+                break
+    try:
+        os.kill(pid, 9)
+    except ProcessLookupError:
+        pass
+    try:
+        os.waitpid(pid, 0)
+    except ChildProcessError:
+        pass
+    sys.stdout.write(seen.decode(errors="replace"))
+case = sys.argv[1]
+if case == "autologin":
+    run(["login", "-f", "lg_e2e"], [("$ ", "printf 'O''UT %s %s %s\\n' \"$(id -un)\" \"$HOME\" \"$0\"; exit")])
+elif case == "password":
+    run(["login", "-H"], [("login: ", "lg_e2e"), ("assword:", "wrong"), ("login: ", "lg_e2e"), ("assword:", "e2epw"), ("$ ", "printf 'O''UT %s\\n' \"$(id -un)\"; exit")])
+elif case == "unknown":
+    run(["login", "-H"], [("login: ", "nobody_here_e2e"), ("assword:", "x")], timeout=12)
+PYDRV
+    assert_contains "autologin gives a login shell as the user, in the home" \
+        "OUT lg_e2e /home/lg_e2e -sh" python3 /tmp/drive_login.py autologin
+    assert_contains "a wrong password is refused and the right one accepted" \
+        "OUT lg_e2e" python3 /tmp/drive_login.py password
+    assert_contains "an unknown user gets the same answer as a wrong password" \
+        "Login incorrect" python3 /tmp/drive_login.py unknown
+    assert_fail "login refuses to run as a normal user" \
+        su -s /bin/bash lg_e2e -c "login -f root"
+    assert_fail "login refuses without a terminal" bash -c "login -f root </dev/null"
+
+    userdel -r lg_e2e 2>/dev/null || true
+    rm -f /tmp/drive_login.py
+}
+
 # ── pwconv family: shadow round trips ──────────────────────────────
 
 test_pwconv_family() {
@@ -1279,6 +1346,7 @@ main() {
     test_newusers
     test_vipw
     test_pwconv_family
+    test_login
     test_aging_and_input
     test_audit_logging
     test_root_option

--- a/tests/gnu-compat.sh
+++ b/tests/gnu-compat.sh
@@ -232,6 +232,7 @@ for pair in \
     "pwunconv:/usr/sbin/pwunconv" \
     "grpconv:/usr/sbin/grpconv" \
     "grpunconv:/usr/sbin/grpunconv" \
+    "login:/usr/bin/login" \
     "gpasswd:/usr/bin/gpasswd" \
     "pwck:/usr/sbin/pwck" \
     "grpck:/usr/sbin/grpck"; do

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -40,6 +40,8 @@ mod test_groupdel;
 mod test_groupmod;
 #[path = "by-util/test_grpck.rs"]
 mod test_grpck;
+#[path = "by-util/test_login.rs"]
+mod test_login;
 #[path = "by-util/test_multicall.rs"]
 mod test_multicall;
 #[path = "by-util/test_newgrp.rs"]


### PR DESCRIPTION
Adds `login`, the twenty-fifth tool — what getty runs on a terminal — and, in two commits before it, fixes the two defects that writing its tests under load exposed.

Stacked on #296. Base retargets to `main` as the stack merges.

## Which `login`

Debian 13 and Ubuntu 25.10 take `login` from util-linux; every release in service — Ubuntu 20.04, 22.04, 24.04, Debian 12 — ships shadow's. Both were driven side by side on real pseudo-terminals (never read: package metadata, `--help`, man pages, behaviour). They agree on everything that matters. This implements the option set they share plus util-linux's `-H` and `--help`; `-r` (rlogin) is refused; util-linux's `vhangup` is not reproduced, as shadow's does not do it either.

## What it does

Prompt → PAM `login` service → account checks → `setcred` → `open_session` (and its environment) → utmp/wtmp → terminal handed over (`TTYGROUP`/`TTYPERM`) → login shell as the user, in the home or `/` with a notice → on exit, `close_session` and the logout record. A wrong password and an unknown name get the same words after the same delay. The shell is a child, not an exec, so the session can be closed; it gets a clean signal mask and `login` keeps its own; groups, gid and uid drop in that order in one `pre_exec`.

Without the `pam` feature the applet says so and exits 1: a login that cannot authenticate is not a login.

## The two fixes it forced (commits 1 and 2)

**`shadow-core`: lock order.** `FileLock` took the per-file `.lock` first and `/etc/.pwd.lock` second. Two tools on different files could deadlock until both timed out. Sampling the lock files during the suite showed a `chpasswd` holding `shadow.lock` for 28 s and a `useradd` holding `passwd`/`group`/`gshadow` for 14 s, each waiting on the other. `.pwd.lock` now comes first — the `lckpwdf(3)` order, the only one that cannot deadlock. Suite back from 35–50 s with failures to 17 s, three clean runs in a row.

**`useradd`: a half-made account.** It committed `passwd` and the group files, then opened `/etc/shadow` on its own; a late lock timeout left a passwd line with no shadow line. The shadow file is now locked with the others and written first. Regression test: a directory where `shadow` should be → `useradd` fails with `passwd` untouched.

## Verification

| | |
|---|---|
| `make check` | fmt, clippy ×3, tests ±`pam`, unprivileged run — exit 0 |
| `cargo test --workspace` | alpine 892 / fedora 882, 0 failed |
| full PAM suite, 3 consecutive runs | 321 passed each, ~17 s |
| e2e deployment suite | 368 assertions, including the password path on a pty |
| `make test-gnu-compat` | 52 comparisons |
| `make test-arm64` | 32 assertions under emulation |
