### PR TITLE
release: 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-09-07
+
 ### Added
 
 - `expiry`, the twenty-eighth tool: it judges the caller's own shadow line as

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -534,7 +534,7 @@ dependencies = [
 
 [[package]]
 name = "shadow-core"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "clap",
  "landlock",
@@ -695,7 +695,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uu_chage"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "clap",
  "rustix",
@@ -706,7 +706,7 @@ dependencies = [
 
 [[package]]
 name = "uu_chfn"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "clap",
  "rustix",
@@ -717,7 +717,7 @@ dependencies = [
 
 [[package]]
 name = "uu_chgpasswd"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "clap",
  "shadow-core",
@@ -728,7 +728,7 @@ dependencies = [
 
 [[package]]
 name = "uu_chpasswd"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "clap",
  "rustix",
@@ -740,7 +740,7 @@ dependencies = [
 
 [[package]]
 name = "uu_chsh"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "clap",
  "rustix",
@@ -751,7 +751,7 @@ dependencies = [
 
 [[package]]
 name = "uu_expiry"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "clap",
  "rustix",
@@ -762,7 +762,7 @@ dependencies = [
 
 [[package]]
 name = "uu_gpasswd"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "clap",
  "rustix",
@@ -774,7 +774,7 @@ dependencies = [
 
 [[package]]
 name = "uu_groupadd"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "clap",
  "rustix",
@@ -785,7 +785,7 @@ dependencies = [
 
 [[package]]
 name = "uu_groupdel"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "clap",
  "rustix",
@@ -796,7 +796,7 @@ dependencies = [
 
 [[package]]
 name = "uu_groupmod"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "clap",
  "rustix",
@@ -807,7 +807,7 @@ dependencies = [
 
 [[package]]
 name = "uu_grpck"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "clap",
  "shadow-core",
@@ -817,7 +817,7 @@ dependencies = [
 
 [[package]]
 name = "uu_grpconv"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "clap",
  "uu_pwconv",
@@ -826,7 +826,7 @@ dependencies = [
 
 [[package]]
 name = "uu_grpunconv"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "clap",
  "uu_pwconv",
@@ -835,7 +835,7 @@ dependencies = [
 
 [[package]]
 name = "uu_login"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "clap",
  "rustix",
@@ -847,7 +847,7 @@ dependencies = [
 
 [[package]]
 name = "uu_newgidmap"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "clap",
  "uu_newuidmap",
@@ -856,7 +856,7 @@ dependencies = [
 
 [[package]]
 name = "uu_newgrp"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "clap",
  "rustix",
@@ -866,7 +866,7 @@ dependencies = [
 
 [[package]]
 name = "uu_newuidmap"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "clap",
  "rustix",
@@ -877,7 +877,7 @@ dependencies = [
 
 [[package]]
 name = "uu_newusers"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "clap",
  "shadow-core",
@@ -888,7 +888,7 @@ dependencies = [
 
 [[package]]
 name = "uu_passwd"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "clap",
  "rustix",
@@ -899,7 +899,7 @@ dependencies = [
 
 [[package]]
 name = "uu_pwck"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "clap",
  "shadow-core",
@@ -909,7 +909,7 @@ dependencies = [
 
 [[package]]
 name = "uu_pwconv"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "clap",
  "rustix",
@@ -920,7 +920,7 @@ dependencies = [
 
 [[package]]
 name = "uu_pwunconv"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "clap",
  "uu_pwconv",
@@ -929,7 +929,7 @@ dependencies = [
 
 [[package]]
 name = "uu_sg"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "clap",
  "shadow-core",
@@ -938,7 +938,7 @@ dependencies = [
 
 [[package]]
 name = "uu_shadow"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "clap",
  "clap_complete",
@@ -977,7 +977,7 @@ dependencies = [
 
 [[package]]
 name = "uu_useradd"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "clap",
  "rustix",
@@ -988,7 +988,7 @@ dependencies = [
 
 [[package]]
 name = "uu_userdel"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "clap",
  "rustix",
@@ -999,7 +999,7 @@ dependencies = [
 
 [[package]]
 name = "uu_usermod"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "clap",
  "rustix",
@@ -1010,7 +1010,7 @@ dependencies = [
 
 [[package]]
 name = "uu_vigr"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "clap",
  "uu_vipw",
@@ -1019,7 +1019,7 @@ dependencies = [
 
 [[package]]
 name = "uu_vipw"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "clap",
  "rustix",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.4.0"
+version = "0.5.0"
 edition = "2024"
 rust-version = "1.94.0"
 license = "MIT"
@@ -58,7 +58,7 @@ categories = ["command-line-utilities"]
 
 [workspace.dependencies]
 # Internal crates
-shadow-core = { path = "src/shadow-core", version = "0.4.0" }
+shadow-core = { path = "src/shadow-core", version = "0.5.0" }
 
 # CLI
 clap = { version = "4", features = ["wrap_help"] }
@@ -86,38 +86,38 @@ tempfile = "3"
 [dependencies]
 clap = { workspace = true }
 clap_complete = { workspace = true, optional = true }
-shadow-core = { path = "src/shadow-core", version = "0.4.0" }
+shadow-core = { path = "src/shadow-core", version = "0.5.0" }
 rustix = { workspace = true }
 
 # Tool crates (optional, enabled by features)
-passwd = { optional = true, version = "0.4.0", package = "uu_passwd", path = "src/uu/passwd" }
-pwck = { optional = true, version = "0.4.0", package = "uu_pwck", path = "src/uu/pwck" }
-useradd = { optional = true, version = "0.4.0", package = "uu_useradd", path = "src/uu/useradd" }
-userdel = { optional = true, version = "0.4.0", package = "uu_userdel", path = "src/uu/userdel" }
-usermod = { optional = true, version = "0.4.0", package = "uu_usermod", path = "src/uu/usermod" }
-chpasswd = { optional = true, version = "0.4.0", package = "uu_chpasswd", path = "src/uu/chpasswd" }
-chage = { optional = true, version = "0.4.0", package = "uu_chage", path = "src/uu/chage" }
-groupadd = { optional = true, version = "0.4.0", package = "uu_groupadd", path = "src/uu/groupadd" }
-groupdel = { optional = true, version = "0.4.0", package = "uu_groupdel", path = "src/uu/groupdel" }
-groupmod = { optional = true, version = "0.4.0", package = "uu_groupmod", path = "src/uu/groupmod" }
-grpck = { optional = true, version = "0.4.0", package = "uu_grpck", path = "src/uu/grpck" }
-chfn = { optional = true, version = "0.4.0", package = "uu_chfn", path = "src/uu/chfn" }
-chsh = { optional = true, version = "0.4.0", package = "uu_chsh", path = "src/uu/chsh" }
-newgrp = { optional = true, version = "0.4.0", package = "uu_newgrp", path = "src/uu/newgrp" }
-gpasswd = { optional = true, version = "0.4.0", package = "uu_gpasswd", path = "src/uu/gpasswd" }
-sg = { optional = true, version = "0.4.0", package = "uu_sg", path = "src/uu/sg" }
-chgpasswd = { optional = true, version = "0.4.0", package = "uu_chgpasswd", path = "src/uu/chgpasswd" }
-newusers = { optional = true, version = "0.4.0", package = "uu_newusers", path = "src/uu/newusers" }
-vipw = { optional = true, version = "0.4.0", package = "uu_vipw", path = "src/uu/vipw" }
-vigr = { optional = true, version = "0.4.0", package = "uu_vigr", path = "src/uu/vigr" }
-pwconv = { optional = true, version = "0.4.0", package = "uu_pwconv", path = "src/uu/pwconv" }
-pwunconv = { optional = true, version = "0.4.0", package = "uu_pwunconv", path = "src/uu/pwunconv" }
-grpconv = { optional = true, version = "0.4.0", package = "uu_grpconv", path = "src/uu/grpconv" }
-grpunconv = { optional = true, version = "0.4.0", package = "uu_grpunconv", path = "src/uu/grpunconv" }
-login = { optional = true, version = "0.4.0", package = "uu_login", path = "src/uu/login" }
-newuidmap = { optional = true, version = "0.4.0", package = "uu_newuidmap", path = "src/uu/newuidmap" }
-newgidmap = { optional = true, version = "0.4.0", package = "uu_newgidmap", path = "src/uu/newgidmap" }
-expiry = { optional = true, version = "0.4.0", package = "uu_expiry", path = "src/uu/expiry" }
+passwd = { optional = true, version = "0.5.0", package = "uu_passwd", path = "src/uu/passwd" }
+pwck = { optional = true, version = "0.5.0", package = "uu_pwck", path = "src/uu/pwck" }
+useradd = { optional = true, version = "0.5.0", package = "uu_useradd", path = "src/uu/useradd" }
+userdel = { optional = true, version = "0.5.0", package = "uu_userdel", path = "src/uu/userdel" }
+usermod = { optional = true, version = "0.5.0", package = "uu_usermod", path = "src/uu/usermod" }
+chpasswd = { optional = true, version = "0.5.0", package = "uu_chpasswd", path = "src/uu/chpasswd" }
+chage = { optional = true, version = "0.5.0", package = "uu_chage", path = "src/uu/chage" }
+groupadd = { optional = true, version = "0.5.0", package = "uu_groupadd", path = "src/uu/groupadd" }
+groupdel = { optional = true, version = "0.5.0", package = "uu_groupdel", path = "src/uu/groupdel" }
+groupmod = { optional = true, version = "0.5.0", package = "uu_groupmod", path = "src/uu/groupmod" }
+grpck = { optional = true, version = "0.5.0", package = "uu_grpck", path = "src/uu/grpck" }
+chfn = { optional = true, version = "0.5.0", package = "uu_chfn", path = "src/uu/chfn" }
+chsh = { optional = true, version = "0.5.0", package = "uu_chsh", path = "src/uu/chsh" }
+newgrp = { optional = true, version = "0.5.0", package = "uu_newgrp", path = "src/uu/newgrp" }
+gpasswd = { optional = true, version = "0.5.0", package = "uu_gpasswd", path = "src/uu/gpasswd" }
+sg = { optional = true, version = "0.5.0", package = "uu_sg", path = "src/uu/sg" }
+chgpasswd = { optional = true, version = "0.5.0", package = "uu_chgpasswd", path = "src/uu/chgpasswd" }
+newusers = { optional = true, version = "0.5.0", package = "uu_newusers", path = "src/uu/newusers" }
+vipw = { optional = true, version = "0.5.0", package = "uu_vipw", path = "src/uu/vipw" }
+vigr = { optional = true, version = "0.5.0", package = "uu_vigr", path = "src/uu/vigr" }
+pwconv = { optional = true, version = "0.5.0", package = "uu_pwconv", path = "src/uu/pwconv" }
+pwunconv = { optional = true, version = "0.5.0", package = "uu_pwunconv", path = "src/uu/pwunconv" }
+grpconv = { optional = true, version = "0.5.0", package = "uu_grpconv", path = "src/uu/grpconv" }
+grpunconv = { optional = true, version = "0.5.0", package = "uu_grpunconv", path = "src/uu/grpunconv" }
+login = { optional = true, version = "0.5.0", package = "uu_login", path = "src/uu/login" }
+newuidmap = { optional = true, version = "0.5.0", package = "uu_newuidmap", path = "src/uu/newuidmap" }
+newgidmap = { optional = true, version = "0.5.0", package = "uu_newgidmap", path = "src/uu/newgidmap" }
+expiry = { optional = true, version = "0.5.0", package = "uu_expiry", path = "src/uu/expiry" }
 
 [features]
 default = ["passwd", "pwck", "useradd", "userdel", "usermod", "chpasswd", "chage",
@@ -151,34 +151,34 @@ path = "src/bin/completions.rs"
 required-features = ["completions"]
 
 [dev-dependencies]
-chage = { version = "0.4.0", package = "uu_chage", path = "src/uu/chage" }
-chfn = { version = "0.4.0", package = "uu_chfn", path = "src/uu/chfn" }
-chpasswd = { version = "0.4.0", package = "uu_chpasswd", path = "src/uu/chpasswd" }
-chsh = { version = "0.4.0", package = "uu_chsh", path = "src/uu/chsh" }
-groupadd = { version = "0.4.0", package = "uu_groupadd", path = "src/uu/groupadd" }
-groupdel = { version = "0.4.0", package = "uu_groupdel", path = "src/uu/groupdel" }
-groupmod = { version = "0.4.0", package = "uu_groupmod", path = "src/uu/groupmod" }
-newgrp = { version = "0.4.0", package = "uu_newgrp", path = "src/uu/newgrp" }
-sg = { version = "0.4.0", package = "uu_sg", path = "src/uu/sg" }
-chgpasswd = { version = "0.4.0", package = "uu_chgpasswd", path = "src/uu/chgpasswd" }
-newusers = { version = "0.4.0", package = "uu_newusers", path = "src/uu/newusers" }
-vipw = { version = "0.4.0", package = "uu_vipw", path = "src/uu/vipw" }
-vigr = { version = "0.4.0", package = "uu_vigr", path = "src/uu/vigr" }
-pwconv = { version = "0.4.0", package = "uu_pwconv", path = "src/uu/pwconv" }
-pwunconv = { version = "0.4.0", package = "uu_pwunconv", path = "src/uu/pwunconv" }
-grpconv = { version = "0.4.0", package = "uu_grpconv", path = "src/uu/grpconv" }
-grpunconv = { version = "0.4.0", package = "uu_grpunconv", path = "src/uu/grpunconv" }
-login = { version = "0.4.0", package = "uu_login", path = "src/uu/login" }
-newuidmap = { version = "0.4.0", package = "uu_newuidmap", path = "src/uu/newuidmap" }
-newgidmap = { version = "0.4.0", package = "uu_newgidmap", path = "src/uu/newgidmap" }
-expiry = { version = "0.4.0", package = "uu_expiry", path = "src/uu/expiry" }
-passwd = { version = "0.4.0", package = "uu_passwd", path = "src/uu/passwd" }
-useradd = { version = "0.4.0", package = "uu_useradd", path = "src/uu/useradd" }
-userdel = { version = "0.4.0", package = "uu_userdel", path = "src/uu/userdel" }
-usermod = { version = "0.4.0", package = "uu_usermod", path = "src/uu/usermod" }
-pwck = { version = "0.4.0", package = "uu_pwck", path = "src/uu/pwck" }
-grpck = { version = "0.4.0", package = "uu_grpck", path = "src/uu/grpck" }
-shadow-core = { path = "src/shadow-core", version = "0.4.0" }
+chage = { version = "0.5.0", package = "uu_chage", path = "src/uu/chage" }
+chfn = { version = "0.5.0", package = "uu_chfn", path = "src/uu/chfn" }
+chpasswd = { version = "0.5.0", package = "uu_chpasswd", path = "src/uu/chpasswd" }
+chsh = { version = "0.5.0", package = "uu_chsh", path = "src/uu/chsh" }
+groupadd = { version = "0.5.0", package = "uu_groupadd", path = "src/uu/groupadd" }
+groupdel = { version = "0.5.0", package = "uu_groupdel", path = "src/uu/groupdel" }
+groupmod = { version = "0.5.0", package = "uu_groupmod", path = "src/uu/groupmod" }
+newgrp = { version = "0.5.0", package = "uu_newgrp", path = "src/uu/newgrp" }
+sg = { version = "0.5.0", package = "uu_sg", path = "src/uu/sg" }
+chgpasswd = { version = "0.5.0", package = "uu_chgpasswd", path = "src/uu/chgpasswd" }
+newusers = { version = "0.5.0", package = "uu_newusers", path = "src/uu/newusers" }
+vipw = { version = "0.5.0", package = "uu_vipw", path = "src/uu/vipw" }
+vigr = { version = "0.5.0", package = "uu_vigr", path = "src/uu/vigr" }
+pwconv = { version = "0.5.0", package = "uu_pwconv", path = "src/uu/pwconv" }
+pwunconv = { version = "0.5.0", package = "uu_pwunconv", path = "src/uu/pwunconv" }
+grpconv = { version = "0.5.0", package = "uu_grpconv", path = "src/uu/grpconv" }
+grpunconv = { version = "0.5.0", package = "uu_grpunconv", path = "src/uu/grpunconv" }
+login = { version = "0.5.0", package = "uu_login", path = "src/uu/login" }
+newuidmap = { version = "0.5.0", package = "uu_newuidmap", path = "src/uu/newuidmap" }
+newgidmap = { version = "0.5.0", package = "uu_newgidmap", path = "src/uu/newgidmap" }
+expiry = { version = "0.5.0", package = "uu_expiry", path = "src/uu/expiry" }
+passwd = { version = "0.5.0", package = "uu_passwd", path = "src/uu/passwd" }
+useradd = { version = "0.5.0", package = "uu_useradd", path = "src/uu/useradd" }
+userdel = { version = "0.5.0", package = "uu_userdel", path = "src/uu/userdel" }
+usermod = { version = "0.5.0", package = "uu_usermod", path = "src/uu/usermod" }
+pwck = { version = "0.5.0", package = "uu_pwck", path = "src/uu/pwck" }
+grpck = { version = "0.5.0", package = "uu_grpck", path = "src/uu/grpck" }
+shadow-core = { path = "src/shadow-core", version = "0.5.0" }
 rustix = { workspace = true }
 tempfile = { workspace = true }
 

--- a/docs/PLATFORM-SUPPORT.md
+++ b/docs/PLATFORM-SUPPORT.md
@@ -85,33 +85,32 @@ Effect, and this is the heaviest of the three gaps:
   PAM before applying a change, and a setuid-root tool must fail closed rather
   than apply an unverified one, so without PAM they refuse every non-root
   invocation outright.
+- `login` has no way to authenticate at all, so the applet prints *PAM
+  support is not compiled in* and exits 1. A static image that needs a
+  getty-driven login must use the glibc archive. utmp and wtmp recording is
+  also a no-op under musl, which has stub `pututxline` and `updwtmpx`;
+  `who(1)` and `last(1)` see nothing there.
+- `expiry` still reports, and `-c` still refuses an expired account; the
+  forced change it performs on an expired password goes through PAM, so the
+  static build says so and points at `passwd(1)` instead.
 
-`expiry -c` reports without PAM; the forced change it performs on an expired
-password goes through PAM, and the static build says so and points at
-`passwd(1)` instead.
-
-`newuidmap` and `newgidmap` need neither PAM nor NSS beyond `getpwuid_r` for
-the caller, and work in the static build.
-
-`login` is the fourth: without PAM it has no way to authenticate, so the
-applet prints *PAM support is not compiled in* and exits 1. A static image
-that needs a getty-driven login must use the glibc archive. utmp and wtmp
-recording is also a no-op under musl, which has stub `pututxline` and
-`updwtmpx`; `who(1)` and `last(1)` see nothing there.
-
-Unaffected: `passwd -S/-l/-u/-d/-e/-n/-x/-w/-i`, and `newgrp`, `sg` and
+Unaffected: `passwd -S/-l/-u/-d/-e/-n/-x/-w/-i`; `newgrp`, `sg` and
 `gpasswd`, which authenticate against the group password through crypt(3)
-rather than PAM -- so a group administrator can still use them. The other ten
-tools are root-only anyway and reach the account files directly.
+rather than PAM -- so a group administrator can still use them; `chage`,
+`newuidmap` and `newgidmap`, which never authenticate through PAM; and the
+seventeen root-only tools, `useradd` through `grpunconv`, which reach the
+account files directly.
 
 ### 2. No NSS
 
-`shadow_core::process` resolves the calling user through `getpwuid_r`, used by
-`passwd`, `chfn`, `chsh`, `chage`, `newgrp`, `sg` and `gpasswd`.
+`shadow_core` resolves the calling user through `getpwuid_r`, used by
+`passwd`, `chfn`, `chsh`, `chage`, `newgrp`, `sg`, `gpasswd`, `expiry`,
+`newuidmap` and `newgidmap`; `login` resolves the name typed at the prompt
+through `getpwnam`.
 
 glibc answers such lookups through its NSS module system, so it sees users from
 LDAP, SSSD, Active Directory or systemd-userdb. musl has no NSS module system
-and reads `/etc/passwd` directly. On a directory-joined host those seven tools
+and reads `/etc/passwd` directly. On a directory-joined host those eleven tools
 do not see network users at all.
 
 ### 3. No yescrypt (`$y$`)
@@ -123,10 +122,11 @@ yescrypt.
 This is not a marginal format: **Debian 12+ and Ubuntu 24.04 use yescrypt as
 the default password hash.** A musl build can neither verify nor produce `$y$`
 hashes, so `newgrp`, `sg` and `gpasswd` fail against a `$y$` group password,
-`gpasswd` cannot set one on a host configured for yescrypt, and `chpasswd -c
-YESCRYPT` is rejected. The prefix guard in `shadow_core::crypt` reports the
-unsupported method explicitly; it never falls back to a weaker hash silently.
-The default method is SHA-512, which is unaffected.
+`gpasswd` cannot set one on a host configured for yescrypt, and `-c YESCRYPT`
+is rejected by `chpasswd`, `chgpasswd` and `newusers`. The prefix guard in
+`shadow_core::crypt` reports the unsupported method explicitly; it never falls
+back to a weaker hash silently. The default method is SHA-512, which is
+unaffected.
 
 ### Where the static build is the right choice
 

--- a/src/uu/grpconv/Cargo.toml
+++ b/src/uu/grpconv/Cargo.toml
@@ -22,7 +22,7 @@ clap = { workspace = true }
 uucore = { workspace = true }
 # One engine serves pwconv, pwunconv, grpconv and grpunconv; this crate names
 # which of the four it is.
-uu_pwconv = { path = "../pwconv", version = "0.4.0" }
+uu_pwconv = { path = "../pwconv", version = "0.5.0" }
 
 [lints]
 workspace = true

--- a/src/uu/grpunconv/Cargo.toml
+++ b/src/uu/grpunconv/Cargo.toml
@@ -22,7 +22,7 @@ clap = { workspace = true }
 uucore = { workspace = true }
 # One engine serves pwconv, pwunconv, grpconv and grpunconv; this crate names
 # which of the four it is.
-uu_pwconv = { path = "../pwconv", version = "0.4.0" }
+uu_pwconv = { path = "../pwconv", version = "0.5.0" }
 
 [lints]
 workspace = true

--- a/src/uu/newgidmap/Cargo.toml
+++ b/src/uu/newgidmap/Cargo.toml
@@ -21,7 +21,7 @@ path = "src/main.rs"
 clap = { workspace = true }
 uucore = { workspace = true }
 # newgidmap is newuidmap writing the other map; one engine, two names.
-uu_newuidmap = { path = "../newuidmap", version = "0.4.0" }
+uu_newuidmap = { path = "../newuidmap", version = "0.5.0" }
 
 [lints]
 workspace = true

--- a/src/uu/pwunconv/Cargo.toml
+++ b/src/uu/pwunconv/Cargo.toml
@@ -22,7 +22,7 @@ clap = { workspace = true }
 uucore = { workspace = true }
 # One engine serves pwconv, pwunconv, grpconv and grpunconv; this crate names
 # which of the four it is.
-uu_pwconv = { path = "../pwconv", version = "0.4.0" }
+uu_pwconv = { path = "../pwconv", version = "0.5.0" }
 
 [lints]
 workspace = true

--- a/src/uu/vigr/Cargo.toml
+++ b/src/uu/vigr/Cargo.toml
@@ -21,7 +21,7 @@ path = "src/main.rs"
 clap = { workspace = true }
 uucore = { workspace = true }
 # vigr is vipw with a different default; the GNU suite ships it as a symlink.
-uu_vipw = { path = "../vipw", version = "0.4.0" }
+uu_vipw = { path = "../vipw", version = "0.5.0" }
 
 [lints]
 workspace = true


### PR DESCRIPTION
Fourteen tools since 0.4.0: `sg`, `chgpasswd`, `newusers`, `vipw`, `vigr`, `pwconv`, `pwunconv`, `grpconv`, `grpunconv`, `login`, `newuidmap`, `newgidmap` and `expiry`, plus `usermod`'s subordinate-id options. A minor bump.

Version to 0.5.0 across the workspace and the lockfile; the Unreleased section becomes 0.5.0, dated today.

`docs/PLATFORM-SUPPORT.md`'s static-musl sections are brought up to the twenty-eight tools: `login` joins the tools PAM takes away; `expiry` keeps reporting there and only its forced change needs PAM; `chage` and the two id-map tools never authenticate through PAM; the root-only set is seventeen. The NSS list grows to eleven with `expiry`, `newuidmap`, `newgidmap` and `login`'s `getpwnam`. `-c YESCRYPT` is refused by `chgpasswd` and `newusers` as by `chpasswd`. Each of those claims was run against the rebuilt static archive in an Alpine container before being written.

This is also the first release whose static archive works setuid for a user (#302), which the changelog records under Fixed.

After merge: tag `0.5.0`, then verify the three archives before announcing anything -- `ldd` and the versioned-symbol floor on the glibc pair, and the static one setuid through a symlink as an unprivileged user.
