### PR TITLE
newuidmap, newgidmap: set the id maps of a user namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `newuidmap` and `newgidmap`, tools twenty-six and twenty-seven: the setuid
+  helpers that write a user namespace's `uid_map` and `gid_map`, which is what
+  Podman and rootless Docker call for every container they start. The caller
+  must own the target process and every requested range must lie inside a
+  range granted to them in `/etc/subuid` or `/etc/subgid` -- by login name or
+  by numeric uid -- except their own id mapped once, which the kernel already
+  allows an unprivileged process; root is exempt from neither, as
+  newuidmap(1) says. Ranges that overlap are refused by name rather than left
+  to the kernel's bare `EINVAL`. The map file is opened through a descriptor
+  held on `/proc/<pid>`, so a pid recycled between the check and the write
+  cannot redirect it; the `fd:N` form takes such a descriptor from the caller.
+  The tests write into a real namespace and read the kernel's map back
+
 - `login`, the twenty-fifth tool and the one `uutils/login` was archived
   towards: what getty runs on a terminal. It prompts for a name and, through
   the `login` PAM service, a password; refuses after `LOGIN_RETRIES` failures

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -835,12 +835,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "uu_newgidmap"
+version = "0.4.0"
+dependencies = [
+ "clap",
+ "uu_newuidmap",
+ "uucore",
+]
+
+[[package]]
 name = "uu_newgrp"
 version = "0.4.0"
 dependencies = [
  "clap",
  "rustix",
  "shadow-core",
+ "uucore",
+]
+
+[[package]]
+name = "uu_newuidmap"
+version = "0.4.0"
+dependencies = [
+ "clap",
+ "rustix",
+ "shadow-core",
+ "tempfile",
  "uucore",
 ]
 
