### PR TITLE
ci: one verification path per change

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,22 @@
 name: CI
 
+# Pull requests are the gate. Main is not rebuilt on every merge: a squash
+# merge produces exactly the tree of the pull-request tip that just passed, so
+# that run only repeated a result. Main is instead exercised once a night,
+# which is also the only way drift in the toolchain and the base images shows
+# up between merges.
 on:
-  push:
-    branches: [main]
   pull_request:
+  schedule:
+    - cron: "0 3 * * *"
+  workflow_dispatch:
+
+# A force-push supersedes the run in flight on the same pull request; letting
+# both finish doubles the queue time behind the rest of the organisation for
+# a result nobody reads. Scheduled runs are never cancelled.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,6 @@ permissions:
 # If there's a prerelease-style suffix to the version, then the release(s)
 # will be marked as a prerelease.
 on:
-  pull_request:
   push:
     tags:
       - '**[0-9]+.[0-9]+.[0-9]+*'

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -19,6 +19,11 @@ unix-archive = ".tar.gz"
 # Build with PAM. Without it `passwd` refuses the interactive change path
 # ("PAM support is not compiled in"), which is the tool's primary function.
 features = ["pam"]
+# No `dist plan` job on pull requests. It only re-parsed this file, which the
+# tag-triggered pipeline does anyway, and it ran twice per pull-request update
+# alongside the CI workflow. `ci.yml` builds the static musl archive on every
+# pull request, which is the release step that can actually break.
+pr-run-mode = "skip"
 
 # Ship only the multicall binary. `shadow-rs-completions` is a build-time
 # helper behind `required-features = ["completions"]`, so it is not part of a


### PR DESCRIPTION
The local gates (`make check`, the Docker matrix, the deployment suite) are where a change is verified. The workflows are the safety net for contributors and the trace check. They were doing three things that only repeated a result already in hand.

**No run on every push to main.** A squash merge produces exactly the tree of the pull-request tip that just passed, so that run rebuilt a known-green tree. Main is now exercised once a night, which also catches toolchain and base-image drift between merges, and on demand through `workflow_dispatch`. The README badge follows the default branch, so it reports the nightly run.

**A force-push cancels the superseded run.** A concurrency group keyed on the pull-request number; scheduled runs are never cancelled.

**No `dist plan` on pull requests.** It re-parsed the dist manifest, which the tag-triggered pipeline does anyway, and it fired alongside the CI workflow on every update. `pr-run-mode = "skip"` in `dist-workspace.toml`, and `release.yml` regenerated with dist 0.32.0 (the diff is the one removed trigger line). The static musl archive, the release step that can actually break, is still built by `ci.yml` on every pull request.

Measured before the change: merging the nine stacked pull requests #291 to #299 fired 48 runs, about 260 runner-minutes, every one on a tree already tested, and queued behind the rest of the organisation.

Checked with actionlint 1.7.7: `ci.yml` is clean; the remaining findings are pre-existing shellcheck style notes inside the dist-generated `release.yml`.
