### PR TITLE
expiry, and usermod's subordinate-id options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `expiry`, the twenty-eighth tool: it judges the caller's own shadow line as
+  `login` would -- silent when all is well, a warning inside `warn_days`, a
+  forced change through PAM when the password has expired, and a refusal when
+  the account has -- so a session that did not come through `login` still
+  meets the policy. Installed setgid `shadow`, as the GNU suite ships it.
+  Under `--prefix` it reports and never changes anything. The aging rules
+  live in `shadow_core::shadow::Aging`, with checked arithmetic over fields
+  anyone who can write `/etc/shadow` chooses
+
+- `usermod` gained `-v/--add-subuids`, `-V/--del-subuids`, `-w/--add-subgids`
+  and `-W/--del-subgids`, each repeatable. A range the user already holds is
+  not added twice; a removal trims, splits or deletes the entries it touches
+  and ignores a range never held; an invalid range is exit 3 before anything
+  is written. `-V` is GNU's letter, so clap's own `-V` gave way and
+  `--version` stays
+
 - `newuidmap` and `newgidmap`, tools twenty-six and twenty-seven: the setuid
   helpers that write a user namespace's `uid_map` and `gid_map`, which is what
   Podman and rootless Docker call for every container they start. The caller

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -750,6 +750,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "uu_expiry"
+version = "0.4.0"
+dependencies = [
+ "clap",
+ "rustix",
+ "shadow-core",
+ "tempfile",
+ "uucore",
+]
+
+[[package]]
 name = "uu_gpasswd"
 version = "0.4.0"
 dependencies = [
@@ -939,6 +950,7 @@ dependencies = [
  "uu_chgpasswd",
  "uu_chpasswd",
  "uu_chsh",
+ "uu_expiry",
  "uu_gpasswd",
  "uu_groupadd",
  "uu_groupdel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ members = [
     "src/uu/login",
     "src/uu/newuidmap",
     "src/uu/newgidmap",
+    "src/uu/expiry",
 ]
 
 [workspace.package]
@@ -116,18 +117,19 @@ grpunconv = { optional = true, version = "0.4.0", package = "uu_grpunconv", path
 login = { optional = true, version = "0.4.0", package = "uu_login", path = "src/uu/login" }
 newuidmap = { optional = true, version = "0.4.0", package = "uu_newuidmap", path = "src/uu/newuidmap" }
 newgidmap = { optional = true, version = "0.4.0", package = "uu_newgidmap", path = "src/uu/newgidmap" }
+expiry = { optional = true, version = "0.4.0", package = "uu_expiry", path = "src/uu/expiry" }
 
 [features]
 default = ["passwd", "pwck", "useradd", "userdel", "usermod", "chpasswd", "chage",
            "groupadd", "groupdel", "groupmod", "grpck", "chfn", "chsh", "newgrp", "gpasswd",
            "sg", "chgpasswd", "newusers", "vipw", "vigr",
            "pwconv", "pwunconv", "grpconv", "grpunconv", "login", "newuidmap",
-           "newgidmap"]
+           "newgidmap", "expiry"]
 
 # PAM authentication (requires libpam-dev). The `?` matters: without it,
 # asking for PAM would drag in the three applets that can use it even when the
 # build deliberately left them out.
-pam = ["passwd?/pam", "chfn?/pam", "chsh?/pam", "login?/pam"]
+pam = ["passwd?/pam", "chfn?/pam", "chsh?/pam", "login?/pam", "expiry?/pam"]
 
 # Shell completions generator
 completions = ["dep:clap_complete"]
@@ -169,6 +171,7 @@ grpunconv = { version = "0.4.0", package = "uu_grpunconv", path = "src/uu/grpunc
 login = { version = "0.4.0", package = "uu_login", path = "src/uu/login" }
 newuidmap = { version = "0.4.0", package = "uu_newuidmap", path = "src/uu/newuidmap" }
 newgidmap = { version = "0.4.0", package = "uu_newgidmap", path = "src/uu/newgidmap" }
+expiry = { version = "0.4.0", package = "uu_expiry", path = "src/uu/expiry" }
 passwd = { version = "0.4.0", package = "uu_passwd", path = "src/uu/passwd" }
 useradd = { version = "0.4.0", package = "uu_useradd", path = "src/uu/useradd" }
 userdel = { version = "0.4.0", package = "uu_userdel", path = "src/uu/userdel" }

--- a/Makefile
+++ b/Makefile
@@ -20,9 +20,12 @@ ROOT_TOOLS = useradd userdel usermod chpasswd chgpasswd newusers \
 # login lives in bin too, and is root-only without being setuid: getty runs
 # it as root, and it refuses to run as anyone else.
 USER_BIN_TOOLS = chage login
-USER_TOOLS = $(SETUID_TOOLS) $(USER_BIN_TOOLS)
+# expiry reads the caller's own /etc/shadow line and nothing else, and the GNU
+# suite ships it setgid shadow -- enough to read the file, no more.
+SETGID_SHADOW_TOOLS = expiry
+USER_TOOLS = $(SETUID_TOOLS) $(USER_BIN_TOOLS) $(SETGID_SHADOW_TOOLS)
 
-ALL_TOOLS = $(SETUID_TOOLS) $(ROOT_TOOLS) $(USER_BIN_TOOLS)
+ALL_TOOLS = $(SETUID_TOOLS) $(ROOT_TOOLS) $(USER_BIN_TOOLS) $(SETGID_SHADOW_TOOLS)
 
 .PHONY: all build build-multicall build-arm64 dist-musl check test test-gnu-compat test-unprivileged test-arm64 install install-multicall uninstall clean
 
@@ -34,7 +37,7 @@ all: build
 # build requirement in the README.
 build:
 	cargo build --release --workspace --bins --exclude uu_shadow \
-		--features uu_passwd/pam,uu_chfn/pam,uu_chsh/pam,uu_login/pam
+		--features uu_passwd/pam,uu_chfn/pam,uu_chsh/pam,uu_login/pam,uu_expiry/pam
 
 build-multicall:
 	cargo build --release --bin shadow-rs --features pam
@@ -137,7 +140,7 @@ test-unprivileged:
 test-gnu-compat:
 	bash tests/gnu-compat.sh
 
-# Default install: 27 standalone per-tool binaries, with the setuid layout and
+# Default install: 28 standalone per-tool binaries, with the setuid layout and
 # the bin/sbin split GNU shadow-utils uses. Only $(SETUID_TOOLS) are setuid.
 install: build
 	@for tool in $(SETUID_TOOLS); do \
@@ -146,12 +149,16 @@ install: build
 	@for tool in $(USER_BIN_TOOLS); do \
 		install -Dm0755 target/release/$$tool $(DESTDIR)$(BINDIR)/$$tool || exit 1; \
 	done
+	@for tool in $(SETGID_SHADOW_TOOLS); do \
+		install -Dm2755 -g shadow target/release/$$tool $(DESTDIR)$(BINDIR)/$$tool || exit 1; \
+	done
 	@for tool in $(ROOT_TOOLS); do \
 		install -Dm0755 target/release/$$tool $(DESTDIR)$(SBINDIR)/$$tool || exit 1; \
 	done
 	@echo "Installed $(words $(ALL_TOOLS)) standalone binaries"
 	@echo "  $(DESTDIR)$(BINDIR)/  setuid (4755): $(SETUID_TOOLS)"
 	@echo "  $(DESTDIR)$(BINDIR)/  user (0755):   $(USER_BIN_TOOLS)"
+	@echo "  $(DESTDIR)$(BINDIR)/  setgid shadow (2755): $(SETGID_SHADOW_TOOLS)"
 	@echo "  $(DESTDIR)$(SBINDIR)/ root (0755):   $(ROOT_TOOLS)"
 
 # Opt-in install: single multicall binary with symlinks. Smaller footprint.

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ default-in-Ubuntu in under 3 years. This project follows that playbook.
 | `login` | **Implemented.** What getty runs: prompts, PAM authentication and session, utmp/wtmp, terminal handover, a login shell. Needs the `pam` feature. |
 | `newuidmap` | **Implemented.** Writes a user namespace's `uid_map` within the caller's `/etc/subuid` grant; what rootless containers call. |
 | `newgidmap` | **Implemented.** `newuidmap` for `gid_map` and `/etc/subgid`. |
+| `expiry` | **Implemented.** Checks the caller's own password aging and forces the change `login` would; setgid `shadow`. |
 
 ## Scope
 
@@ -94,7 +95,9 @@ implemented. Of the rest:
 | tool | status |
 |---|---|
 | `login` | shipped. Debian 13 and Ubuntu 25.10 take `login` from util-linux, but every release in service today — Ubuntu 20.04, 22.04 and 24.04, Debian 12 — ships shadow's, and `uutils/login` was archived pointing here. It implements the option set the two share, plus util-linux's `-H` |
-| `expiry`, `groupmems` | Debian's tail; in scope, not yet shipped. `faillog` and `lastlog` left the Debian package with 13 and are not planned |
+| `expiry` | shipped |
+| `groupmems` | out of scope. Debian 13 and Fedora do not ship it; Ubuntu 24.04 does, without a `/etc/pam.d/groupmems`, so every action there fails against PAM's default — a tool one distribution ships and none can use |
+| `faillog`, `lastlog` | left the Debian package with 13; not planned |
 | `newuidmap`, `newgidmap` | shipped. Fedora's pair, the basis of rootless containers |
 | `shadowconfig`, `cpgr`, `cppw`, `adduser` | Debian packaging scripts and a Fedora symlink, not upstream tools; out of scope |
 
@@ -147,9 +150,9 @@ docker compose run --rm debian cargo build --release
 
 ### Install
 
-Default install: 27 standalone per-tool binaries with least-privilege setuid
+Default install: 28 standalone per-tool binaries with least-privilege setuid
 layout matching GNU shadow-utils. Only `passwd`, `chfn`, `chsh`, `newgrp`,
-`gpasswd`, `sg`, `newuidmap` and `newgidmap` are installed setuid-root; the other 19 are plain `0755`.
+`gpasswd`, `sg`, `newuidmap` and `newgidmap` are installed setuid-root, `expiry` is setgid `shadow`; the other 19 are plain `0755`.
 
 ```shell
 sudo make install PREFIX=/usr/local
@@ -202,7 +205,7 @@ sudo install -o root -g root -m 4755 \
     uu_shadow-*/shadow-rs /usr/local/bin/shadow-rs
 for tool in passwd chfn chsh newgrp gpasswd sg chage chpasswd chgpasswd newusers \
             groupadd groupdel groupmod grpck pwck useradd userdel usermod vipw vigr \
-            pwconv pwunconv grpconv grpunconv login newuidmap newgidmap; do
+            pwconv pwunconv grpconv grpunconv login newuidmap newgidmap expiry; do
     sudo ln -sf shadow-rs "/usr/local/bin/$tool"
 done
 ```

--- a/docs/PLATFORM-SUPPORT.md
+++ b/docs/PLATFORM-SUPPORT.md
@@ -86,6 +86,10 @@ Effect, and this is the heaviest of the three gaps:
   than apply an unverified one, so without PAM they refuse every non-root
   invocation outright.
 
+`expiry -c` reports without PAM; the forced change it performs on an expired
+password goes through PAM, and the static build says so and points at
+`passwd(1)` instead.
+
 `newuidmap` and `newgidmap` need neither PAM nor NSS beyond `getpwuid_r` for
 the caller, and work in the static build.
 

--- a/docs/SECURITY-HARDENING.md
+++ b/docs/SECURITY-HARDENING.md
@@ -8,7 +8,7 @@ Techniques adopted from OpenBSD and best practices for setuid-root tools.
 
 - [x] `caller_is_root()` uses `getuid()` not `geteuid()` for authorization
 - [x] In the multicall layout, an applet outside
-      `passwd`/`chfn`/`chsh`/`newgrp`/`gpasswd`/`sg`/`newuidmap`/`newgidmap`
+      `passwd`/`chfn`/`chsh`/`newgrp`/`gpasswd`/`sg`/`newuidmap`/`newgidmap`/`expiry`
       drops to the caller's uid before running, so the single setuid binary has
       the same privilege model as the per-tool install — and fails closed if the
       kernel will not take the privilege away

--- a/docs/man/expiry.1.md
+++ b/docs/man/expiry.1.md
@@ -1,0 +1,82 @@
+# expiry(1) - check and enforce password expiration
+
+## NAME
+
+expiry - check and enforce password expiration policy
+
+## SYNOPSIS
+
+**expiry** [**-c**] [**-f**]
+
+## DESCRIPTION
+
+**expiry** looks at the calling user's own /etc/shadow line and does what
+**login**(1) would do with it. When all is well it says nothing. When the
+password is due to expire within its warning period it says so. When the
+password has expired it says so and requires a new one on the spot, through
+PAM, exactly as **passwd**(1) would. When the account itself has expired it
+turns the caller away.
+
+It exists for sessions that did not come through **login**: a display
+manager, an ssh key, a **su** without a password. Shell profiles run
+`expiry -c` so those sessions still meet the aging policy.
+
+## OPTIONS
+
+**-c**, **--check**
+:   Check the caller's password expiration, and enforce what is found.
+
+**-f**, **--force**
+:   Force a password change if the caller's password has expired.
+
+With either option the behaviour is the same, as it is in the GNU tool; with
+neither, nothing is asked and the usage is printed. **-P**/**--prefix** reads
+the account files under another directory and only reports, since a PAM
+change would act on this system's account of the same name.
+
+## WHAT IS DECIDED, IN ORDER
+
+1. A locked password is a policy of its own and is not reported.
+2. An expiration date in the past, or a password expired for longer than its
+   inactivity period, means the account is disabled: *Your account has
+   expired; please contact your system administrator.* Exit 1.
+3. A last-change day of 0, or a password older than its maximum age, must be
+   changed: *You are required to change your password immediately (password
+   expired).* followed by the change. Exit 0 once it is made.
+4. Inside the warning period: *Your password will expire in N days.* — or
+   *tomorrow*, or *today*. Exit 0.
+5. Otherwise, silence and exit 0.
+
+A maximum age of 10000 days or more means never, as **chage -l** prints it.
+
+## PRIVILEGES
+
+The GNU suite installs **expiry** setgid **shadow**: enough to read
+/etc/shadow, no more, and the password change runs through PAM as the caller.
+The per-tool install here does the same. The single multicall binary keeps its
+setuid privilege for **expiry**, having nothing narrower to offer, and reads
+the one line it needs.
+
+## EXIT STATUS
+
+**0**
+:   Nothing to enforce, a warning issued, or the required change made.
+
+**1**
+:   The account has expired, or the required change failed, or the account
+    files could not be read.
+
+**2**
+:   Invalid command syntax, including neither **-c** nor **-f**.
+
+## FILES
+
+/etc/passwd, /etc/shadow
+:   The caller's account and aging information.
+
+/etc/pam.d/passwd
+:   The PAM service the change goes through.
+
+## SEE ALSO
+
+chage(1), login(1), passwd(1), shadow(5)

--- a/docs/man/usermod.8.md
+++ b/docs/man/usermod.8.md
@@ -64,6 +64,28 @@ changes that are specified on the command line.
 :   Unlock the user's password by removing the '!' prefix from the
     shadow password.
 
+## SUBORDINATE IDS
+
+**-v**, **--add-subuids** *FIRST-LAST*
+:   Grant the user the subordinate user IDs *FIRST* to *LAST*, inclusive, in
+    /etc/subuid. A range the user already holds is not added again. May be
+    repeated.
+
+**-V**, **--del-subuids** *FIRST-LAST*
+:   Revoke the range. An entry the range covers disappears; one it overlaps is
+    trimmed, and one it cuts through the middle of is split, so the IDs on
+    either side stay granted. A range the user never held is a no-op.
+
+**-w**, **--add-subgids** *FIRST-LAST*, **-W**, **--del-subgids** *FIRST-LAST*
+:   The same for subordinate group IDs and /etc/subgid.
+
+An invalid range — reversed, not two numbers, above 2³²−1 — is refused with
+exit status 3 before anything is written. Entries are keyed by the login name
+given on the command line and are not renamed by **-l**: a range is a grant to
+a name, and an administrator who renames the account re-grants it if that is
+what they meant. Because **-V** is this option, **--version** has no short
+form.
+
 ## EXIT STATUS
 
 **0**

--- a/src/bin/completions.rs
+++ b/src/bin/completions.rs
@@ -33,6 +33,8 @@ fn get_tool_app(name: &str) -> Option<Command> {
         "chpasswd" => Some(chpasswd::uu_app()),
         #[cfg(feature = "chsh")]
         "chsh" => Some(chsh::uu_app()),
+        #[cfg(feature = "expiry")]
+        "expiry" => Some(expiry::uu_app()),
         #[cfg(feature = "groupadd")]
         "groupadd" => Some(groupadd::uu_app()),
         #[cfg(feature = "groupdel")]
@@ -94,6 +96,8 @@ fn all_tool_names() -> Vec<&'static str> {
     names.push("chpasswd");
     #[cfg(feature = "chsh")]
     names.push("chsh");
+    #[cfg(feature = "expiry")]
+    names.push("expiry");
     #[cfg(feature = "groupadd")]
     names.push("groupadd");
     #[cfg(feature = "groupdel")]

--- a/src/bin/shadow-rs.rs
+++ b/src/bin/shadow-rs.rs
@@ -11,7 +11,8 @@
 //! # Privileges
 //!
 //! The per-tool install makes only `passwd`, `chfn`, `chsh`, `newgrp`,
-//! `gpasswd`, `sg`, `newuidmap` and `newgidmap` setuid-root.
+//! `gpasswd`, `sg`, `newuidmap` and `newgidmap` setuid-root, and `expiry`
+//! setgid `shadow`.
 //! A multicall install has to make the one binary setuid, which
 //! would hand euid 0 to every applet — an unprivileged `pwck -s` rewriting
 //! `/etc/passwd`. So before an applet outside that set runs, the binary drops
@@ -30,8 +31,11 @@ type Applet = fn(&[OsString]) -> i32;
 /// it has to read `/etc/gshadow` to check a group password, and the GNU suite
 /// ships it as a symlink to the setuid `newgrp` for exactly that. The two id
 /// mappers are here because writing a namespace's map beyond the caller's
-/// own id needs `CAP_SETUID`/`CAP_SETGID` in the parent namespace.
-const SETUID_APPLETS: [&str; 8] = [
+/// own id needs `CAP_SETUID`/`CAP_SETGID` in the parent namespace. `expiry`
+/// is setgid `shadow` in the per-tool install, which is only enough to read
+/// `/etc/shadow`; a single setuid binary has nothing that narrow to offer, so
+/// it keeps euid 0 here and reads the one line it needs.
+const SETUID_APPLETS: [&str; 9] = [
     "passwd",
     "chfn",
     "chsh",
@@ -40,6 +44,7 @@ const SETUID_APPLETS: [&str; 8] = [
     "sg",
     "newuidmap",
     "newgidmap",
+    "expiry",
 ];
 
 /// Every applet compiled into this binary, by name, in `--list` order.
@@ -50,7 +55,7 @@ const SETUID_APPLETS: [&str; 8] = [
 // nothing, and the binding is then not mutated.
 #[allow(unused_mut)]
 fn applets() -> Vec<(&'static str, Applet)> {
-    let mut table: Vec<(&'static str, Applet)> = Vec::with_capacity(27);
+    let mut table: Vec<(&'static str, Applet)> = Vec::with_capacity(28);
     #[cfg(feature = "chage")]
     table.push(("chage", |a| chage::uumain(a.iter().cloned())));
     #[cfg(feature = "chfn")]
@@ -61,6 +66,8 @@ fn applets() -> Vec<(&'static str, Applet)> {
     table.push(("chpasswd", |a| chpasswd::uumain(a.iter().cloned())));
     #[cfg(feature = "chsh")]
     table.push(("chsh", |a| chsh::uumain(a.iter().cloned())));
+    #[cfg(feature = "expiry")]
+    table.push(("expiry", |a| expiry::uumain(a.iter().cloned())));
     #[cfg(feature = "gpasswd")]
     table.push(("gpasswd", |a| gpasswd::uumain(a.iter().cloned())));
     #[cfg(feature = "groupadd")]
@@ -263,12 +270,13 @@ fn print_available_utils() {
 mod tests {
     use super::*;
 
-    const ALL_TOOLS: [&str; 27] = [
+    const ALL_TOOLS: [&str; 28] = [
         "chage",
         "chfn",
         "chgpasswd",
         "chpasswd",
         "chsh",
+        "expiry",
         "gpasswd",
         "groupadd",
         "groupdel",
@@ -322,6 +330,7 @@ mod tests {
                         | "sg"
                         | "newuidmap"
                         | "newgidmap"
+                        | "expiry"
                 ),
                 "{tool}"
             );

--- a/src/shadow-core/src/nscd.rs
+++ b/src/shadow-core/src/nscd.rs
@@ -28,12 +28,14 @@ pub fn invalidate_cache(database: &str) {
     let safe_env = hardening::sanitized_env();
 
     // Use absolute paths to avoid PATH-based lookups in setuid context.
-    let _ = Command::new("/usr/sbin/nscd")
-        .arg("-i")
-        .arg(database)
-        .env_clear()
-        .envs(safe_env.iter().map(|(k, v)| (k, v)))
-        .status();
+    if let Some(nscd_db) = nscd_database(database) {
+        let _ = Command::new("/usr/sbin/nscd")
+            .arg("-i")
+            .arg(nscd_db)
+            .env_clear()
+            .envs(safe_env.iter().map(|(k, v)| (k, v)))
+            .status();
+    }
 
     // sssd: sss_cache with the appropriate flag
     let flag = match database {
@@ -46,4 +48,31 @@ pub fn invalidate_cache(database: &str) {
         .env_clear()
         .envs(safe_env.iter().map(|(k, v)| (k, v)))
         .status();
+}
+
+/// The nscd cache that a change to `database` can leave stale, if any.
+///
+/// nscd caches `passwd`, `group`, `hosts`, `services` and `netgroup`. It has
+/// never cached `shadow` -- the entries it holds carry the `x` placeholder --
+/// so a password change leaves nothing of nscd's stale, and asking it to
+/// invalidate `shadow` only made every `passwd` and `chage` print *nscd:
+/// 'shadow' is not a known database* on the user's terminal.
+fn nscd_database(database: &str) -> Option<&str> {
+    match database {
+        "passwd" | "group" | "hosts" | "services" | "netgroup" => Some(database),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_shadow_is_not_an_nscd_database() {
+        assert_eq!(nscd_database("passwd"), Some("passwd"));
+        assert_eq!(nscd_database("group"), Some("group"));
+        assert_eq!(nscd_database("shadow"), None);
+        assert_eq!(nscd_database("gshadow"), None);
+    }
 }

--- a/src/shadow-core/src/shadow.rs
+++ b/src/shadow-core/src/shadow.rs
@@ -624,3 +624,195 @@ mod tests {
         }
     }
 }
+
+// ---------------------------------------------------------------------------
+// Aging: what an account's shadow line says about logging in today
+// ---------------------------------------------------------------------------
+
+/// What the aging fields mean for a login attempt on a given day.
+///
+/// The order of the variants is the order the checks are made in; the first
+/// that applies wins, which is how `login` and `expiry` behave.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Aging {
+    /// The account has expired, or its password has been expired for longer
+    /// than the inactivity period allows. No login, no password change.
+    AccountExpired,
+    /// The password must be changed before the session continues: it was
+    /// expired by an administrator (`last_change` of 0) or has aged past
+    /// `max_age`.
+    MustChange,
+    /// The password expires within `warn_days`; `0` means today.
+    ExpiresIn(i64),
+    /// Nothing to report.
+    Ok,
+}
+
+/// A `max_age` at or above this many days disables expiry, as `chage -l`
+/// prints `never` at this value.
+const NEVER: i64 = 10_000;
+
+impl ShadowEntry {
+    /// Judge the aging fields as of `today` (days since the epoch).
+    ///
+    /// Arithmetic is checked: every input is read from a file anyone who can
+    /// write `/etc/shadow` chooses, and plain addition wraps in release builds.
+    #[must_use]
+    pub fn aging(&self, today: i64) -> Aging {
+        if let Some(expire) = self.expire_date
+            && expire > 0
+            && today >= expire
+        {
+            return Aging::AccountExpired;
+        }
+        let Some(last) = self.last_change else {
+            // No date at all: nothing is enforced.
+            return Aging::Ok;
+        };
+        if last == 0 {
+            return Aging::MustChange;
+        }
+        let Some(max) = self.max_age.filter(|m| *m >= 0 && *m < NEVER) else {
+            return Aging::Ok;
+        };
+        let Some(expires) = last.checked_add(max) else {
+            return Aging::Ok;
+        };
+        if today > expires {
+            // Past the inactivity period the account itself is disabled.
+            if let Some(inactive) = self.inactive_days.filter(|i| *i >= 0)
+                && let Some(limit) = expires.checked_add(inactive)
+                && today > limit
+            {
+                return Aging::AccountExpired;
+            }
+            return Aging::MustChange;
+        }
+        if let Some(warn) = self.warn_days.filter(|w| *w > 0)
+            && let Some(warn_from) = expires.checked_sub(warn)
+            && today >= warn_from
+        {
+            return Aging::ExpiresIn(expires - today);
+        }
+        Aging::Ok
+    }
+}
+
+#[cfg(test)]
+mod aging_tests {
+    use super::*;
+
+    fn entry(
+        last: Option<i64>,
+        max: Option<i64>,
+        warn: Option<i64>,
+        inactive: Option<i64>,
+        expire: Option<i64>,
+    ) -> ShadowEntry {
+        ShadowEntry {
+            name: "a".to_string(),
+            passwd: "$6$x$y".to_string(),
+            last_change: last,
+            min_age: Some(0),
+            max_age: max,
+            warn_days: warn,
+            inactive_days: inactive,
+            expire_date: expire,
+            reserved: String::new(),
+        }
+    }
+
+    #[test]
+    fn test_healthy_and_never() {
+        assert_eq!(
+            entry(Some(20_000), Some(99_999), Some(7), None, None).aging(20_100),
+            Aging::Ok
+        );
+        assert_eq!(
+            entry(Some(20_000), None, Some(7), None, None).aging(30_000),
+            Aging::Ok
+        );
+        assert_eq!(
+            entry(None, Some(1), Some(7), None, None).aging(30_000),
+            Aging::Ok,
+            "no date, nothing enforced"
+        );
+        assert_eq!(
+            entry(Some(20_000), Some(10_000), Some(7), None, None).aging(40_000),
+            Aging::Ok,
+            "10000 means never"
+        );
+    }
+
+    #[test]
+    fn test_must_change() {
+        assert_eq!(
+            entry(Some(0), Some(99_999), None, None, None).aging(20_000),
+            Aging::MustChange,
+            "last change 0 is the admin's marker"
+        );
+        assert_eq!(
+            entry(Some(20_000), Some(30), None, None, None).aging(20_031),
+            Aging::MustChange
+        );
+        assert_eq!(
+            entry(Some(20_000), Some(30), None, None, None).aging(20_030),
+            Aging::Ok,
+            "the last valid day is not yet expired"
+        );
+    }
+
+    #[test]
+    fn test_warning_window() {
+        let e = entry(Some(20_000), Some(30), Some(7), None, None);
+        assert_eq!(e.aging(20_022), Aging::Ok);
+        assert_eq!(e.aging(20_023), Aging::ExpiresIn(7));
+        assert_eq!(e.aging(20_029), Aging::ExpiresIn(1));
+        assert_eq!(e.aging(20_030), Aging::ExpiresIn(0));
+    }
+
+    #[test]
+    fn test_account_expiry_and_inactivity() {
+        assert_eq!(
+            entry(Some(20_000), Some(99_999), None, None, Some(20_050)).aging(20_050),
+            Aging::AccountExpired
+        );
+        assert_eq!(
+            entry(Some(20_000), Some(99_999), None, None, Some(20_050)).aging(20_049),
+            Aging::Ok
+        );
+        let e = entry(Some(20_000), Some(30), None, Some(5), None);
+        assert_eq!(
+            e.aging(20_033),
+            Aging::MustChange,
+            "within the inactivity period"
+        );
+        assert_eq!(
+            e.aging(20_036),
+            Aging::AccountExpired,
+            "past it, the account is disabled"
+        );
+        assert_eq!(
+            entry(Some(20_000), Some(99_999), None, None, Some(0)).aging(30_000),
+            Aging::Ok,
+            "an expiry of 0 is unset"
+        );
+    }
+
+    /// Values from the file are hostile until proven otherwise.
+    #[test]
+    fn test_arithmetic_is_checked() {
+        assert_eq!(
+            entry(Some(i64::MAX), Some(5), Some(7), None, None).aging(20_000),
+            Aging::Ok
+        );
+        assert_eq!(
+            entry(Some(20_000), Some(5), Some(i64::MAX), None, None).aging(20_004),
+            Aging::ExpiresIn(1)
+        );
+        assert_eq!(
+            entry(Some(20_000), Some(5), None, Some(i64::MAX), None).aging(30_000),
+            Aging::MustChange
+        );
+    }
+}

--- a/src/shadow-core/src/subid.rs
+++ b/src/shadow-core/src/subid.rs
@@ -241,3 +241,170 @@ mod tests {
         }
     }
 }
+
+// ---------------------------------------------------------------------------
+// Ranges: what usermod -v/-V/-w/-W do to a user's entries
+// ---------------------------------------------------------------------------
+
+/// Parse `FIRST-LAST`, both inclusive, as usermod(8) spells a range.
+///
+/// Plain decimals only, `LAST` not below `FIRST`, and nothing above the
+/// 32-bit ids the kernel maps. `None` for anything else, which the caller
+/// reports as an invalid range.
+#[must_use]
+pub fn parse_range(spec: &str) -> Option<(u64, u64)> {
+    let (first, last) = spec.split_once('-')?;
+    let number = |s: &str| {
+        (!s.is_empty() && s.bytes().all(|b| b.is_ascii_digit()))
+            .then(|| s.parse::<u64>().ok())
+            .flatten()
+            .filter(|n| u32::try_from(*n).is_ok())
+    };
+    let (first, last) = (number(first)?, number(last)?);
+    (last >= first).then_some((first, last))
+}
+
+/// Grant `[first, last]` to `name`.
+///
+/// A range already covered by one of the user's entries is left alone -- the
+/// grant exists, and a second copy would only confuse whoever reads the file
+/// -- otherwise a new entry is appended. No check is made against other
+/// users' entries: the GNU tool makes none, and an administrator may
+/// deliberately share a range.
+pub fn add_range(entries: &mut Vec<SubIdEntry>, name: &str, first: u64, last: u64) {
+    let covered = entries
+        .iter()
+        .any(|e| e.name == name && e.start <= first && last < e.start + e.count);
+    if !covered {
+        entries.push(SubIdEntry {
+            name: name.to_string(),
+            start: first,
+            count: last - first + 1,
+        });
+    }
+}
+
+/// Revoke `[first, last]` from `name`.
+///
+/// An entry the range covers entirely disappears; one it overlaps is trimmed,
+/// and one it cuts through the middle of is split in two, so the ids on
+/// either side stay granted. A range the user never had is a no-op.
+pub fn remove_range(entries: &mut Vec<SubIdEntry>, name: &str, first: u64, last: u64) {
+    let mut kept = Vec::with_capacity(entries.len() + 1);
+    for e in entries.drain(..) {
+        if e.name != name || e.count == 0 {
+            kept.push(e);
+            continue;
+        }
+        let (start, end) = (e.start, e.start + e.count - 1);
+        if last < start || first > end {
+            kept.push(e);
+            continue;
+        }
+        if start < first {
+            kept.push(SubIdEntry {
+                name: e.name.clone(),
+                start,
+                count: first - start,
+            });
+        }
+        if end > last {
+            kept.push(SubIdEntry {
+                name: e.name.clone(),
+                start: last + 1,
+                count: end - last,
+            });
+        }
+    }
+    *entries = kept;
+}
+
+#[cfg(test)]
+mod range_tests {
+    use super::*;
+
+    fn e(name: &str, start: u64, count: u64) -> SubIdEntry {
+        SubIdEntry {
+            name: name.to_string(),
+            start,
+            count,
+        }
+    }
+
+    #[test]
+    fn test_parse_range() {
+        assert_eq!(parse_range("300000-300999"), Some((300_000, 300_999)));
+        assert_eq!(parse_range("5-5"), Some((5, 5)));
+        assert_eq!(parse_range("0-10"), Some((0, 10)));
+        for bad in [
+            "300999-300000",
+            "a-b",
+            "300000",
+            "-5",
+            "5-",
+            "1-4294967296",
+            " 1-2",
+            "1-2-3",
+        ] {
+            assert_eq!(parse_range(bad), None, "{bad:?}");
+        }
+    }
+
+    /// Adding appends, unless the user already holds the range.
+    #[test]
+    fn test_add_range() {
+        let mut v = vec![e("alice", 100_000, 65_536)];
+        add_range(&mut v, "alice", 300_000, 300_999);
+        assert_eq!(v.len(), 2);
+        assert_eq!((v[1].start, v[1].count), (300_000, 1000));
+        add_range(&mut v, "alice", 300_000, 300_999);
+        add_range(&mut v, "alice", 300_500, 300_600);
+        assert_eq!(v.len(), 2, "covered ranges are not added again");
+        add_range(&mut v, "bob", 300_000, 300_999);
+        assert_eq!(v.len(), 3, "another user may hold the same ids");
+    }
+
+    /// Removing trims, splits or deletes, and ignores what was never there.
+    #[test]
+    fn test_remove_range() {
+        let mut v = vec![e("alice", 300_000, 1000), e("bob", 300_000, 1000)];
+        remove_range(&mut v, "alice", 300_000, 300_499);
+        assert_eq!(
+            v.iter()
+                .filter(|x| x.name == "alice")
+                .map(|x| (x.start, x.count))
+                .collect::<Vec<_>>(),
+            vec![(300_500, 500)]
+        );
+        assert!(
+            v.iter().any(|x| x.name == "bob" && x.count == 1000),
+            "bob is untouched"
+        );
+
+        remove_range(&mut v, "alice", 300_700, 300_799);
+        let alice: Vec<_> = v
+            .iter()
+            .filter(|x| x.name == "alice")
+            .map(|x| (x.start, x.count))
+            .collect();
+        assert_eq!(
+            alice,
+            vec![(300_500, 200), (300_800, 200)],
+            "a cut in the middle splits"
+        );
+
+        remove_range(&mut v, "alice", 500_000, 500_010);
+        assert_eq!(
+            v.iter().filter(|x| x.name == "alice").count(),
+            2,
+            "a range never held is a no-op"
+        );
+
+        remove_range(&mut v, "alice", 300_000, 300_999);
+        assert_eq!(
+            v.iter().filter(|x| x.name == "alice").count(),
+            0,
+            "covered entries disappear"
+        );
+    }
+}

--- a/src/uu/expiry/Cargo.toml
+++ b/src/uu/expiry/Cargo.toml
@@ -1,0 +1,39 @@
+[package]
+name = "uu_expiry"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+categories.workspace = true
+rust-version.workspace = true
+description = "expiry ~ (shadow-rs) check and enforce password expiration"
+
+[lib]
+path = "src/expiry.rs"
+
+[[bin]]
+name = "expiry"
+path = "src/main.rs"
+
+[dependencies]
+clap = { workspace = true }
+rustix = { workspace = true }
+shadow-core = { workspace = true }
+uucore = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }
+
+[features]
+default = []
+pam = ["shadow-core/pam"]
+
+[lints]
+workspace = true
+
+# Distributed via the `shadow-rs` multicall binary in the workspace root
+# package, not as a standalone archive (see dist-workspace.toml, issue #207).
+[package.metadata.dist]
+dist = false

--- a/src/uu/expiry/locales/en-US.ftl
+++ b/src/uu/expiry/locales/en-US.ftl
@@ -1,0 +1,2 @@
+expiry-about = Check and enforce password expiration
+expiry-usage = expiry [-c] [-f]

--- a/src/uu/expiry/src/expiry.rs
+++ b/src/uu/expiry/src/expiry.rs
@@ -1,0 +1,316 @@
+// This file is part of the shadow-rs package.
+//
+// For the full copyright and license information, please view the LICENSE
+// file that was distributed with this source code.
+// spell-checker:ignore setgid chauthtok
+
+//! `expiry` — check and enforce password expiration.
+//!
+//! Drop-in replacement for shadow-utils `expiry(1)`. It looks at the caller's
+//! own shadow line and does what `login` would do with it: says nothing if
+//! all is well, warns when the password is about to expire, forces a change
+//! when it has, and turns the caller away when the account itself has
+//! expired. Shell profiles run it so a session started by something other
+//! than `login` -- a display manager, an ssh key -- still meets the policy.
+//!
+//! The GNU tool is setgid `shadow`: enough to read `/etc/shadow`, and the
+//! password change goes through PAM as the caller. That is how the per-tool
+//! install ships it. The single setuid binary keeps euid 0 for it instead,
+//! having nothing narrower to offer.
+
+use std::fmt;
+use std::io::Write as _;
+use std::path::Path;
+
+use clap::{Arg, ArgAction, Command};
+
+use shadow_core::shadow::{Aging, ShadowEntry};
+use shadow_core::sysroot::SysRoot;
+
+use uucore::error::{UError, UResult};
+
+mod options {
+    pub const CHECK: &str = "check";
+    pub const FORCE: &str = "force";
+    pub const PREFIX: &str = "prefix";
+}
+
+/// The PAM service the change goes through, as `passwd` does.
+#[cfg(feature = "pam")]
+const PAM_SERVICE: &str = "passwd";
+
+/// Errors `expiry` can produce.
+#[derive(Debug)]
+enum ExpiryError {
+    /// Exit 1 — the account may not continue, or the change failed.
+    Refused(String),
+    /// Exit 1 — the caller or their shadow line could not be read.
+    Failure(String),
+    /// Exit 2 — usage.
+    Usage(String),
+}
+
+impl fmt::Display for ExpiryError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Refused(m) | Self::Failure(m) | Self::Usage(m) => f.write_str(m),
+        }
+    }
+}
+
+impl std::error::Error for ExpiryError {}
+
+impl UError for ExpiryError {
+    fn code(&self) -> i32 {
+        match self {
+            Self::Refused(_) | Self::Failure(_) => 1,
+            Self::Usage(_) => 2,
+        }
+    }
+}
+
+/// The words `login` uses, which people and scripts know.
+const ACCOUNT_EXPIRED: &str = "Your account has expired; please contact your system administrator.";
+const MUST_CHANGE: &str =
+    "You are required to change your password immediately (password expired).";
+
+/// The warning for a password expiring in `days`.
+fn warning(days: i64) -> String {
+    match days {
+        0 => "Your password will expire today.".to_string(),
+        1 => "Your password will expire tomorrow.".to_string(),
+        n => format!("Your password will expire in {n} days."),
+    }
+}
+
+/// Entry point for the `expiry` utility.
+#[uucore::main]
+pub fn uumain(args: impl uucore::Args) -> UResult<()> {
+    shadow_core::hardening::harden_process();
+
+    let Some(matches) = shadow_core::cli::parse_args(uu_app(), args, |_| 2)? else {
+        return Ok(());
+    };
+    let check = matches.get_flag(options::CHECK);
+    let force = matches.get_flag(options::FORCE);
+    if !check && !force {
+        // expiry(1) does nothing without being asked; the GNU tool prints its
+        // usage and exits 2.
+        return Err(ExpiryError::Usage("one of -c or -f is required".into()).into());
+    }
+    let prefix = matches.get_one::<String>(options::PREFIX).map(Path::new);
+    let root = SysRoot::new(prefix);
+
+    let uid = rustix::process::getuid().as_raw();
+    let account = shadow_core::hardening::lookup_passwd_entry_by_uid(uid)
+        .map_err(|e| ExpiryError::Failure(format!("cannot identify the caller: {e}")))?;
+
+    let shadow_path = root.shadow_path();
+    let entries = shadow_core::shadow::read_shadow_file(&shadow_path)
+        .map_err(|e| ExpiryError::Failure(format!("cannot read {}: {e}", shadow_path.display())))?;
+    let Some(entry) = entries.iter().find(|e| e.name == account.name) else {
+        // No shadow line: no policy to enforce.
+        return Ok(());
+    };
+    let today = shadow_core::shadow::days_since_epoch()
+        .map_err(|e| ExpiryError::Failure(format!("cannot determine the date: {e}")))?;
+
+    match judge(entry, today) {
+        Verdict::Fine => Ok(()),
+        Verdict::Warn(text) => {
+            let _ = writeln!(std::io::stdout(), "{text}");
+            Ok(())
+        }
+        Verdict::AccountExpired => {
+            let _ = writeln!(std::io::stdout(), "{ACCOUNT_EXPIRED}");
+            Err(ExpiryError::Refused("account expired".into()).into())
+        }
+        Verdict::MustChange => {
+            let _ = writeln!(std::io::stdout(), "{MUST_CHANGE}");
+            // Under --prefix the line belongs to another tree, and a PAM
+            // change would act on this system's account of the same name.
+            if prefix.is_some() {
+                return Err(ExpiryError::Refused("password change required".into()).into());
+            }
+            change_password(&account.name)
+        }
+    }
+}
+
+/// What to do about the line, as text rather than as `Aging`, so the
+/// decision and its wording can be tested without a terminal.
+#[derive(Debug, PartialEq, Eq)]
+enum Verdict {
+    Fine,
+    Warn(String),
+    MustChange,
+    AccountExpired,
+}
+
+fn judge(entry: &ShadowEntry, today: i64) -> Verdict {
+    // A locked account is not an expiring one: the lock is the policy.
+    if entry.is_locked() {
+        return Verdict::Fine;
+    }
+    match entry.aging(today) {
+        Aging::Ok => Verdict::Fine,
+        Aging::ExpiresIn(days) => Verdict::Warn(warning(days)),
+        Aging::MustChange => Verdict::MustChange,
+        Aging::AccountExpired => Verdict::AccountExpired,
+    }
+}
+
+/// Change the caller's expired password through PAM, as `passwd` would.
+///
+/// The real uid is the caller's, so `pam_unix` asks for the current password
+/// first; the euid -- root in the multicall layout, the caller's own with
+/// setgid `shadow` -- decides whether the write goes through `pam_unix`
+/// directly or through its setuid helper, and both work.
+#[cfg(feature = "pam")]
+fn change_password(user: &str) -> UResult<()> {
+    use shadow_core::pam::{ConvMode, PamContext, flags};
+
+    let mut pam = PamContext::new(PAM_SERVICE, user, ConvMode::Tty)
+        .map_err(|e| ExpiryError::Failure(format!("PAM: {e}")))?;
+    pam.chauthtok(flags::PAM_CHANGE_EXPIRED_AUTHTOK)
+        .map_err(|e| ExpiryError::Refused(format!("password change failed: {e}")))?;
+    shadow_core::audit::log_user_event(
+        "CHNG_PASSWD",
+        user,
+        rustix::process::getuid().as_raw(),
+        true,
+    );
+    Ok(())
+}
+
+#[cfg(not(feature = "pam"))]
+fn change_password(_user: &str) -> UResult<()> {
+    Err(ExpiryError::Refused(
+        "PAM support is not compiled in \u{2014} the password must be changed with passwd(1)"
+            .into(),
+    )
+    .into())
+}
+
+/// Build the clap `Command` for `expiry`.
+#[must_use]
+pub fn uu_app() -> Command {
+    Command::new("expiry")
+        .about("Check and enforce password expiration for the calling user")
+        .override_usage("expiry [-c] [-f]")
+        .version(shadow_core::cli::VERSION)
+        .after_help(shadow_core::cli::AFTER_HELP)
+        .arg(
+            Arg::new(options::CHECK)
+                .short('c')
+                .long("check")
+                .help("check the user's password expiration")
+                .action(ArgAction::SetTrue),
+        )
+        .arg(
+            Arg::new(options::FORCE)
+                .short('f')
+                .long("force")
+                .help("force a password change if the user's password has expired")
+                .action(ArgAction::SetTrue),
+        )
+        .arg(
+            Arg::new(options::PREFIX)
+                .short('P')
+                .long("prefix")
+                .help("read the account files under PREFIX_DIR; only reports, never changes")
+                .value_name("PREFIX_DIR"),
+        )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn entry(
+        last: Option<i64>,
+        max: Option<i64>,
+        warn: Option<i64>,
+        expire: Option<i64>,
+        passwd: &str,
+    ) -> ShadowEntry {
+        ShadowEntry {
+            name: "a".to_string(),
+            passwd: passwd.to_string(),
+            last_change: last,
+            min_age: Some(0),
+            max_age: max,
+            warn_days: warn,
+            inactive_days: None,
+            expire_date: expire,
+            reserved: String::new(),
+        }
+    }
+
+    #[test]
+    fn test_app_builds() {
+        uu_app().debug_assert();
+    }
+
+    #[test]
+    fn test_verdicts() {
+        assert_eq!(
+            judge(
+                &entry(Some(20_000), Some(99_999), Some(7), None, "$6$x$y"),
+                20_100
+            ),
+            Verdict::Fine
+        );
+        assert_eq!(
+            judge(
+                &entry(Some(0), Some(99_999), Some(7), None, "$6$x$y"),
+                20_100
+            ),
+            Verdict::MustChange
+        );
+        assert_eq!(
+            judge(
+                &entry(Some(20_000), Some(30), Some(7), None, "$6$x$y"),
+                20_040
+            ),
+            Verdict::MustChange
+        );
+        assert_eq!(
+            judge(
+                &entry(Some(20_000), Some(99_999), Some(7), Some(20_050), "$6$x$y"),
+                20_100
+            ),
+            Verdict::AccountExpired
+        );
+        assert_eq!(
+            judge(
+                &entry(Some(20_000), Some(30), Some(7), None, "$6$x$y"),
+                20_029
+            ),
+            Verdict::Warn("Your password will expire tomorrow.".to_string())
+        );
+    }
+
+    /// A locked password is a policy of its own, not an expiring one.
+    #[test]
+    fn test_locked_is_fine() {
+        assert_eq!(
+            judge(&entry(Some(0), Some(1), Some(7), None, "!$6$x$y"), 30_000),
+            Verdict::Fine
+        );
+    }
+
+    #[test]
+    fn test_warning_wording() {
+        assert_eq!(warning(0), "Your password will expire today.");
+        assert_eq!(warning(1), "Your password will expire tomorrow.");
+        assert_eq!(warning(5), "Your password will expire in 5 days.");
+    }
+
+    #[test]
+    fn test_exit_codes() {
+        assert_eq!(ExpiryError::Refused("x".into()).code(), 1);
+        assert_eq!(ExpiryError::Failure("x".into()).code(), 1);
+        assert_eq!(ExpiryError::Usage("x".into()).code(), 2);
+    }
+}

--- a/src/uu/expiry/src/main.rs
+++ b/src/uu/expiry/src/main.rs
@@ -1,0 +1,6 @@
+// This file is part of the shadow-rs package.
+//
+// For the full copyright and license information, please view the LICENSE
+// file that was distributed with this source code.
+
+uucore::bin!(uu_expiry);

--- a/src/uu/usermod/src/usermod.rs
+++ b/src/uu/usermod/src/usermod.rs
@@ -40,6 +40,10 @@ mod options {
     pub const ROOT: &str = "root";
     pub const PREFIX: &str = "prefix";
     pub const USER: &str = "USER";
+    pub const ADD_SUBUIDS: &str = "add-subuids";
+    pub const DEL_SUBUIDS: &str = "del-subuids";
+    pub const ADD_SUBGIDS: &str = "add-subgids";
+    pub const DEL_SUBGIDS: &str = "del-subgids";
 }
 
 #[derive(Debug)]
@@ -130,6 +134,10 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
                 .map_err(|e| UsermodError::BadArgument(e.to_string()))?;
         }
     }
+
+    // Subordinate id ranges are validated with the other arguments, before any
+    // file is written; usermod(8) exits 3 for an invalid one.
+    let subid_changes = parse_subid_changes(&matches)?;
 
     // Parse the expiry date before anything is written, so a malformed value
     // cannot leave the passwd change committed and the shadow change not.
@@ -413,11 +421,89 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         }
     }
 
+    apply_subid_changes(&root, login, &subid_changes)?;
+
     nscd::invalidate_cache("passwd");
     nscd::invalidate_cache("group");
 
     audit::log_user_event("MOD_USER", login, new_uid, true);
 
+    Ok(())
+}
+
+/// One requested change to `/etc/subuid` or `/etc/subgid`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct SubIdChange {
+    gids: bool,
+    remove: bool,
+    first: u64,
+    last: u64,
+}
+
+/// Read `-v`, `-V`, `-w` and `-W`, each of which may be given more than once.
+fn parse_subid_changes(matches: &clap::ArgMatches) -> Result<Vec<SubIdChange>, UsermodError> {
+    let mut changes = Vec::new();
+    for (key, gids, remove) in [
+        (options::ADD_SUBUIDS, false, false),
+        (options::DEL_SUBUIDS, false, true),
+        (options::ADD_SUBGIDS, true, false),
+        (options::DEL_SUBGIDS, true, true),
+    ] {
+        for spec in matches.get_many::<String>(key).into_iter().flatten() {
+            let (first, last) = shadow_core::subid::parse_range(spec).ok_or_else(|| {
+                UsermodError::BadArgument(format!(
+                    "invalid subordinate {} range '{spec}'",
+                    if gids { "gid" } else { "uid" }
+                ))
+            })?;
+            changes.push(SubIdChange {
+                gids,
+                remove,
+                first,
+                last,
+            });
+        }
+    }
+    Ok(changes)
+}
+
+/// Apply the subordinate id changes, each file in its own transaction.
+///
+/// The entries are keyed by the login name as given on the command line. The
+/// GNU tool does the same, and does not rename them on `-l` either: a range
+/// is a grant to a name, and the administrator who renames the account
+/// re-grants it if that is what they meant.
+fn apply_subid_changes(
+    root: &SysRoot,
+    login: &str,
+    changes: &[SubIdChange],
+) -> Result<(), UsermodError> {
+    use shadow_core::subid::{SubIdEntry, add_range, remove_range};
+
+    for gids in [false, true] {
+        let mine: Vec<&SubIdChange> = changes.iter().filter(|c| c.gids == gids).collect();
+        if mine.is_empty() {
+            continue;
+        }
+        let path = if gids {
+            root.subgid_path()
+        } else {
+            root.subuid_path()
+        };
+        let mut file = LockedFile::<SubIdEntry>::open_or_empty(&path).map_err(|e| {
+            UsermodError::CantUpdate(format!("cannot open {}: {e}", path.display()))
+        })?;
+        for c in mine {
+            if c.remove {
+                remove_range(file.entries_mut(), login, c.first, c.last);
+            } else {
+                add_range(file.entries_mut(), login, c.first, c.last);
+            }
+        }
+        file.commit().map_err(|e| {
+            UsermodError::CantUpdate(format!("cannot write {}: {e}", path.display()))
+        })?;
+    }
     Ok(())
 }
 
@@ -469,6 +555,15 @@ pub fn uu_app() -> Command {
         .about("Edit a user account's fields")
         .override_usage("usermod [options] LOGIN")
         .version(shadow_core::cli::VERSION)
+        // usermod(8) spells --del-subuids as -V; clap's own -V is given up
+        // and --version kept.
+        .disable_version_flag(true)
+        .arg(
+            Arg::new("version")
+                .long("version")
+                .help("print version")
+                .action(ArgAction::Version),
+        )
         .after_help(shadow_core::cli::AFTER_HELP)
         .arg(
             Arg::new(options::COMMENT)
@@ -578,6 +673,38 @@ pub fn uu_app() -> Command {
                 .long("prefix")
                 .value_name("PREFIX_DIR")
                 .help("Directory prefix"),
+        )
+        .arg(
+            Arg::new(options::ADD_SUBUIDS)
+                .short('v')
+                .long("add-subuids")
+                .value_name("FIRST-LAST")
+                .action(ArgAction::Append)
+                .help("add a range of subordinate uids"),
+        )
+        .arg(
+            Arg::new(options::DEL_SUBUIDS)
+                .short('V')
+                .long("del-subuids")
+                .value_name("FIRST-LAST")
+                .action(ArgAction::Append)
+                .help("remove a range of subordinate uids"),
+        )
+        .arg(
+            Arg::new(options::ADD_SUBGIDS)
+                .short('w')
+                .long("add-subgids")
+                .value_name("FIRST-LAST")
+                .action(ArgAction::Append)
+                .help("add a range of subordinate gids"),
+        )
+        .arg(
+            Arg::new(options::DEL_SUBGIDS)
+                .short('W')
+                .long("del-subgids")
+                .value_name("FIRST-LAST")
+                .action(ArgAction::Append)
+                .help("remove a range of subordinate gids"),
         )
         .arg(
             Arg::new(options::USER)

--- a/tests/arm64-smoke.sh
+++ b/tests/arm64-smoke.sh
@@ -64,10 +64,10 @@ version=$("${QEMU[@]}" "$BIN" --version 2>&1)
 if [ -n "$version" ]; then ok "runs: $version"; else bad "would not run"; exit 1; fi
 
 applets=$("${QEMU[@]}" "$BIN" --list 2>/dev/null | tail -n +2 | wc -l)
-if [ "$applets" -ge 27 ]; then
+if [ "$applets" -ge 28 ]; then
     ok "carries $applets applets"
 else
-    bad "expected at least 27 applets, found $applets"
+    bad "expected at least 28 applets, found $applets"
 fi
 
 # ── A prefix tree, so nothing here touches the container's own accounts ──
@@ -128,6 +128,7 @@ check "vigr starts" "${QEMU[@]}" "$BIN" vigr --help
 check "login starts" "${QEMU[@]}" "$BIN" login --help
 check "newuidmap starts" "${QEMU[@]}" "$BIN" newuidmap --help
 check "newgidmap starts" "${QEMU[@]}" "$BIN" newgidmap --help
+check "expiry starts" "${QEMU[@]}" "$BIN" expiry --help
 
 # newusers writes three files and a home directory from one line, so it
 # exercises the allocator, crypt(3) and the fchown in shadow_core::home

--- a/tests/by-util/test_expiry.rs
+++ b/tests/by-util/test_expiry.rs
@@ -1,0 +1,119 @@
+// This file is part of the shadow-rs package.
+//
+// For the full copyright and license information, please view the LICENSE
+// file that was distributed with this source code.
+// spell-checker:ignore setgid
+
+//! Integration tests for `expiry`.
+//!
+//! `expiry` judges the *caller's* shadow line, so the tests run as root and
+//! write root's line into a prefix tree in each state. Under `--prefix` the
+//! tool reports and never changes anything, which is what lets a required
+//! change be asserted here without a password prompt; the prompt itself is
+//! exercised in the e2e suite, on a real user, on a terminal.
+
+use crate::common::{run, skip_unless_root};
+
+fn prefix(shadow_line: &str) -> tempfile::TempDir {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let etc = dir.path().join("etc");
+    std::fs::create_dir_all(&etc).expect("etc");
+    std::fs::write(etc.join("shadow"), format!("{shadow_line}\n")).expect("shadow");
+    dir
+}
+
+fn expiry(dir: &tempfile::TempDir, args: &[&str]) -> crate::common::Output {
+    let p = dir.path().to_str().expect("utf8").to_string();
+    let mut all = vec!["--prefix", p.as_str()];
+    all.extend_from_slice(args);
+    run("expiry", &all)
+}
+
+fn today() -> i64 {
+    shadow_core::shadow::days_since_epoch().expect("clock")
+}
+
+#[test]
+fn test_help_and_usage() {
+    run("expiry", &["--help"])
+        .assert_code(0)
+        .assert_stdout_contains("Usage:");
+    // Nothing asked, nothing done: usage, exit 2, as the GNU tool.
+    run("expiry", &[]).assert_code(2);
+}
+
+#[test]
+fn test_healthy_is_silent() {
+    if skip_unless_root() {
+        return;
+    }
+    let dir = prefix(&format!("root:$6$x$y:{}:0:99999:7:::", today() - 10));
+    let out = expiry(&dir, &["-c"]);
+    out.assert_code(0);
+    assert!(out.stdout.is_empty(), "{:?}", out.stdout);
+}
+
+#[test]
+fn test_warning_before_expiry() {
+    if skip_unless_root() {
+        return;
+    }
+    let dir = prefix(&format!("root:$6$x$y:{}:0:30:7:::", today() - 27));
+    expiry(&dir, &["-c"])
+        .assert_code(0)
+        .assert_stdout_contains("Your password will expire in 3 days.");
+}
+
+#[test]
+fn test_expired_password_requires_a_change() {
+    if skip_unless_root() {
+        return;
+    }
+    for line in [
+        "root:$6$x$y:0:0:99999:7:::".to_string(),
+        format!("root:$6$x$y:{}:0:30:7:::", today() - 60),
+    ] {
+        let dir = prefix(&line);
+        expiry(&dir, &["-c"]).assert_code(1).assert_stdout_contains(
+            "You are required to change your password immediately (password expired).",
+        );
+        expiry(&dir, &["-f"]).assert_code(1);
+    }
+}
+
+#[test]
+fn test_expired_account_is_turned_away() {
+    if skip_unless_root() {
+        return;
+    }
+    let dir = prefix(&format!(
+        "root:$6$x$y:{}:0:99999:7::{}:",
+        today() - 10,
+        today() - 1
+    ));
+    expiry(&dir, &["-c"]).assert_code(1).assert_stdout_contains(
+        "Your account has expired; please contact your system administrator.",
+    );
+}
+
+/// A locked password is a policy of its own.
+#[test]
+fn test_locked_is_silent() {
+    if skip_unless_root() {
+        return;
+    }
+    let dir = prefix("root:!$6$x$y:0:0:1:7:::");
+    let out = expiry(&dir, &["-c"]);
+    out.assert_code(0);
+    assert!(out.stdout.is_empty());
+}
+
+/// No shadow line for the caller: no policy to enforce.
+#[test]
+fn test_no_line_is_silent() {
+    if skip_unless_root() {
+        return;
+    }
+    let dir = prefix("someoneelse:$6$x$y:0:0:1:7:::");
+    expiry(&dir, &["-c"]).assert_code(0);
+}

--- a/tests/by-util/test_multicall.rs
+++ b/tests/by-util/test_multicall.rs
@@ -16,12 +16,13 @@ use std::process::Command;
 use crate::common::{run, run_cmd};
 
 /// Every applet this build is expected to carry, in `--list` order.
-const TOOLS: [&str; 27] = [
+const TOOLS: [&str; 28] = [
     "chage",
     "chfn",
     "chgpasswd",
     "chpasswd",
     "chsh",
+    "expiry",
     "gpasswd",
     "groupadd",
     "groupdel",

--- a/tests/by-util/test_usermod_subid.rs
+++ b/tests/by-util/test_usermod_subid.rs
@@ -1,0 +1,122 @@
+// This file is part of the shadow-rs package.
+//
+// For the full copyright and license information, please view the LICENSE
+// file that was distributed with this source code.
+// spell-checker:ignore subuid subgid
+
+//! Integration tests for `usermod`'s subordinate id options.
+
+use crate::common::{run, skip_unless_root};
+
+fn prefix() -> tempfile::TempDir {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let etc = dir.path().join("etc");
+    std::fs::create_dir_all(&etc).expect("etc");
+    std::fs::write(
+        etc.join("passwd"),
+        "alice:x:1000:1000::/home/alice:/bin/sh\nbob:x:1001:1001::/home/bob:/bin/sh\n",
+    )
+    .expect("passwd");
+    std::fs::write(
+        etc.join("shadow"),
+        "alice:!:19000:0:99999:7:::\nbob:!:19000:0:99999:7:::\n",
+    )
+    .expect("shadow");
+    std::fs::write(etc.join("group"), "alice:x:1000:\nbob:x:1001:\n").expect("group");
+    std::fs::write(etc.join("subuid"), "alice:100000:65536\nbob:165536:65536\n").expect("subuid");
+    std::fs::write(etc.join("subgid"), "alice:100000:65536\nbob:165536:65536\n").expect("subgid");
+    dir
+}
+
+fn usermod(dir: &tempfile::TempDir, args: &[&str]) -> crate::common::Output {
+    let p = dir.path().to_str().expect("utf8").to_string();
+    let mut all = vec!["--prefix", p.as_str()];
+    all.extend_from_slice(args);
+    run("usermod", &all)
+}
+
+fn lines(dir: &tempfile::TempDir, file: &str, user: &str) -> Vec<String> {
+    std::fs::read_to_string(dir.path().join("etc").join(file))
+        .expect("read")
+        .lines()
+        .filter(|l| l.starts_with(&format!("{user}:")))
+        .map(str::to_string)
+        .collect()
+}
+
+#[test]
+fn test_add_and_remove_ranges() {
+    if skip_unless_root() {
+        return;
+    }
+    let dir = prefix();
+    usermod(
+        &dir,
+        &["-v", "300000-300999", "-w", "300000-300999", "alice"],
+    )
+    .assert_code(0);
+    assert_eq!(
+        lines(&dir, "subuid", "alice"),
+        vec!["alice:100000:65536", "alice:300000:1000"]
+    );
+    assert_eq!(
+        lines(&dir, "subgid", "alice"),
+        vec!["alice:100000:65536", "alice:300000:1000"]
+    );
+
+    // A covered range is not added twice.
+    usermod(&dir, &["-v", "300500-300600", "alice"]).assert_code(0);
+    assert_eq!(lines(&dir, "subuid", "alice").len(), 2);
+
+    // A partial removal splits; the exact remainder disappears.
+    usermod(&dir, &["-V", "300000-300499", "alice"]).assert_code(0);
+    assert_eq!(
+        lines(&dir, "subuid", "alice"),
+        vec!["alice:100000:65536", "alice:300500:500"]
+    );
+    usermod(
+        &dir,
+        &["-V", "300500-300999", "-W", "300000-300999", "alice"],
+    )
+    .assert_code(0);
+    assert_eq!(lines(&dir, "subuid", "alice"), vec!["alice:100000:65536"]);
+    assert_eq!(lines(&dir, "subgid", "alice"), vec!["alice:100000:65536"]);
+
+    // Someone else's entries are never touched.
+    assert_eq!(lines(&dir, "subuid", "bob"), vec!["bob:165536:65536"]);
+}
+
+/// The option may be repeated, and a range no one held is a silent no-op.
+#[test]
+fn test_repeated_and_absent_ranges() {
+    if skip_unless_root() {
+        return;
+    }
+    let dir = prefix();
+    usermod(
+        &dir,
+        &["-v", "310000-310009", "-v", "320000-320009", "alice"],
+    )
+    .assert_code(0);
+    assert_eq!(lines(&dir, "subuid", "alice").len(), 3);
+    usermod(&dir, &["-V", "500000-500010", "alice"]).assert_code(0);
+    assert_eq!(lines(&dir, "subuid", "alice").len(), 3);
+}
+
+/// An invalid range is exit 3 with the GNU wording, before anything changes.
+#[test]
+fn test_invalid_range_is_refused() {
+    if skip_unless_root() {
+        return;
+    }
+    let dir = prefix();
+    for bad in ["300999-300000", "a-b", "300000"] {
+        usermod(&dir, &["-v", bad, "alice"])
+            .assert_code(3)
+            .assert_stderr_contains(&format!("invalid subordinate uid range '{bad}'"));
+    }
+    usermod(&dir, &["-w", "1-0", "alice"])
+        .assert_code(3)
+        .assert_stderr_contains("invalid subordinate gid range '1-0'");
+    assert_eq!(lines(&dir, "subuid", "alice"), vec!["alice:100000:65536"]);
+}

--- a/tests/e2e/deploy-test.sh
+++ b/tests/e2e/deploy-test.sh
@@ -100,13 +100,13 @@ hash_password() {
 
 # ── TOOLS list ──────────────────────────────────────────────────────
 
-TOOLS="passwd pwck useradd userdel usermod chpasswd chgpasswd newusers chage groupadd groupdel groupmod gpasswd grpck chfn chsh newgrp sg vipw vigr pwconv pwunconv grpconv grpunconv login newuidmap newgidmap"
+TOOLS="passwd pwck useradd userdel usermod chpasswd chgpasswd newusers chage groupadd groupdel groupmod gpasswd grpck chfn chsh newgrp sg vipw vigr pwconv pwunconv grpconv grpunconv login newuidmap newgidmap expiry"
 SETUID_TOOLS="passwd chfn chsh newgrp gpasswd sg newuidmap newgidmap"
 
 # The tools an unprivileged user runs are installed in bin, the rest in sbin,
 # which is the split the GNU package uses: sbin is not on a normal user's
 # PATH, so `passwd` there would be "command not found".
-USER_TOOLS="$SETUID_TOOLS chage login"
+USER_TOOLS="$SETUID_TOOLS chage login expiry"
 BINDIR="/usr/sbin"
 USER_BINDIR="/usr/bin"
 
@@ -869,6 +869,63 @@ test_gpasswd_group_admin() {
     userdel -r gp_member 2>/dev/null || true
 }
 
+# ── usermod subordinate ids, and expiry ────────────────────────────
+
+test_subid_and_expiry() {
+    section "usermod -v/-V/-w/-W, and expiry"
+
+    userdel -r ex_user 2>/dev/null || true
+    assert_ok "useradd -m ex_user" useradd -m -s /bin/sh ex_user
+    assert_ok "set a password" bash -c "printf 'ex_user:oldpw\n' | chpasswd"
+
+    assert_ok "usermod -v grants a subuid range" usermod -v 500000-500999 ex_user
+    assert_file_contains "the range is in /etc/subuid" /etc/subuid '^ex_user:500000:1000$'
+    assert_ok "usermod -V of half of it splits the entry" usermod -V 500000-500499 ex_user
+    assert_file_contains "the remainder is what is left" /etc/subuid '^ex_user:500500:500$'
+    assert_fail "an invalid range is refused" usermod -v 9-1 ex_user
+
+    assert_ok "expiry -c is silent on a healthy account" \
+        bash -c "out=\$(su -s /bin/sh ex_user -c 'expiry -c'); test -z \"\$out\""
+    chage -M 30 -d "$(date -d '-27 days' +%Y-%m-%d)" ex_user
+    assert_contains "expiry warns inside the warning window" "Your password will expire in 3 days." \
+        su -s /bin/sh ex_user -c 'expiry -c'
+
+    if command -v python3 >/dev/null 2>&1; then
+        chage -M 1 -d 2000-01-01 ex_user
+        cat > /tmp/drive_expiry.py <<'PYDRV'
+import os, pty, select, sys, time
+pid, fd = pty.fork()
+if pid == 0:
+    os.environ["TERM"] = "dumb"; os.execvp("su", ["su", "-s", "/bin/sh", "ex_user", "-c", "expiry -f; echo RC=$?"])
+buf = b""; t0 = time.time(); i = 0
+steps = [("urrent password:", "oldpw"), ("ew password:", "N3w-Passw0rd-e2e"), ("etype new password:", "N3w-Passw0rd-e2e")]
+while time.time() - t0 < 20 and b"RC=" not in buf:
+    r, _, _ = select.select([fd], [], [], 0.2)
+    if r:
+        try: buf += os.read(fd, 4096)
+        except OSError: break
+    if i < len(steps) and steps[i][0].encode() in buf:
+        os.write(fd, steps[i][1].encode() + b"\n"); buf = buf.replace(steps[i][0].encode(), b"", 1); i += 1
+try: os.kill(pid, 9)
+except ProcessLookupError: pass
+os.waitpid(pid, 0)
+sys.stdout.write(buf.decode(errors="replace"))
+PYDRV
+        before=$(grep '^ex_user:' /etc/shadow | cut -d: -f2)
+        assert_contains "expiry -f on an expired password forces the change" "RC=0" python3 /tmp/drive_expiry.py
+        assert_ok "and the hash changed" \
+            bash -c "test \"\$(grep '^ex_user:' /etc/shadow | cut -d: -f2)\" != \"$before\""
+        rm -f /tmp/drive_expiry.py
+    fi
+
+    chage -E 2000-01-01 ex_user
+    assert_fail "expiry refuses an expired account" su -s /bin/sh ex_user -c 'expiry -c'
+    chage -E -1 ex_user
+
+    userdel -r ex_user 2>/dev/null || true
+    sed -i '/^ex_user:/d' /etc/subuid /etc/subgid
+}
+
 # ── newuidmap / newgidmap: id maps for a user namespace ────────────
 
 test_idmap() {
@@ -1399,6 +1456,7 @@ main() {
     test_pwconv_family
     test_login
     test_idmap
+    test_subid_and_expiry
     test_aging_and_input
     test_audit_logging
     test_root_option

--- a/tests/gnu-compat.sh
+++ b/tests/gnu-compat.sh
@@ -233,6 +233,7 @@ for pair in \
     "grpconv:/usr/sbin/grpconv" \
     "grpunconv:/usr/sbin/grpunconv" \
     "login:/usr/bin/login" \
+    "expiry:/usr/bin/expiry" \
     "gpasswd:/usr/bin/gpasswd" \
     "pwck:/usr/sbin/pwck" \
     "grpck:/usr/sbin/grpck"; do
@@ -249,6 +250,7 @@ compare_exit "newuidmap with no operands" "$RS/newuidmap" "/usr/bin/newuidmap"
 compare_exit "newgidmap with no operands" "$RS/newgidmap" "/usr/bin/newgidmap"
 compare_exit "newuidmap with an incomplete triple" "$RS/newuidmap 1 0 100000" "/usr/bin/newuidmap 1 0 100000"
 compare_exit "newgidmap with a zero count" "$RS/newgidmap 1 0 100000 0" "/usr/bin/newgidmap 1 0 100000 0"
+compare_exit "usermod with an invalid subuid range" "$RS/usermod -v 9-1 root" "/usr/sbin/usermod -v 9-1 root"
 compare_exit "newuidmap on a process that is not there" "$RS/newuidmap 4194304 0 0 1" "/usr/bin/newuidmap 4194304 0 0 1"
 
 # ── Results ─────────────────────────────────────────────────────────

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -28,6 +28,8 @@ mod test_chgpasswd;
 mod test_chpasswd;
 #[path = "by-util/test_chsh.rs"]
 mod test_chsh;
+#[path = "by-util/test_expiry.rs"]
+mod test_expiry;
 #[path = "by-util/test_fuzz_corpus.rs"]
 mod test_fuzz_corpus;
 #[path = "by-util/test_gpasswd.rs"]
@@ -64,5 +66,7 @@ mod test_useradd;
 mod test_userdel;
 #[path = "by-util/test_usermod.rs"]
 mod test_usermod;
+#[path = "by-util/test_usermod_subid.rs"]
+mod test_usermod_subid;
 #[path = "by-util/test_vipw.rs"]
 mod test_vipw;


### PR DESCRIPTION
Two commits: `usermod` gains the four subordinate-id options GNU has and ours lacked, and `expiry` — the twenty-eighth tool and the last the Scope table lists as in scope — is added.

Stacked on #298. Base retargets to `main` as the stack merges.

## `usermod -v/-V/-w/-W`

Established by running the GNU tool: a range already held is not added twice; a removal **trims, splits or deletes** the entries it touches and ignores a range never held; other users' entries are never consulted (an administrator may share a range on purpose); an invalid range is exit 3 with GNU's wording before anything is written. Entries are keyed by the login name given and not renamed by `-l`, as GNU's are not. `-V` is GNU's letter, so clap's own `-V` gave way; `--version` stays. Helpers live in `shadow_core::subid`.

## `expiry`

Judges the caller's own shadow line as `login` would — silent, warning, forced change through PAM, or refusal. The rules are one function, `shadow_core::shadow::Aging`, with checked arithmetic over fields anyone who can write `/etc/shadow` chooses; order is `login`'s; a maximum age ≥ 10000 means never, as `chage -l` prints it; a locked password is not reported.

**Privileges.** GNU ships it setgid `shadow` — enough to read the file, no more — and the change runs through PAM as the caller. The per-tool install does the same (a new install class, `2755 root:shadow`). The multicall binary keeps euid 0 for it, having nothing narrower to offer. Under `--prefix` it reports and never changes anything.

## `groupmems` is out of scope

Debian 13 and Fedora do not ship it, and on Ubuntu 24.04 every action fails against PAM's default for want of a `/etc/pam.d/groupmems` — a tool one distribution ships and none can use. The Scope table now says so.

## Verification

| | |
|---|---|
| `make check` | fmt, clippy ×3, tests ±`pam`, unprivileged run — exit 0 |
| `cargo test --workspace` | alpine 935 / fedora (pam) 950, 0 failed |
| e2e deployment suite | 410 assertions, including `expiry -f` driving a real PAM password change under a pty |
| `make test-gnu-compat` | 59 comparisons |
| `make test-arm64` | 35 assertions under emulation |
