### PR TITLE
shadow-core: read AT_EXECFN through getauxval, not a run-time lookup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,21 @@ jobs:
           "$bin" --version
           "$bin" --list | grep -qE '^ *passwd$'
           test -f "$RUNNER_TEMP/$name/PLATFORM-SUPPORT.md"
+      # Deployed the way `make install-multicall` deploys it: setuid root,
+      # reached through a symlink, called by an unprivileged user. Nothing
+      # else exercises the static binary in setuid context, and the argv[0]
+      # check once aborted every such call there (AT_EXECFN read through a
+      # by-name lookup of a symbol the static link had never pulled in).
+      - name: The archive works setuid, through a symlink, for a user
+        run: |
+          set -eu
+          name=uu_shadow-x86_64-unknown-linux-musl-static
+          sudo install -m 4755 -o root -g root "$RUNNER_TEMP/$name/shadow-rs" /usr/local/sbin/shadow-rs
+          sudo ln -sf /usr/local/sbin/shadow-rs /usr/local/bin/passwd
+          out=$(sudo -u nobody /usr/local/bin/passwd -S 2>&1) || true
+          sudo rm -f /usr/local/bin/passwd /usr/local/sbin/shadow-rs
+          echo "$out"
+          echo "$out" | grep -qE '^nobody '
       # shadow-core's crypt(3) wrapper has musl-specific expectations (no
       # yescrypt, `rounds=` honoured). Run its unit tests against the static
       # musl libc, not only Alpine's dynamic one in the Docker matrix.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -145,6 +145,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The static musl archive aborted every setuid invocation with *argv[0] does
+  not match executed binary*, so on a host that deployed it as `make
+  install-multicall` does, no user could run `passwd`, `chfn`, `chsh`,
+  `newgrp`, `sg` or `gpasswd` at all; root, for whom the check does not run,
+  saw nothing wrong. The check read `AT_EXECFN` through rustix, which looks
+  getauxval(3) up by name at run time; in a static link nothing had pulled
+  that symbol into the binary, the lookup found nothing, and the tool's name
+  was compared against an empty string. getauxval is now called directly,
+  which links it in. Every static archive published so far, 0.2.2 through
+  0.4.0, has this defect; the glibc archives never did. CI now runs the
+  static archive setuid, through a symlink, as an unprivileged user
+
 - Two tools working on different account files at the same time could
   deadlock until both timed out. `FileLock` took the per-file `.lock` first
   and `/etc/.pwd.lock` second, so a tool holding `passwd.lock` and waiting for

--- a/src/shadow-core/src/process.rs
+++ b/src/shadow-core/src/process.rs
@@ -191,6 +191,11 @@ fn write_utmp(rec: &SessionRecord<'_>, ut_type: libc::c_short) {
     // SAFETY: standard utmpx API; `ut` is fully initialized and outlives the
     // calls. pututxline copies the record. Failures are deliberately ignored:
     // see the doc comment on record_login.
+    //
+    // The libc crate marks these deprecated on musl because musl implements
+    // them as stubs. That is the documented behaviour of the static build
+    // (docs/PLATFORM-SUPPORT.md): recording is a no-op there, not an error.
+    #[allow(deprecated)]
     unsafe {
         libc::setutxent();
         libc::pututxline(&raw const ut);
@@ -617,9 +622,30 @@ pub fn gid_exists(gid: u32) -> io::Result<bool> {
 /// from the ELF auxiliary vector records the real path the kernel executed,
 /// which cannot be spoofed from userspace.
 ///
-/// Returns `true` if the basenames match, `false` if they differ.
+/// Returns `true` if the basenames match, `false` if they differ or if
+/// `AT_EXECFN` cannot be read at all: a check that cannot run must fail
+/// closed in a setuid binary.
+///
+/// The value is read through getauxval(3) called directly. rustix's `param`
+/// module reaches that function by name at run time, through `dlsym(3)`, so
+/// that it can tolerate a glibc older than 2.16. In a statically linked
+/// binary a symbol is only present if something links it in, and a lookup by
+/// name links nothing in: the static musl archive carried no `getauxval` at
+/// all, rustix reported an empty `AT_EXECFN`, and every setuid invocation of
+/// that archive aborted here. A direct call both links the symbol and needs
+/// no lookup. glibc 2.34, the floor of the glibc archives, and musl both
+/// provide it.
 pub fn verify_argv0_matches_execfn(argv0: &str) -> bool {
-    let execfn = rustix::param::linux_execfn();
+    // SAFETY: getauxval has no preconditions. The `AT_EXECFN` string is
+    // placed on the initial stack by the kernel and lives as long as the
+    // process, so the pointer is valid for the borrow taken here.
+    let execfn = unsafe {
+        let ptr = libc::getauxval(libc::AT_EXECFN) as *const libc::c_char;
+        if ptr.is_null() {
+            return false;
+        }
+        std::ffi::CStr::from_ptr(ptr)
+    };
     let execfn = execfn.to_string_lossy();
 
     let argv0_base = std::path::Path::new(argv0)


### PR DESCRIPTION
The static musl archive aborted every setuid invocation with *argv[0] does not match executed binary*. Deployed as `make install-multicall` deploys it, setuid root and reached through symlinks, no user could run `passwd`, `chfn`, `chsh`, `newgrp`, `sg` or `gpasswd`; root, for whom the check does not run, saw nothing wrong. Every static archive published so far, 0.2.2 through 0.4.0, has the defect. The glibc archives never did.

**Cause.** The check compared the basename of `argv[0]` with `AT_EXECFN` obtained from rustix's `param` module. rustix reaches getauxval(3) by name at run time, through `dlsym(3)`, so that it can tolerate a glibc older than 2.16. In a statically linked binary a symbol is present only if something links it in, and a lookup by name links nothing in: the archive carried no `getauxval` at all, rustix returned an empty string, and the tool's name never matched it. Confirmed by instrumenting the abort (`argv0="passwd" execfn=""`) and by a probe binary that calls `libc::getauxval` directly, which made rustix's own lookup succeed too because the symbol was then linked.

**Fix.** `verify_argv0_matches_execfn` calls `libc::getauxval(AT_EXECFN)` directly. That links the symbol and needs no lookup. glibc 2.34, the floor of the glibc archives, and musl both provide it. A null result still fails closed.

**Verified** on the rebuilt static archive in an Alpine 3.23 container, installed 4755 root with symlinks, as an unprivileged user:

```
passwd -S                    -> fresh P 2026-09-07 0 99999 7 -1   (exit 0)
exec -a chsh passwd -S       -> argv[0] does not match executed binary (exit 1, still refused)
expiry -c, fresh account     -> silent, exit 0
expiry -c, expired account   -> refused, exit 1
expiry -f, expired password  -> PAM notice pointing at passwd(1), exit 1
sg fresh -c id               -> uid=1000(fresh) gid=1000(fresh) (exit 0)
```

**CI.** The `Static musl archive` job now installs the archive setuid root, links `passwd` to it and runs `passwd -S` as `nobody`. Nothing exercised the static binary in setuid context before; the whole suite runs as root, where the check is skipped.

Also silences, with the reason, the libc crate's musl deprecation warnings on the utmp calls: stubs are the documented behaviour of the static build.