@@ -927,7 +947,9 @@ dependencies = [
  "uu_grpconv",
  "uu_grpunconv",
  "uu_login",
+ "uu_newgidmap",
  "uu_newgrp",
+ "uu_newuidmap",
  "uu_newusers",
  "uu_passwd",
  "uu_pwck",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,8 @@ members = [
     "src/uu/grpconv",
     "src/uu/grpunconv",
     "src/uu/login",
+    "src/uu/newuidmap",
+    "src/uu/newgidmap",
 ]
 
 [workspace.package]
@@ -112,12 +114,15 @@ pwunconv = { optional = true, version = "0.4.0", package = "uu_pwunconv", path =
 grpconv = { optional = true, version = "0.4.0", package = "uu_grpconv", path = "src/uu/grpconv" }
 grpunconv = { optional = true, version = "0.4.0", package = "uu_grpunconv", path = "src/uu/grpunconv" }
 login = { optional = true, version = "0.4.0", package = "uu_login", path = "src/uu/login" }
+newuidmap = { optional = true, version = "0.4.0", package = "uu_newuidmap", path = "src/uu/newuidmap" }
+newgidmap = { optional = true, version = "0.4.0", package = "uu_newgidmap", path = "src/uu/newgidmap" }
 
 [features]
 default = ["passwd", "pwck", "useradd", "userdel", "usermod", "chpasswd", "chage",
            "groupadd", "groupdel", "groupmod", "grpck", "chfn", "chsh", "newgrp", "gpasswd",
            "sg", "chgpasswd", "newusers", "vipw", "vigr",
-           "pwconv", "pwunconv", "grpconv", "grpunconv", "login"]
+           "pwconv", "pwunconv", "grpconv", "grpunconv", "login", "newuidmap",
+           "newgidmap"]
 
 # PAM authentication (requires libpam-dev). The `?` matters: without it,
 # asking for PAM would drag in the three applets that can use it even when the
@@ -162,6 +167,8 @@ pwunconv = { version = "0.4.0", package = "uu_pwunconv", path = "src/uu/pwunconv
 grpconv = { version = "0.4.0", package = "uu_grpconv", path = "src/uu/grpconv" }
 grpunconv = { version = "0.4.0", package = "uu_grpunconv", path = "src/uu/grpunconv" }
 login = { version = "0.4.0", package = "uu_login", path = "src/uu/login" }
+newuidmap = { version = "0.4.0", package = "uu_newuidmap", path = "src/uu/newuidmap" }
+newgidmap = { version = "0.4.0", package = "uu_newgidmap", path = "src/uu/newgidmap" }
 passwd = { version = "0.4.0", package = "uu_passwd", path = "src/uu/passwd" }
 useradd = { version = "0.4.0", package = "uu_useradd", path = "src/uu/useradd" }
 userdel = { version = "0.4.0", package = "uu_userdel", path = "src/uu/userdel" }

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ SBINDIR ?= $(PREFIX)/sbin
 
 # Tools that need setuid-root to allow non-root callers (change own password,
 # GECOS, shell, effective group, or administer a group as a group admin).
-SETUID_TOOLS = passwd chfn chsh newgrp gpasswd sg
+SETUID_TOOLS = passwd chfn chsh newgrp gpasswd sg newuidmap newgidmap
 
 # Root-only tools (no setuid; fail at getuid() check for non-root callers).
 ROOT_TOOLS = useradd userdel usermod chpasswd chgpasswd newusers \
@@ -137,7 +137,7 @@ test-unprivileged:
 test-gnu-compat:
 	bash tests/gnu-compat.sh
 
-# Default install: 25 standalone per-tool binaries, with the setuid layout and
+# Default install: 27 standalone per-tool binaries, with the setuid layout and
 # the bin/sbin split GNU shadow-utils uses. Only $(SETUID_TOOLS) are setuid.
 install: build
 	@for tool in $(SETUID_TOOLS); do \

--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ default-in-Ubuntu in under 3 years. This project follows that playbook.
 | `grpconv` | **Implemented.** `pwconv` for group and gshadow. |
 | `grpunconv` | **Implemented.** `pwunconv` for group and gshadow. |
 | `login` | **Implemented.** What getty runs: prompts, PAM authentication and session, utmp/wtmp, terminal handover, a login shell. Needs the `pam` feature. |
+| `newuidmap` | **Implemented.** Writes a user namespace's `uid_map` within the caller's `/etc/subuid` grant; what rootless containers call. |
+| `newgidmap` | **Implemented.** `newuidmap` for `gid_map` and `/etc/subgid`. |
 
 ## Scope
 
@@ -93,7 +95,7 @@ implemented. Of the rest:
 |---|---|
 | `login` | shipped. Debian 13 and Ubuntu 25.10 take `login` from util-linux, but every release in service today — Ubuntu 20.04, 22.04 and 24.04, Debian 12 — ships shadow's, and `uutils/login` was archived pointing here. It implements the option set the two share, plus util-linux's `-H` |
 | `expiry`, `groupmems` | Debian's tail; in scope, not yet shipped. `faillog` and `lastlog` left the Debian package with 13 and are not planned |
-| `newuidmap`, `newgidmap` | Fedora's pair, the basis of rootless containers; in scope, not yet shipped |
+| `newuidmap`, `newgidmap` | shipped. Fedora's pair, the basis of rootless containers |
 | `shadowconfig`, `cpgr`, `cppw`, `adduser` | Debian packaging scripts and a Fedora symlink, not upstream tools; out of scope |
 
 Three tools that the GNU suite ships are provided by other projects in this
@@ -145,9 +147,9 @@ docker compose run --rm debian cargo build --release
 
 ### Install
 
-Default install: 25 standalone per-tool binaries with least-privilege setuid
+Default install: 27 standalone per-tool binaries with least-privilege setuid
 layout matching GNU shadow-utils. Only `passwd`, `chfn`, `chsh`, `newgrp`,
-`gpasswd` and `sg` are installed setuid-root; the other 19 are plain `0755`.
+`gpasswd`, `sg`, `newuidmap` and `newgidmap` are installed setuid-root; the other 19 are plain `0755`.
 
 ```shell
 sudo make install PREFIX=/usr/local
@@ -155,7 +157,7 @@ sudo make install PREFIX=/usr/local
 
 Alternative: single multicall binary with symlinks. Smaller footprint (~15×
 disk savings). The binary is installed setuid-root so that `passwd`, `chfn`,
-`chsh`, `newgrp`, `gpasswd` and `sg` can serve unprivileged callers; every other
+`chsh`, `newgrp`, `gpasswd`, `sg`, `newuidmap` and `newgidmap` can serve unprivileged callers; every other
 applet drops back to the caller's uid before it runs, so the privilege model
 is the same as the per-tool layout. Intended for container/embedded use cases.
 
@@ -200,7 +202,7 @@ sudo install -o root -g root -m 4755 \
     uu_shadow-*/shadow-rs /usr/local/bin/shadow-rs
 for tool in passwd chfn chsh newgrp gpasswd sg chage chpasswd chgpasswd newusers \
             groupadd groupdel groupmod grpck pwck useradd userdel usermod vipw vigr \
-            pwconv pwunconv grpconv grpunconv login; do
+            pwconv pwunconv grpconv grpunconv login newuidmap newgidmap; do
     sudo ln -sf shadow-rs "/usr/local/bin/$tool"
 done
 ```

--- a/docker/Dockerfile.debian
+++ b/docker/Dockerfile.debian
@@ -12,6 +12,8 @@ FROM rust:1.98-trixie
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     libpam0g-dev \
+    # uidmap: GNU newuidmap/newgidmap, for tests/gnu-compat.sh
+    uidmap \
     libselinux1-dev \
     libaudit-dev \
     pkg-config \

--- a/docs/PLATFORM-SUPPORT.md
+++ b/docs/PLATFORM-SUPPORT.md
@@ -86,6 +86,9 @@ Effect, and this is the heaviest of the three gaps:
   than apply an unverified one, so without PAM they refuse every non-root
   invocation outright.
 
+`newuidmap` and `newgidmap` need neither PAM nor NSS beyond `getpwuid_r` for
+the caller, and work in the static build.
+
 `login` is the fourth: without PAM it has no way to authenticate, so the
 applet prints *PAM support is not compiled in* and exits 1. A static image
 that needs a getty-driven login must use the glibc archive. utmp and wtmp

--- a/docs/SECURITY-HARDENING.md
+++ b/docs/SECURITY-HARDENING.md
@@ -8,7 +8,7 @@ Techniques adopted from OpenBSD and best practices for setuid-root tools.
 
 - [x] `caller_is_root()` uses `getuid()` not `geteuid()` for authorization
 - [x] In the multicall layout, an applet outside
-      `passwd`/`chfn`/`chsh`/`newgrp`/`gpasswd`/`sg`
+      `passwd`/`chfn`/`chsh`/`newgrp`/`gpasswd`/`sg`/`newuidmap`/`newgidmap`
       drops to the caller's uid before running, so the single setuid binary has
       the same privilege model as the per-tool install — and fails closed if the
       kernel will not take the privilege away

--- a/docs/man/newgidmap.1.md
+++ b/docs/man/newgidmap.1.md
@@ -1,0 +1,15 @@
+# newgidmap(1) - set the group ID mapping of a user namespace
+
+## NAME
+
+newgidmap - see **newuidmap**(1)
+
+## DESCRIPTION
+
+**newgidmap** is **newuidmap**(1) writing /proc/*pid*/gid_map against
+/etc/subgid. Everything — the checks, the descriptor-bound write, the
+**fd:***N* form, the exit status — is described there.
+
+## SEE ALSO
+
+newuidmap(1), subgid(5), user_namespaces(7)

--- a/docs/man/newuidmap.1.md
+++ b/docs/man/newuidmap.1.md
@@ -1,0 +1,96 @@
+# newuidmap(1) - set the user ID mapping of a user namespace
+
+## NAME
+
+newuidmap, newgidmap - set the user or group ID mapping of a user namespace
+
+## SYNOPSIS
+
+**newuidmap** [*pid*|**fd:***N*] *uid* *loweruid* *count* [*uid* *loweruid* *count* ...]
+
+**newgidmap** [*pid*|**fd:***N*] *gid* *lowergid* *count* [*gid* *lowergid* *count* ...]
+
+## DESCRIPTION
+
+**newuidmap** writes /proc/*pid*/uid_map, the table that says which user IDs
+inside the user namespace of process *pid* correspond to which user IDs
+outside it. Each triple maps *count* IDs starting at *uid* inside the
+namespace onto *count* IDs starting at *loweruid* outside it. **newgidmap**
+does the same for group IDs and /proc/*pid*/gid_map.
+
+The kernel lets an unprivileged process map exactly one ID into a namespace it
+created: its own. Everything beyond that — the range of IDs a container needs
+for its own users and groups — requires the privilege these helpers carry.
+They are installed setuid-root for that, and they hand out that privilege
+only within the ranges the administrator granted the caller in /etc/subuid
+and /etc/subgid. Podman and rootless Docker call them for every container
+they start.
+
+The two are one program with a selector.
+
+## WHAT IS CHECKED
+
+Before anything is written:
+
+- The command line must be a target followed by one or more triples of
+  plain decimal numbers. A count of zero is refused as an overflow, as the
+  GNU helper words it.
+- Every requested outside range [*loweruid*, *loweruid*+*count*) must lie
+  inside one range granted to the caller in /etc/subuid — an entry naming the
+  caller by login name or by numeric UID — **or** be the caller's own ID
+  mapped once. Root is not exempt from the /etc/subuid requirement, as
+  newuidmap(1) has always said.
+- The ranges may not overlap one another, on either side. The kernel refuses
+  overlaps too, with nothing but `EINVAL`; the helper names them.
+- The target process must belong to the caller: the owner of /proc/*pid* must
+  be the caller's real UID and GID, and those must be the caller's account
+  IDs. The message names all three on each side, so an administrator can see
+  which disagrees.
+
+Then the map file is opened *through the directory descriptor of
+/proc/pid* and written in a single write, which is the only form the kernel
+accepts. A namespace's map may be written once; a second attempt is refused
+by the kernel and reported.
+
+## THE fd:N FORM
+
+A caller that has checked the target itself can pass **fd:***N*, a descriptor
+it holds open on /proc/*pid*. The helper works through that descriptor, so a
+process ID recycled between the caller's checks and the write cannot
+redirect it to another process. A descriptor on anything but a /proc/*pid*
+directory is a usage error.
+
+## OPTIONS
+
+**--help**
+:   Display help and exit.
+
+## EXIT STATUS
+
+**0**
+:   The map was written.
+
+**1**
+:   Usage error, a range not granted or overlapping, a target that is not the
+    caller's or cannot be found, or a write the kernel refused. Nothing was
+    written.
+
+## FILES
+
+/etc/subuid, /etc/subgid
+:   The subordinate ID ranges granted to each user.
+
+/proc/*pid*/uid_map, /proc/*pid*/gid_map
+:   The files written.
+
+## DIFFERENCES FROM THE GNU HELPERS
+
+Overlapping ranges are refused with a message naming them; the GNU helper
+passes them to the kernel and reports its `EINVAL`. Numbers must be plain
+decimals: a negative count is a usage error here where the GNU helper folds
+it into the overflow message. Neither changes any outcome the kernel would
+have accepted.
+
+## SEE ALSO
+
+subuid(5), subgid(5), user_namespaces(7), usermod(8), unshare(1)

--- a/src/bin/completions.rs
+++ b/src/bin/completions.rs
@@ -49,8 +49,12 @@ fn get_tool_app(name: &str) -> Option<Command> {
         "grpunconv" => Some(grpunconv::uu_app()),
         #[cfg(feature = "login")]
         "login" => Some(login::uu_app()),
+        #[cfg(feature = "newgidmap")]
+        "newgidmap" => Some(newgidmap::uu_app()),
         #[cfg(feature = "newgrp")]
         "newgrp" => Some(newgrp::uu_app()),
+        #[cfg(feature = "newuidmap")]
+        "newuidmap" => Some(newuidmap::uu_app()),
         #[cfg(feature = "newusers")]
         "newusers" => Some(newusers::uu_app()),
         #[cfg(feature = "passwd")]
@@ -106,8 +110,12 @@ fn all_tool_names() -> Vec<&'static str> {
     names.push("grpunconv");
     #[cfg(feature = "login")]
     names.push("login");
+    #[cfg(feature = "newgidmap")]
+    names.push("newgidmap");
     #[cfg(feature = "newgrp")]
     names.push("newgrp");
+    #[cfg(feature = "newuidmap")]
+    names.push("newuidmap");
     #[cfg(feature = "newusers")]
     names.push("newusers");
     #[cfg(feature = "passwd")]

--- a/src/bin/shadow-rs.rs
+++ b/src/bin/shadow-rs.rs
@@ -11,7 +11,7 @@
 //! # Privileges
 //!
 //! The per-tool install makes only `passwd`, `chfn`, `chsh`, `newgrp`,
-//! `gpasswd` and `sg` setuid-root.
+//! `gpasswd`, `sg`, `newuidmap` and `newgidmap` setuid-root.
 //! A multicall install has to make the one binary setuid, which
 //! would hand euid 0 to every applet — an unprivileged `pwck -s` rewriting
 //! `/etc/passwd`. So before an applet outside that set runs, the binary drops
@@ -25,11 +25,22 @@ use std::process::ExitCode;
 
 type Applet = fn(&[OsString]) -> i32;
 
-/// Applets that keep euid 0 for an unprivileged caller: the same six that
+/// Applets that keep euid 0 for an unprivileged caller: the same eight that
 /// `make install` marks setuid. `sg` is here for the reason `newgrp` is --
 /// it has to read `/etc/gshadow` to check a group password, and the GNU suite
-/// ships it as a symlink to the setuid `newgrp` for exactly that.
-const SETUID_APPLETS: [&str; 6] = ["passwd", "chfn", "chsh", "newgrp", "gpasswd", "sg"];
+/// ships it as a symlink to the setuid `newgrp` for exactly that. The two id
+/// mappers are here because writing a namespace's map beyond the caller's
+/// own id needs `CAP_SETUID`/`CAP_SETGID` in the parent namespace.
+const SETUID_APPLETS: [&str; 8] = [
+    "passwd",
+    "chfn",
+    "chsh",
+    "newgrp",
+    "gpasswd",
+    "sg",
+    "newuidmap",
+    "newgidmap",
+];
 
 /// Every applet compiled into this binary, by name, in `--list` order.
 // `#[cfg]` is not accepted on the elements of a `vec![]` literal, so the
@@ -39,7 +50,7 @@ const SETUID_APPLETS: [&str; 6] = ["passwd", "chfn", "chsh", "newgrp", "gpasswd"
 // nothing, and the binding is then not mutated.
 #[allow(unused_mut)]
 fn applets() -> Vec<(&'static str, Applet)> {
-    let mut table: Vec<(&'static str, Applet)> = Vec::with_capacity(25);
+    let mut table: Vec<(&'static str, Applet)> = Vec::with_capacity(27);
     #[cfg(feature = "chage")]
     table.push(("chage", |a| chage::uumain(a.iter().cloned())));
     #[cfg(feature = "chfn")]
@@ -66,8 +77,12 @@ fn applets() -> Vec<(&'static str, Applet)> {
     table.push(("grpunconv", |a| grpunconv::uumain(a.iter().cloned())));
     #[cfg(feature = "login")]
     table.push(("login", |a| login::uumain(a.iter().cloned())));
+    #[cfg(feature = "newgidmap")]
+    table.push(("newgidmap", |a| newgidmap::uumain(a.iter().cloned())));
     #[cfg(feature = "newgrp")]
     table.push(("newgrp", |a| newgrp::uumain(a.iter().cloned())));
+    #[cfg(feature = "newuidmap")]
+    table.push(("newuidmap", |a| newuidmap::uumain(a.iter().cloned())));
     #[cfg(feature = "newusers")]
     table.push(("newusers", |a| newusers::uumain(a.iter().cloned())));
     #[cfg(feature = "passwd")]
@@ -248,7 +263,7 @@ fn print_available_utils() {
 mod tests {
     use super::*;
 
-    const ALL_TOOLS: [&str; 25] = [
+    const ALL_TOOLS: [&str; 27] = [
         "chage",
         "chfn",
         "chgpasswd",
@@ -262,7 +277,9 @@ mod tests {
         "grpconv",
         "grpunconv",
         "login",
+        "newgidmap",
         "newgrp",
+        "newuidmap",
         "newusers",
         "passwd",
         "pwck",
@@ -297,7 +314,14 @@ mod tests {
                 keeps_privilege(tool),
                 matches!(
                     tool,
-                    "passwd" | "chfn" | "chsh" | "newgrp" | "gpasswd" | "sg"
+                    "passwd"
+                        | "chfn"
+                        | "chsh"
+                        | "newgrp"
+                        | "gpasswd"
+                        | "sg"
+                        | "newuidmap"
+                        | "newgidmap"
                 ),
                 "{tool}"
             );

--- a/src/uu/newgidmap/Cargo.toml
+++ b/src/uu/newgidmap/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "uu_newgidmap"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+categories.workspace = true
+rust-version.workspace = true
+description = "newgidmap ~ (shadow-rs) set the group ID mapping of a user namespace"
+
+[lib]
+path = "src/newgidmap.rs"
+
+[[bin]]
+name = "newgidmap"
+path = "src/main.rs"
+
+[dependencies]
+clap = { workspace = true }
+uucore = { workspace = true }
+# newgidmap is newuidmap writing the other map; one engine, two names.
+uu_newuidmap = { path = "../newuidmap", version = "0.4.0" }
+
+[lints]
+workspace = true
+
+# Distributed via the `shadow-rs` multicall binary in the workspace root
+# package, not as a standalone archive (see dist-workspace.toml, issue #207).
+[package.metadata.dist]
+dist = false

--- a/src/uu/newgidmap/locales/en-US.ftl
+++ b/src/uu/newgidmap/locales/en-US.ftl
@@ -1,0 +1,2 @@
+newgidmap-about = Set the group ID mapping of a user namespace
+newgidmap-usage = newgidmap [<pid>|fd:<pidfd>] <gid> <lowergid> <count> [...]

--- a/src/uu/newgidmap/src/main.rs
+++ b/src/uu/newgidmap/src/main.rs
@@ -1,0 +1,6 @@
+// This file is part of the shadow-rs package.
+//
+// For the full copyright and license information, please view the LICENSE
+// file that was distributed with this source code.
+
+uucore::bin!(uu_newgidmap);

--- a/src/uu/newgidmap/src/newgidmap.rs
+++ b/src/uu/newgidmap/src/newgidmap.rs
@@ -1,0 +1,36 @@
+// This file is part of the shadow-rs package.
+//
+// For the full copyright and license information, please view the LICENSE
+// file that was distributed with this source code.
+// spell-checker:ignore newgidmap newuidmap subgid
+
+//! `newgidmap` — set the group ID mapping of a user namespace.
+//!
+//! The same program as `newuidmap`, writing `gid_map` against `/etc/subgid`;
+//! see `uu_newuidmap`. This crate only names which map.
+
+use clap::Command;
+use uucore::error::UResult;
+
+/// Entry point for the `newgidmap` utility.
+#[uucore::main]
+pub fn uumain(args: impl uucore::Args) -> UResult<()> {
+    uu_newuidmap::run(uu_newuidmap::Tool::Gid, args)
+}
+
+/// Build the clap `Command` for `newgidmap`.
+#[must_use]
+pub fn uu_app() -> Command {
+    uu_newuidmap::app(uu_newuidmap::Tool::Gid)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_app_builds_under_its_own_name() {
+        uu_app().debug_assert();
+        assert_eq!(uu_app().get_name(), "newgidmap");
+    }
+}

--- a/src/uu/newuidmap/Cargo.toml
+++ b/src/uu/newuidmap/Cargo.toml
@@ -1,0 +1,35 @@
+[package]
+name = "uu_newuidmap"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+categories.workspace = true
+rust-version.workspace = true
+description = "newuidmap ~ (shadow-rs) set the user ID mapping of a user namespace"
+
+[lib]
+path = "src/newuidmap.rs"
+
+[[bin]]
+name = "newuidmap"
+path = "src/main.rs"
+
+[dependencies]
+clap = { workspace = true }
+rustix = { workspace = true }
+shadow-core = { workspace = true }
+uucore = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }
+
+[lints]
+workspace = true
+
+# Distributed via the `shadow-rs` multicall binary in the workspace root
+# package, not as a standalone archive (see dist-workspace.toml, issue #207).
+[package.metadata.dist]
+dist = false

--- a/src/uu/newuidmap/locales/en-US.ftl
+++ b/src/uu/newuidmap/locales/en-US.ftl
@@ -1,0 +1,2 @@
+newuidmap-about = Set the user ID mapping of a user namespace
+newuidmap-usage = newuidmap [<pid>|fd:<pidfd>] <uid> <loweruid> <count> [...]

--- a/src/uu/newuidmap/src/main.rs
+++ b/src/uu/newuidmap/src/main.rs
@@ -1,0 +1,6 @@
+// This file is part of the shadow-rs package.
+//
+// For the full copyright and license information, please view the LICENSE
+// file that was distributed with this source code.
+
+uucore::bin!(uu_newuidmap);

--- a/src/uu/newuidmap/src/newuidmap.rs
+++ b/src/uu/newuidmap/src/newuidmap.rs
@@ -1,0 +1,756 @@
+// This file is part of the shadow-rs package.
+//
+// For the full copyright and license information, please view the LICENSE
+// file that was distributed with this source code.
+// spell-checker:ignore newuidmap newgidmap subuid subgid pidfd openat fstat setgroups rootless podman
+
+//! `newuidmap` and `newgidmap` — set the ID mappings of a user namespace.
+//!
+//! Drop-in replacements for the shadow-utils helpers of the same names, which
+//! are what makes rootless containers possible: an unprivileged user may map
+//! only their own ID into a namespace they create, and these setuid helpers
+//! extend that to the ranges the administrator granted them in `/etc/subuid`
+//! and `/etc/subgid`. Podman and rootless Docker call them for every
+//! container they start.
+//!
+//! The two are one program with a selector; `newgidmap` lives in its own
+//! crate and names the selector.
+//!
+//! What the kernel requires of the write is in `user_namespaces(7)`. What the
+//! helper must check before writing was established by running the GNU
+//! helper: the caller must own the target process, every requested range must
+//! sit inside a range granted to the caller, and root is exempt from neither.
+
+use std::fmt;
+use std::fmt::Write as _;
+use std::os::fd::{AsFd as _, OwnedFd, RawFd};
+
+use clap::{Arg, Command};
+
+use shadow_core::subid::SubIdEntry;
+
+use uucore::error::{UError, UResult};
+
+mod options {
+    pub const ARGS: &str = "args";
+}
+
+/// `user_namespaces(7)`: "Since Linux 4.16, the limit is 340 lines."
+const MAX_LINES: usize = 340;
+
+/// Which map is being written.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Tool {
+    Uid,
+    Gid,
+}
+
+impl Tool {
+    fn name(self) -> &'static str {
+        match self {
+            Self::Uid => "newuidmap",
+            Self::Gid => "newgidmap",
+        }
+    }
+
+    /// The kind of ID, as the messages and the man pages spell it.
+    fn id(self) -> &'static str {
+        match self {
+            Self::Uid => "uid",
+            Self::Gid => "gid",
+        }
+    }
+
+    fn map_file(self) -> &'static str {
+        match self {
+            Self::Uid => "uid_map",
+            Self::Gid => "gid_map",
+        }
+    }
+
+    fn subid_path(self, root: &shadow_core::sysroot::SysRoot) -> std::path::PathBuf {
+        match self {
+            Self::Uid => root.subuid_path(),
+            Self::Gid => root.subgid_path(),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Error type
+// ---------------------------------------------------------------------------
+
+/// Every failure exits 1, as the GNU helpers do; the variants keep the
+/// messages apart.
+#[derive(Debug)]
+enum MapError {
+    /// The command line is malformed.
+    Usage(String),
+    /// The target process cannot be opened or is not the caller's.
+    Target(String),
+    /// A range is not granted to the caller, or the set of ranges is invalid.
+    NotAllowed(String),
+    /// The kernel refused the write.
+    Write(String),
+}
+
+impl fmt::Display for MapError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Usage(m) | Self::Target(m) | Self::NotAllowed(m) | Self::Write(m) => {
+                f.write_str(m)
+            }
+        }
+    }
+}
+
+impl std::error::Error for MapError {}
+
+impl UError for MapError {
+    fn code(&self) -> i32 {
+        match self {
+            Self::Usage(_) | Self::Target(_) | Self::NotAllowed(_) | Self::Write(_) => 1,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// The command line
+// ---------------------------------------------------------------------------
+
+/// Where to find the target process.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Target {
+    Pid(u32),
+    /// `fd:N`: a descriptor the caller already holds open on `/proc/<pid>`,
+    /// which is how a caller makes sure the pid has not been recycled between
+    /// its own checks and this program's.
+    Fd(RawFd),
+}
+
+/// One `inside outside count` triple.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct Mapping {
+    inside: u32,
+    outside: u32,
+    count: u32,
+}
+
+impl Mapping {
+    fn outside_end(self) -> u64 {
+        u64::from(self.outside) + u64::from(self.count)
+    }
+    fn inside_end(self) -> u64 {
+        u64::from(self.inside) + u64::from(self.count)
+    }
+}
+
+/// A decimal number and nothing else: no sign, no space, no suffix.
+fn parse_u32(s: &str) -> Option<u32> {
+    if s.is_empty() || !s.bytes().all(|b| b.is_ascii_digit()) {
+        return None;
+    }
+    s.parse().ok()
+}
+
+fn usage(tool: Tool) -> MapError {
+    MapError::Usage(format!(
+        "usage: {} [<pid>|fd:<pidfd>] <{id}> <lower{id}> <count> [ <{id}> <lower{id}> <count> ] ...",
+        tool.name(),
+        id = tool.id()
+    ))
+}
+
+/// Split the operands into the target and the mappings.
+fn parse_args(tool: Tool, args: &[String]) -> Result<(Target, Vec<Mapping>), MapError> {
+    let Some(first) = args.first() else {
+        return Err(usage(tool));
+    };
+    let target = if let Some(fd) = first.strip_prefix("fd:") {
+        Target::Fd(
+            parse_u32(fd)
+                .and_then(|n| RawFd::try_from(n).ok())
+                .ok_or_else(|| usage(tool))?,
+        )
+    } else {
+        Target::Pid(parse_u32(first).ok_or_else(|| usage(tool))?)
+    };
+
+    let rest = &args[1..];
+    if rest.is_empty() || !rest.len().is_multiple_of(3) {
+        // The GNU wording, which reports the count that did not divide.
+        return Err(MapError::Usage(format!(
+            "ranges: {} is wrong for argc: {}",
+            rest.len().div_ceil(3),
+            args.len()
+        )));
+    }
+    let mut mappings = Vec::with_capacity(rest.len() / 3);
+    for [inside, outside, count] in rest.as_chunks::<3>().0 {
+        let inside = parse_u32(inside).ok_or_else(|| usage(tool))?;
+        let outside = parse_u32(outside).ok_or_else(|| usage(tool))?;
+        // Not a number at all is a usage error; a number that is not a
+        // positive count is reported the way the GNU helper reports it.
+        let count = parse_u32(count).ok_or_else(|| usage(tool))?;
+        if count == 0 {
+            return Err(MapError::NotAllowed(format!(
+                "sub{} overflow detected.",
+                tool.id()
+            )));
+        }
+        let m = Mapping {
+            inside,
+            outside,
+            count,
+        };
+        if m.inside_end() > u64::from(u32::MAX) + 1 || m.outside_end() > u64::from(u32::MAX) + 1 {
+            return Err(MapError::NotAllowed(format!(
+                "sub{} overflow detected.",
+                tool.id()
+            )));
+        }
+        mappings.push(m);
+    }
+    if mappings.len() > MAX_LINES {
+        return Err(MapError::NotAllowed(format!(
+            "too many ranges: the kernel accepts at most {MAX_LINES}"
+        )));
+    }
+    Ok((target, mappings))
+}
+
+// ---------------------------------------------------------------------------
+// Authorization
+// ---------------------------------------------------------------------------
+
+/// Who is asking.
+#[derive(Debug, Clone)]
+struct Caller {
+    name: String,
+    /// Real uid and gid: what the kernel will hold the caller to.
+    uid: u32,
+    gid: u32,
+    /// The account's own ids, from the password database.
+    pw_uid: u32,
+    pw_gid: u32,
+}
+
+/// The ranges granted to the caller in `/etc/subuid` or `/etc/subgid`.
+///
+/// An entry names its owner either by login name or by numeric uid; both
+/// spellings grant. Note that for `newgidmap` too the owner is the *user*: the
+/// files list which user may map which subordinate ids.
+fn granted_ranges(entries: &[SubIdEntry], caller: &Caller) -> Vec<(u64, u64)> {
+    let uid_text = caller.uid.to_string();
+    entries
+        .iter()
+        .filter(|e| e.name == caller.name || e.name == uid_text)
+        .map(|e| (e.start, e.start + e.count))
+        .collect()
+}
+
+/// Check every requested range against what the caller may map.
+///
+/// A range is allowed when it lies inside one granted range, or when it is the
+/// caller's own id mapped once: the kernel lets an unprivileged process map
+/// its own id into a namespace it created, so refusing it here would take
+/// away something the caller already had. Root is not exempt from the
+/// `/etc/subuid` requirement, as newuidmap(1) says in so many words.
+fn check_allowed(
+    tool: Tool,
+    mappings: &[Mapping],
+    granted: &[(u64, u64)],
+    own_id: u32,
+) -> Result<(), MapError> {
+    for m in mappings {
+        let start = u64::from(m.outside);
+        let end = m.outside_end();
+        let own = m.count == 1 && m.outside == own_id;
+        let inside_grant = granted.iter().any(|(gs, ge)| *gs <= start && end <= *ge);
+        if !(own || inside_grant) {
+            return Err(MapError::NotAllowed(format!(
+                "{id} range [{}-{}) -> [{}-{}) not allowed",
+                m.inside,
+                m.inside_end(),
+                m.outside,
+                m.outside_end(),
+                id = tool.id()
+            )));
+        }
+    }
+    Ok(())
+}
+
+/// Refuse ranges that overlap, on either side.
+///
+/// The kernel refuses them too, with `EINVAL` and nothing else; naming the
+/// problem costs nothing and cannot change any outcome the kernel would have
+/// accepted.
+fn check_no_overlap(tool: Tool, mappings: &[Mapping]) -> Result<(), MapError> {
+    for (i, a) in mappings.iter().enumerate() {
+        for b in &mappings[i + 1..] {
+            let inside_clash =
+                u64::from(a.inside) < b.inside_end() && u64::from(b.inside) < a.inside_end();
+            let outside_clash =
+                u64::from(a.outside) < b.outside_end() && u64::from(b.outside) < a.outside_end();
+            if inside_clash || outside_clash {
+                return Err(MapError::NotAllowed(format!(
+                    "{id} ranges [{}-{}) -> [{}-{}) and [{}-{}) -> [{}-{}) overlap",
+                    a.inside,
+                    a.inside_end(),
+                    a.outside,
+                    a.outside_end(),
+                    b.inside,
+                    b.inside_end(),
+                    b.outside,
+                    b.outside_end(),
+                    id = tool.id()
+                )));
+            }
+        }
+    }
+    Ok(())
+}
+
+/// The bytes the kernel wants: one `inside outside count` line per range,
+/// delivered in a single write.
+fn render(mappings: &[Mapping]) -> String {
+    let mut out = String::new();
+    for m in mappings {
+        let _ = writeln!(out, "{} {} {}", m.inside, m.outside, m.count);
+    }
+    out
+}
+
+// ---------------------------------------------------------------------------
+// The target process
+// ---------------------------------------------------------------------------
+
+/// Open `/proc/<pid>` (or adopt the caller's descriptor) and check that the
+/// process belongs to the caller.
+///
+/// Everything afterwards goes through this descriptor -- `openat` for the map
+/// file -- so a pid recycled between the check and the write cannot redirect
+/// it: the descriptor stays bound to the process it was opened on.
+fn open_target(target: Target, caller: &Caller) -> Result<OwnedFd, MapError> {
+    use rustix::fs::{Mode, OFlags};
+
+    let dir = match target {
+        Target::Pid(pid) => rustix::fs::open(
+            format!("/proc/{pid}"),
+            OFlags::RDONLY | OFlags::DIRECTORY | OFlags::NOFOLLOW | OFlags::CLOEXEC,
+            Mode::empty(),
+        )
+        .map_err(|e| {
+            MapError::Target(format!(
+                "Could not open proc directory for target {pid}: {e}"
+            ))
+        })?,
+        // The caller's descriptor is re-opened through its /proc/self/fd
+        // entry, a magic link that resolves to the object the descriptor
+        // refers to rather than to a path -- so this is the same /proc/<pid>
+        // instance the caller checked, and no raw descriptor is adopted.
+        Target::Fd(fd) => rustix::fs::open(
+            format!("/proc/self/fd/{fd}"),
+            OFlags::RDONLY | OFlags::DIRECTORY | OFlags::CLOEXEC,
+            Mode::empty(),
+        )
+        .map_err(|e| {
+            MapError::Usage(format!(
+                "fd:{fd} is not a descriptor open on a /proc/<pid> directory: {e}"
+            ))
+        })?,
+    };
+
+    let st = rustix::fs::fstat(&dir)
+        .map_err(|e| MapError::Target(format!("cannot stat the target: {e}")))?;
+    if !rustix::fs::FileType::from_raw_mode(st.st_mode).is_dir() {
+        return Err(MapError::Usage(
+            "the fd: argument must be a descriptor open on a /proc/<pid> directory".into(),
+        ));
+    }
+    // GNU's exact wording, which names all three ids on each side so an
+    // administrator can see which of them disagrees.
+    if st.st_uid != caller.uid
+        || st.st_uid != caller.pw_uid
+        || st.st_gid != caller.gid
+        || st.st_gid != caller.pw_gid
+    {
+        return Err(MapError::Target(format!(
+            "Target process is owned by a different user: uid:{} pw_uid:{} st_uid:{}, gid:{} pw_gid:{} st_gid:{}",
+            caller.uid, caller.pw_uid, st.st_uid, caller.gid, caller.pw_gid, st.st_gid
+        )));
+    }
+    Ok(dir)
+}
+
+/// Write the map through the target's directory descriptor, in one write.
+fn write_map(tool: Tool, dir: &OwnedFd, contents: &str) -> Result<(), MapError> {
+    use rustix::fs::{Mode, OFlags};
+
+    let file = rustix::fs::openat(
+        dir.as_fd(),
+        tool.map_file(),
+        OFlags::WRONLY | OFlags::CLOEXEC | OFlags::NOFOLLOW,
+        Mode::empty(),
+    )
+    .map_err(|e| MapError::Write(format!("cannot open {}: {e}", tool.map_file())))?;
+    // A single write at offset zero is the only form the kernel takes: a
+    // partial write, or a second one, is refused wholesale.
+    match rustix::io::write(&file, contents.as_bytes()) {
+        Ok(n) if n == contents.len() => Ok(()),
+        Ok(n) => Err(MapError::Write(format!(
+            "write to {} was short: {n} of {} bytes",
+            tool.map_file(),
+            contents.len()
+        ))),
+        Err(e) => Err(MapError::Write(format!(
+            "write to {} failed: {e}",
+            tool.map_file()
+        ))),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Entry points
+// ---------------------------------------------------------------------------
+
+/// Entry point for the `newuidmap` utility.
+#[uucore::main]
+pub fn uumain(args: impl uucore::Args) -> UResult<()> {
+    run(Tool::Uid, args)
+}
+
+/// Build the clap `Command` for `newuidmap`.
+#[must_use]
+pub fn uu_app() -> Command {
+    app(Tool::Uid)
+}
+
+/// Run either helper.
+pub fn run(tool: Tool, args: impl uucore::Args) -> UResult<()> {
+    // A setuid helper with no children and no prompts: the full hardening,
+    // including a sanitized environment, costs nothing here.
+    shadow_core::hardening::harden_process();
+
+    let Some(matches) = shadow_core::cli::parse_args(app(tool), args, |_| 1)? else {
+        return Ok(());
+    };
+    let operands: Vec<String> = matches
+        .get_many::<String>(options::ARGS)
+        .map(|v| v.cloned().collect())
+        .unwrap_or_default();
+
+    let (target, mappings) = parse_args(tool, &operands)?;
+
+    let uid = rustix::process::getuid().as_raw();
+    let gid = rustix::process::getgid().as_raw();
+    let entry = shadow_core::hardening::lookup_passwd_entry_by_uid(uid)
+        .map_err(|e| MapError::Target(format!("cannot identify the caller: {e}")))?;
+    let caller = Caller {
+        name: entry.name,
+        uid,
+        gid,
+        pw_uid: entry.uid,
+        pw_gid: entry.gid,
+    };
+
+    // Checks first, in an order that reveals nothing about the target to a
+    // caller who may not map anything: the ranges are judged before the
+    // process is looked at.
+    let root = shadow_core::sysroot::SysRoot::default();
+    let entries = shadow_core::subid::read_subid_file(&tool.subid_path(&root)).unwrap_or_default();
+    let granted = granted_ranges(&entries, &caller);
+    let own_id = match tool {
+        Tool::Uid => caller.uid,
+        Tool::Gid => caller.gid,
+    };
+    check_no_overlap(tool, &mappings)?;
+    check_allowed(tool, &mappings, &granted, own_id)?;
+
+    let dir = open_target(target, &caller)?;
+    write_map(tool, &dir, &render(&mappings))?;
+    Ok(())
+}
+
+/// Build the clap `Command` for either helper.
+#[must_use]
+pub fn app(tool: Tool) -> Command {
+    Command::new(tool.name())
+        .about(match tool {
+            Tool::Uid => "Set the user ID mapping of a user namespace",
+            Tool::Gid => "Set the group ID mapping of a user namespace",
+        })
+        .override_usage(format!(
+            "{} [<pid>|fd:<pidfd>] <{id}> <lower{id}> <count> [ <{id}> <lower{id}> <count> ] ...",
+            tool.name(),
+            id = tool.id()
+        ))
+        .version(shadow_core::cli::VERSION)
+        .after_help(shadow_core::cli::AFTER_HELP)
+        .arg(
+            Arg::new(options::ARGS)
+                .help("the target process, then one or more inside/outside/count triples")
+                .value_name("pid id lowerid count...")
+                .num_args(0..)
+                .index(1),
+        )
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn caller() -> Caller {
+        Caller {
+            name: "alice".to_string(),
+            uid: 1000,
+            gid: 1000,
+            pw_uid: 1000,
+            pw_gid: 1000,
+        }
+    }
+
+    fn entry(name: &str, start: u64, count: u64) -> SubIdEntry {
+        SubIdEntry {
+            name: name.to_string(),
+            start,
+            count,
+        }
+    }
+
+    fn args(v: &[&str]) -> Vec<String> {
+        v.iter().map(|s| (*s).to_string()).collect()
+    }
+
+    #[test]
+    fn test_apps_build() {
+        app(Tool::Uid).debug_assert();
+        app(Tool::Gid).debug_assert();
+    }
+
+    #[test]
+    fn test_parse_pid_and_triples() {
+        let (t, m) = parse_args(
+            Tool::Uid,
+            &args(&["1234", "0", "100000", "65536", "65536", "1000", "1"]),
+        )
+        .expect("parses");
+        assert_eq!(t, Target::Pid(1234));
+        assert_eq!(m.len(), 2);
+        assert_eq!(
+            m[0],
+            Mapping {
+                inside: 0,
+                outside: 100_000,
+                count: 65_536
+            }
+        );
+        assert_eq!(
+            m[1],
+            Mapping {
+                inside: 65_536,
+                outside: 1000,
+                count: 1
+            }
+        );
+    }
+
+    #[test]
+    fn test_parse_fd_form() {
+        let (t, _) = parse_args(Tool::Uid, &args(&["fd:3", "0", "100000", "10"])).expect("parses");
+        assert_eq!(t, Target::Fd(3));
+        assert!(parse_args(Tool::Uid, &args(&["fd:", "0", "1", "1"])).is_err());
+        assert!(parse_args(Tool::Uid, &args(&["fd:x", "0", "1", "1"])).is_err());
+    }
+
+    /// Operands that are not triples, and numbers that are not plain
+    /// decimals, are usage errors; a count that is not positive is the
+    /// overflow message, as the GNU helper words it.
+    #[test]
+    fn test_parse_rejections() {
+        assert!(matches!(
+            parse_args(Tool::Uid, &args(&[])),
+            Err(MapError::Usage(_))
+        ));
+        assert!(matches!(
+            parse_args(Tool::Uid, &args(&["1234"])),
+            Err(MapError::Usage(_))
+        ));
+        assert!(matches!(
+            parse_args(Tool::Uid, &args(&["1234", "0", "100000"])),
+            Err(MapError::Usage(_))
+        ));
+        assert!(matches!(
+            parse_args(Tool::Uid, &args(&["1234", "0", "100000", "many"])),
+            Err(MapError::Usage(_))
+        ));
+        assert!(matches!(
+            parse_args(Tool::Uid, &args(&["1234", "-1", "100000", "1"])),
+            Err(MapError::Usage(_))
+        ));
+        assert!(matches!(
+            parse_args(Tool::Uid, &args(&["abc", "0", "1", "1"])),
+            Err(MapError::Usage(_))
+        ));
+        let zero =
+            parse_args(Tool::Uid, &args(&["1234", "0", "100000", "0"])).expect_err("refused");
+        assert_eq!(zero.to_string(), "subuid overflow detected.");
+        let over =
+            parse_args(Tool::Gid, &args(&["1234", "0", "4294967295", "2"])).expect_err("refused");
+        assert_eq!(over.to_string(), "subgid overflow detected.");
+    }
+
+    /// Both spellings of the owner grant: the login name and the numeric uid.
+    #[test]
+    fn test_granted_ranges_by_name_and_by_uid() {
+        let entries = vec![
+            entry("alice", 100_000, 65_536),
+            entry("1000", 200_000, 1000),
+            entry("bob", 300_000, 1000),
+        ];
+        let g = granted_ranges(&entries, &caller());
+        assert_eq!(g, vec![(100_000, 165_536), (200_000, 201_000)]);
+    }
+
+    /// A range is allowed inside a grant, refused when it pokes out, and the
+    /// caller's own id maps once without any grant.
+    #[test]
+    fn test_check_allowed() {
+        let granted = vec![(100_000u64, 165_536u64)];
+        let ok = [Mapping {
+            inside: 0,
+            outside: 100_000,
+            count: 65_536,
+        }];
+        assert!(check_allowed(Tool::Uid, &ok, &granted, 1000).is_ok());
+
+        let partly = [Mapping {
+            inside: 0,
+            outside: 165_530,
+            count: 10,
+        }];
+        let err = check_allowed(Tool::Uid, &partly, &granted, 1000).expect_err("refused");
+        assert_eq!(
+            err.to_string(),
+            "uid range [0-10) -> [165530-165540) not allowed"
+        );
+
+        let own = [Mapping {
+            inside: 0,
+            outside: 1000,
+            count: 1,
+        }];
+        assert!(check_allowed(Tool::Uid, &own, &[], 1000).is_ok());
+        let own_twice = [Mapping {
+            inside: 0,
+            outside: 1000,
+            count: 2,
+        }];
+        assert!(check_allowed(Tool::Uid, &own_twice, &[], 1000).is_err());
+        let someone_else = [Mapping {
+            inside: 0,
+            outside: 1001,
+            count: 1,
+        }];
+        assert!(check_allowed(Tool::Uid, &someone_else, &[], 1000).is_err());
+    }
+
+    /// Root is not exempt: with no grant, root may map only itself once.
+    #[test]
+    fn test_root_is_not_exempt() {
+        let big = [Mapping {
+            inside: 0,
+            outside: 100_000,
+            count: 10,
+        }];
+        assert!(check_allowed(Tool::Uid, &big, &[], 0).is_err());
+        let self_only = [Mapping {
+            inside: 0,
+            outside: 0,
+            count: 1,
+        }];
+        assert!(check_allowed(Tool::Uid, &self_only, &[], 0).is_ok());
+    }
+
+    #[test]
+    fn test_overlap_is_refused_on_either_side() {
+        let inside = [
+            Mapping {
+                inside: 0,
+                outside: 100_000,
+                count: 10,
+            },
+            Mapping {
+                inside: 5,
+                outside: 200_000,
+                count: 10,
+            },
+        ];
+        assert!(check_no_overlap(Tool::Uid, &inside).is_err());
+        let outside = [
+            Mapping {
+                inside: 0,
+                outside: 100_000,
+                count: 10,
+            },
+            Mapping {
+                inside: 10,
+                outside: 100_005,
+                count: 10,
+            },
+        ];
+        assert!(check_no_overlap(Tool::Uid, &outside).is_err());
+        let touching = [
+            Mapping {
+                inside: 0,
+                outside: 100_000,
+                count: 10,
+            },
+            Mapping {
+                inside: 10,
+                outside: 100_010,
+                count: 10,
+            },
+        ];
+        assert!(
+            check_no_overlap(Tool::Uid, &touching).is_ok(),
+            "adjacent is not overlapping"
+        );
+    }
+
+    /// The bytes the kernel reads: one line per range, three numbers, one
+    /// space, newline-terminated.
+    #[test]
+    fn test_render() {
+        let m = [
+            Mapping {
+                inside: 0,
+                outside: 1000,
+                count: 1,
+            },
+            Mapping {
+                inside: 1,
+                outside: 100_000,
+                count: 65_536,
+            },
+        ];
+        assert_eq!(render(&m), "0 1000 1\n1 100000 65536\n");
+    }
+
+    #[test]
+    fn test_every_failure_exits_one() {
+        for e in [
+            MapError::Usage("x".into()),
+            MapError::Target("x".into()),
+            MapError::NotAllowed("x".into()),
+            MapError::Write("x".into()),
+        ] {
+            assert_eq!(e.code(), 1);
+        }
+    }
+}

--- a/tests/arm64-smoke.sh
+++ b/tests/arm64-smoke.sh
@@ -64,10 +64,10 @@ version=$("${QEMU[@]}" "$BIN" --version 2>&1)
 if [ -n "$version" ]; then ok "runs: $version"; else bad "would not run"; exit 1; fi
 
 applets=$("${QEMU[@]}" "$BIN" --list 2>/dev/null | tail -n +2 | wc -l)
-if [ "$applets" -ge 25 ]; then
+if [ "$applets" -ge 27 ]; then
     ok "carries $applets applets"
 else
-    bad "expected at least 25 applets, found $applets"
+    bad "expected at least 27 applets, found $applets"
 fi
 
 # ── A prefix tree, so nothing here touches the container's own accounts ──
@@ -126,6 +126,8 @@ check "sg starts" "${QEMU[@]}" "$BIN" sg --help
 check "vipw starts" "${QEMU[@]}" "$BIN" vipw --help
 check "vigr starts" "${QEMU[@]}" "$BIN" vigr --help
 check "login starts" "${QEMU[@]}" "$BIN" login --help
+check "newuidmap starts" "${QEMU[@]}" "$BIN" newuidmap --help
+check "newgidmap starts" "${QEMU[@]}" "$BIN" newgidmap --help
 
 # newusers writes three files and a home directory from one line, so it
 # exercises the allocator, crypt(3) and the fchown in shadow_core::home

--- a/tests/by-util/test_multicall.rs
+++ b/tests/by-util/test_multicall.rs
@@ -16,7 +16,7 @@ use std::process::Command;
 use crate::common::{run, run_cmd};
 
 /// Every applet this build is expected to carry, in `--list` order.
-const TOOLS: [&str; 25] = [
+const TOOLS: [&str; 27] = [
     "chage",
     "chfn",
     "chgpasswd",
@@ -30,7 +30,9 @@ const TOOLS: [&str; 25] = [
     "grpconv",
     "grpunconv",
     "login",
+    "newgidmap",
     "newgrp",
+    "newuidmap",
     "newusers",
     "passwd",
     "pwck",

--- a/tests/by-util/test_newuidmap.rs
+++ b/tests/by-util/test_newuidmap.rs
@@ -1,0 +1,349 @@
+// This file is part of the shadow-rs package.
+//
+// For the full copyright and license information, please view the LICENSE
+// file that was distributed with this source code.
+// spell-checker:ignore newuidmap newgidmap subuid subgid setgroups unshare userns
+
+//! Integration tests for `newuidmap` and `newgidmap`.
+//!
+//! The success path needs a user namespace to write into. A test user
+//! creates one with `unshare -U` and keeps it alive; the helper is then run
+//! *as that user*, unprivileged, against the child. The kernel lets an
+//! unprivileged writer map its own id once into a namespace it owns, so that
+//! single-line mapping is a real end-to-end write -- observable in the
+//! child's `uid_map` afterwards. Everything the helper refuses is checked the
+//! same way, against the same live target.
+
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant};
+
+use crate::common::{run, skip_unless_root};
+
+/// A user, and a process of theirs sitting in a fresh user namespace.
+struct Owner {
+    name: String,
+    uid: u32,
+    gid: u32,
+    ns: Child,
+}
+
+impl Owner {
+    fn new(tag: &str) -> Option<Owner> {
+        let name = format!("{tag}_{}", std::process::id());
+        run("useradd", &["-M", &name]).assert_code(0);
+        let entry = shadow_core::process::getpwnam(&name)
+            .expect("nss")
+            .expect("created");
+
+        let mut cmd = Command::new("unshare");
+        cmd.args(["-U", "sleep", "60"])
+            .env_clear()
+            .env("PATH", "/usr/bin:/bin")
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::piped());
+        let mut ns =
+            shadow_core::process::spawn_as_user(&mut cmd, entry.uid, entry.gid, vec![entry.gid])
+                .expect("spawn unshare");
+        // Give unshare a moment to enter the namespace, and notice if it could
+        // not (a kernel or seccomp that forbids it), in which case skip.
+        let deadline = Instant::now() + Duration::from_secs(3);
+        loop {
+            if let Ok(Some(_)) = ns.try_wait() {
+                let _ = run("userdel", &[&name]);
+                return None;
+            }
+            let map =
+                std::fs::read_to_string(format!("/proc/{}/uid_map", ns.id())).unwrap_or_default();
+            // An unmapped fresh namespace has an empty uid_map.
+            if map.is_empty()
+                && std::fs::read_to_string(format!("/proc/{}/status", ns.id()))
+                    .is_ok_and(|s| s.contains("NSpid"))
+            {
+                std::thread::sleep(Duration::from_millis(200));
+                return Some(Owner {
+                    name,
+                    uid: entry.uid,
+                    gid: entry.gid,
+                    ns,
+                });
+            }
+            if Instant::now() > deadline {
+                let _ = ns.kill();
+                let _ = run("userdel", &[&name]);
+                return None;
+            }
+            std::thread::sleep(Duration::from_millis(50));
+        }
+    }
+
+    fn pid(&self) -> String {
+        self.ns.id().to_string()
+    }
+
+    /// Run `<tool> <args>` as this user, unprivileged.
+    fn run_as(&self, tool: &str, args: &[&str]) -> crate::common::Output {
+        let mut cmd = Command::new(env!("CARGO_BIN_EXE_shadow-rs"));
+        cmd.arg(tool)
+            .args(args)
+            .env_clear()
+            .env("PATH", "/usr/bin:/bin")
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+        let child =
+            shadow_core::process::spawn_as_user(&mut cmd, self.uid, self.gid, vec![self.gid])
+                .expect("spawn tool");
+        let out = child.wait_with_output().expect("wait");
+        crate::common::Output {
+            code: out.status.code().unwrap_or(-1),
+            stdout: String::from_utf8_lossy(&out.stdout).into_owned(),
+            stderr: String::from_utf8_lossy(&out.stderr).into_owned(),
+        }
+    }
+
+    fn map(&self, which: &str) -> String {
+        std::fs::read_to_string(format!("/proc/{}/{which}", self.ns.id())).unwrap_or_default()
+    }
+}
+
+impl Drop for Owner {
+    fn drop(&mut self) {
+        let _ = self.ns.kill();
+        let _ = self.ns.wait();
+        let _ = run("userdel", &[&self.name]);
+    }
+}
+
+/// Grant a subordinate range by writing the files directly, as an
+/// administrator (or a package's postinst) would; the tools under test read
+/// them, they do not manage them here.
+fn grant_subids(name: &str, start: u32, count: u32) {
+    use std::io::Write as _;
+    for file in ["/etc/subuid", "/etc/subgid"] {
+        let mut f = std::fs::OpenOptions::new()
+            .append(true)
+            .create(true)
+            .open(file)
+            .expect(file);
+        writeln!(f, "{name}:{start}:{count}").expect("append");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Refusals that need no namespace
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_help_and_usage() {
+    run("newuidmap", &["--help"])
+        .assert_code(0)
+        .assert_stdout_contains("Usage:");
+    run("newgidmap", &["--help"])
+        .assert_code(0)
+        .assert_stdout_contains("Usage:");
+    run("newuidmap", &[])
+        .assert_code(1)
+        .assert_stderr_contains("usage:");
+    run("newuidmap", &["1", "0", "100000"])
+        .assert_code(1)
+        .assert_stderr_contains("ranges:");
+    run("newuidmap", &["1", "0", "100000", "many"])
+        .assert_code(1)
+        .assert_stderr_contains("usage:");
+    run("newuidmap", &["1", "0", "100000", "0"])
+        .assert_code(1)
+        .assert_stderr_contains("subuid overflow detected.");
+    run("newgidmap", &["1", "0", "100000", "0"])
+        .assert_code(1)
+        .assert_stderr_contains("subgid overflow detected.");
+}
+
+#[test]
+fn test_no_such_process() {
+    if skip_unless_root() {
+        return;
+    }
+    // The range check comes before the process is looked at; root maps
+    // itself once, so this reaches the target and finds nothing there.
+    run("newuidmap", &["4194304", "0", "0", "1"])
+        .assert_code(1)
+        .assert_stderr_contains("Could not open proc directory for target 4194304");
+}
+
+/// A process that is not the caller's is refused by name and number.
+#[test]
+fn test_someone_elses_process_is_refused() {
+    if skip_unless_root() {
+        return;
+    }
+    let Some(owner) = Owner::new("nm_other") else {
+        return;
+    };
+    // pid 1 belongs to root; the user asks to map only their own id, which is
+    // allowed by range, so the refusal is about ownership.
+    owner
+        .run_as("newuidmap", &["1", "0", &owner.uid.to_string(), "1"])
+        .assert_code(1)
+        .assert_stderr_contains("Target process is owned by a different user");
+}
+
+// ---------------------------------------------------------------------------
+// Against a live namespace
+// ---------------------------------------------------------------------------
+
+/// The one write an unprivileged caller may make: their own id, once. It has
+/// to land in the kernel, not merely be allowed.
+#[test]
+fn test_own_uid_maps_once_and_the_kernel_shows_it() {
+    if skip_unless_root() {
+        return;
+    }
+    let Some(owner) = Owner::new("nm_own") else {
+        return;
+    };
+    let uid = owner.uid.to_string();
+    owner
+        .run_as("newuidmap", &[&owner.pid(), "0", &uid, "1"])
+        .assert_code(0);
+    let map = owner.map("uid_map");
+    let fields: Vec<&str> = map.split_whitespace().collect();
+    assert_eq!(
+        fields,
+        vec!["0", uid.as_str(), "1"],
+        "uid_map after the write: {map:?}"
+    );
+}
+
+/// The same for gids. An unprivileged writer of `gid_map` must first deny
+/// setgroups in the namespace; the helper, being setuid on a real system,
+/// need not, so the test does it as the owner would.
+#[test]
+fn test_own_gid_maps_once() {
+    if skip_unless_root() {
+        return;
+    }
+    let Some(owner) = Owner::new("nm_gid") else {
+        return;
+    };
+    std::fs::write(format!("/proc/{}/setgroups", owner.pid()), "deny").expect("deny setgroups");
+    let gid = owner.gid.to_string();
+    owner
+        .run_as("newgidmap", &[&owner.pid(), "0", &gid, "1"])
+        .assert_code(0);
+    let map = owner.map("gid_map");
+    assert_eq!(
+        map.split_whitespace().collect::<Vec<_>>(),
+        vec!["0", gid.as_str(), "1"],
+        "{map:?}"
+    );
+}
+
+/// A range outside the grant is refused before anything reaches the kernel,
+/// with the range spelled out.
+#[test]
+fn test_range_outside_the_grant_is_refused() {
+    if skip_unless_root() {
+        return;
+    }
+    let Some(owner) = Owner::new("nm_range") else {
+        return;
+    };
+    grant_subids(&owner.name, 100_000, 65_536);
+    owner
+        .run_as("newuidmap", &[&owner.pid(), "0", "165530", "10"])
+        .assert_code(1)
+        .assert_stderr_contains("uid range [0-10) -> [165530-165540) not allowed");
+    assert!(
+        owner.map("uid_map").is_empty(),
+        "nothing may have been written"
+    );
+}
+
+/// The kernel would refuse an overlap with a bare EINVAL; the helper names it.
+#[test]
+fn test_overlap_is_named() {
+    if skip_unless_root() {
+        return;
+    }
+    let Some(owner) = Owner::new("nm_overlap") else {
+        return;
+    };
+    grant_subids(&owner.name, 100_000, 65_536);
+    owner
+        .run_as(
+            "newuidmap",
+            &[&owner.pid(), "0", "100000", "10", "5", "100100", "10"],
+        )
+        .assert_code(1)
+        .assert_stderr_contains("overlap");
+}
+
+/// A second write to the same namespace is refused by the kernel, and the
+/// helper reports it rather than pretending.
+#[test]
+fn test_a_map_is_written_once() {
+    if skip_unless_root() {
+        return;
+    }
+    let Some(owner) = Owner::new("nm_twice") else {
+        return;
+    };
+    let uid = owner.uid.to_string();
+    owner
+        .run_as("newuidmap", &[&owner.pid(), "0", &uid, "1"])
+        .assert_code(0);
+    owner
+        .run_as("newuidmap", &[&owner.pid(), "0", &uid, "1"])
+        .assert_code(1)
+        .assert_stderr_contains("write to uid_map failed");
+}
+
+/// The `fd:N` form: the caller hands over a descriptor on /proc/<pid>, and a
+/// descriptor on anything else is a usage error.
+#[test]
+fn test_fd_form() {
+    if skip_unless_root() {
+        return;
+    }
+    let Some(owner) = Owner::new("nm_fd") else {
+        return;
+    };
+    // Descriptor 5 in the child: open /proc/<pid> and pass it through.
+    let dir = std::fs::File::open(format!("/proc/{}", owner.pid())).expect("open proc dir");
+    let uid = owner.uid.to_string();
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_shadow-rs"));
+    cmd.args(["newuidmap", "fd:0", "0", &uid, "1"])
+        .env_clear()
+        .env("PATH", "/usr/bin:/bin")
+        .stdin(Stdio::from(dir))
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    let out = shadow_core::process::spawn_as_user(&mut cmd, owner.uid, owner.gid, vec![owner.gid])
+        .expect("spawn")
+        .wait_with_output()
+        .expect("wait");
+    assert!(
+        out.status.success(),
+        "fd form failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert_eq!(
+        owner.map("uid_map").split_whitespace().collect::<Vec<_>>(),
+        vec!["0", uid.as_str(), "1"]
+    );
+
+    let not_a_dir = std::fs::File::open("/etc/hostname").expect("open");
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_shadow-rs"));
+    cmd.args(["newuidmap", "fd:0", "0", &uid, "1"])
+        .env_clear()
+        .env("PATH", "/usr/bin:/bin")
+        .stdin(Stdio::from(not_a_dir))
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    let out = shadow_core::process::spawn_as_user(&mut cmd, owner.uid, owner.gid, vec![owner.gid])
+        .expect("spawn")
+        .wait_with_output()
+        .expect("wait");
+    assert_eq!(out.status.code(), Some(1));
+}

--- a/tests/e2e/deploy-test.sh
+++ b/tests/e2e/deploy-test.sh
@@ -100,8 +100,8 @@ hash_password() {
 
 # ── TOOLS list ──────────────────────────────────────────────────────
 
-TOOLS="passwd pwck useradd userdel usermod chpasswd chgpasswd newusers chage groupadd groupdel groupmod gpasswd grpck chfn chsh newgrp sg vipw vigr pwconv pwunconv grpconv grpunconv login"
-SETUID_TOOLS="passwd chfn chsh newgrp gpasswd sg"
+TOOLS="passwd pwck useradd userdel usermod chpasswd chgpasswd newusers chage groupadd groupdel groupmod gpasswd grpck chfn chsh newgrp sg vipw vigr pwconv pwunconv grpconv grpunconv login newuidmap newgidmap"
+SETUID_TOOLS="passwd chfn chsh newgrp gpasswd sg newuidmap newgidmap"
 
 # The tools an unprivileged user runs are installed in bin, the rest in sbin,
 # which is the split the GNU package uses: sbin is not on a normal user's
@@ -869,6 +869,57 @@ test_gpasswd_group_admin() {
     userdel -r gp_member 2>/dev/null || true
 }
 
+# ── newuidmap / newgidmap: id maps for a user namespace ────────────
+
+test_idmap() {
+    section "newuidmap / newgidmap — id maps for a user namespace"
+
+    userdel -r im_user 2>/dev/null || true
+    assert_ok "useradd -M im_user" useradd -M im_user
+    printf 'im_user:200000:65536\n' >> /etc/subuid
+    printf 'im_user:200000:65536\n' >> /etc/subgid
+
+    assert_fail "no operands is a usage error" newuidmap
+    assert_contains "an operand count that is not triples is reported" "ranges:" \
+        bash -c "newuidmap 1 0 200000 2>&1; true"
+    assert_contains "a zero count is the overflow message" "subuid overflow detected." \
+        bash -c "newuidmap 1 0 200000 0 2>&1; true"
+    assert_contains "no such process" "Could not open proc directory" \
+        bash -c "newuidmap 4194304 0 0 1 2>&1; true"
+
+    if ! su -s /bin/sh im_user -c 'unshare -U true' 2>/dev/null; then
+        echo -e "  ${YELLOW}⊘${NC} user namespaces not available here, skipping the live checks"
+        userdel im_user 2>/dev/null || true
+        return
+    fi
+    # A namespace owned by im_user, kept alive while the checks run.
+    su -s /bin/sh im_user -c 'unshare -U sh -c "echo \$\$ > /tmp/im_pid; sleep 30"' &
+    sleep 1; pid=$(cat /tmp/im_pid)
+    uid=$(id -u im_user); gid=$(id -g im_user)
+
+    assert_contains "a range outside the grant is refused by name" "not allowed" \
+        su -s /bin/sh im_user -c "newuidmap $pid 0 300000 10 2>&1; true"
+    assert_contains "overlapping ranges are refused by name" "overlap" \
+        su -s /bin/sh im_user -c "newuidmap $pid 0 200000 10 5 200100 10 2>&1; true"
+    assert_contains "someone else's process is refused" "owned by a different user" \
+        su -s /bin/sh im_user -c "newuidmap 1 0 $uid 1 2>&1; true"
+    assert_ok "the owner maps their own uid once" \
+        su -s /bin/sh im_user -c "newuidmap $pid 0 $uid 1"
+    assert_ok "and the kernel shows it" \
+        bash -c "test \"\$(tr -s ' ' < /proc/$pid/uid_map | sed 's/^ //')\" = '0 $uid 1'"
+    assert_fail "a second write is refused" \
+        su -s /bin/sh im_user -c "newuidmap $pid 0 $uid 1"
+    echo deny > /proc/$pid/setgroups
+    assert_ok "the owner maps their own gid once" \
+        su -s /bin/sh im_user -c "newgidmap $pid 0 $gid 1"
+    assert_ok "and the kernel shows that too" \
+        bash -c "test \"\$(tr -s ' ' < /proc/$pid/gid_map | sed 's/^ //')\" = '0 $gid 1'"
+
+    kill $pid 2>/dev/null; wait 2>/dev/null
+    sed -i '/^im_user:/d' /etc/subuid /etc/subgid
+    userdel im_user 2>/dev/null || true
+}
+
 # ── login: a session on a terminal ─────────────────────────────────
 
 test_login() {
@@ -1347,6 +1398,7 @@ main() {
     test_vipw
     test_pwconv_family
     test_login
+    test_idmap
     test_aging_and_input
     test_audit_logging
     test_root_option

--- a/tests/gnu-compat.sh
+++ b/tests/gnu-compat.sh
@@ -241,6 +241,16 @@ for pair in \
     compare_exit "$tool --help" "$RS/$tool --help" "$gnu --help"
 done
 
+# The GNU id mappers take no --help: any bad command line is the usage text
+# and exit 1, ours answers --help with 0. What the two share is what happens
+# to a caller who gets the operands wrong, so that is what is compared.
+echo "=== newuidmap / newgidmap refuse the same bad command lines ==="
+compare_exit "newuidmap with no operands" "$RS/newuidmap" "/usr/bin/newuidmap"
+compare_exit "newgidmap with no operands" "$RS/newgidmap" "/usr/bin/newgidmap"
+compare_exit "newuidmap with an incomplete triple" "$RS/newuidmap 1 0 100000" "/usr/bin/newuidmap 1 0 100000"
+compare_exit "newgidmap with a zero count" "$RS/newgidmap 1 0 100000 0" "/usr/bin/newgidmap 1 0 100000 0"
+compare_exit "newuidmap on a process that is not there" "$RS/newuidmap 4194304 0 0 1" "/usr/bin/newuidmap 4194304 0 0 1"
+
 # ── Results ─────────────────────────────────────────────────────────
 
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -46,6 +46,8 @@ mod test_login;
 mod test_multicall;
 #[path = "by-util/test_newgrp.rs"]
 mod test_newgrp;
+#[path = "by-util/test_newuidmap.rs"]
+mod test_newuidmap;
 #[path = "by-util/test_newusers.rs"]
 mod test_newusers;
 #[path = "by-util/test_passwd.rs"]


### PR DESCRIPTION
Adds `newuidmap` and `newgidmap`, tools twenty-six and twenty-seven — the setuid helpers that write a user namespace's `uid_map`/`gid_map`, which Podman and rootless Docker call for every container. Fedora ships them in shadow-utils. With these two, **every tool the two reference distributions ship from the suite now exists here.**

Stacked on #297. Base retargets to `main` as the stack merges.

## What is checked before anything is written

Established by running the GNU helpers against a real user namespace, never by reading them:

- Operands: a target (`pid` or `fd:N`) and plain-decimal triples; a zero count is *subuid overflow detected.*
- Every outside range must lie inside a range granted to the caller in `/etc/subuid`/`/etc/subgid` — an entry by login name **or** by numeric uid — or be the caller's own id mapped once (what the kernel already allows unprivileged). Root is exempt from neither.
- The target must belong to the caller: real uid, account uid, and the owner of `/proc/<pid>` — all three named when they disagree.
- Overlapping ranges are refused **by name**. The kernel refuses them too, with a bare `EINVAL`; the message changes no accepted outcome.

The map file is opened through a descriptor held on `/proc/<pid>`, so a recycled pid cannot redirect the write; `fd:N` takes such a descriptor from a caller that did its own checks, re-opened through `/proc/self/fd` rather than adopted — no `unsafe` in the tool.

## The tests do the real thing

A test user creates a namespace with `unshare -U`; the helper runs **as that user, unprivileged**, against it. The own-id mapping lands and the kernel's `uid_map` reads `0 <uid> 1` back; a second write is refused by the kernel and reported; the `fd:` form works; every refusal is checked against the same live target. On glibc and musl alike, and again in the e2e image.

`tests/gnu-compat.sh` now holds both against GNU's helpers (the Debian image gains `uidmap`). They take no `--help` — any bad command line is usage and exit 1 — so the comparison is on the refusals the two share.

## Verification

| | |
|---|---|
| `make check` | fmt, clippy ×3, tests ±`pam`, unprivileged run — exit 0 |
| `cargo test --workspace` | alpine 912 / fedora (pam) 934, 0 failed |
| e2e deployment suite | 393 assertions, the kernel-visible writes included |
| `make test-gnu-compat` | 57 comparisons |
| `make test-arm64` | 34 assertions under emulation |
